### PR TITLE
OSS launch polish — SEO + disclaimers + README + REPORT trim

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2026 Urban Morph and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Note: this licence covers the code in this repository only. Each data layer
+in the catalog carries its own open licence (CC0-1.0, CC-BY-4.0, CC-BY-SA-4.0,
+ODbL-1.0, ODC-PDDL-1.0, GODL-India). See the per-card line on the catalog at
+https://bharatlas.com/ for the licence applicable to a given layer.

--- a/README.md
+++ b/README.md
@@ -1,70 +1,107 @@
 # bharatlas
 
 [![ci](https://github.com/urbanmorph/geodata/actions/workflows/ci.yml/badge.svg)](https://github.com/urbanmorph/geodata/actions/workflows/ci.yml)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#status)
 
-Lightweight, open-source visualiser + contribution flow for India's geo data — state, district, sub-district, block, village admin boundaries, plus community-submitted layers under open licences.
+A visual catalog, drag-drop verifier, and anonymous contribution flow for India's geo data. Admin boundaries from state to village, plus community-submitted layers under open licences.
 
 **Live**: https://bharatlas.com
+
+```
+catalog          → state · district · subdistrict · block · village (LGD-coded)
+verify           → drop GeoJSON · KML · KMZ · GPX · TCX · Parquet → render + validate
+submit           → contribute under an open licence · anonymous · admin-token model
+view (/c/<id>)   → public page per submission, ▲/▼ vote, JSON-LD indexed
+```
 
 ## What's in this repo
 
 | Path | Contents |
 |---|---|
-| `web/` | Vanilla TypeScript + Vite viewer. Static, hosted on Cloudflare Pages. |
+| `web/` | Vanilla TypeScript + Vite viewer + Cloudflare Pages Functions (`web/functions/`). |
+| `web/migrations/` | D1 SQL migrations: submissions, tokens, ratings, votes, originals. |
+| `web/tests/` | vitest unit tests for pure functions (validators, tokens, view rendering, votes). |
 | `scripts/fetch.sh` | Pulls parquets + PMTiles from [yashveeeeeeer/india-geodata](https://github.com/yashveeeeeeer/india-geodata) releases. |
 | `scripts/extract_per_state.py` | Slices pan-India parquets into per-state GeoJSON via DuckDB-spatial. |
-| `scripts/upload_r2.sh` | Mirrors `sources/` + `data/` to the Cloudflare R2 bucket. |
-| `catalog.json` | Dataset index used by the viewer. Single source of truth. |
-| `REPORT.md` | Coverage report + provenance + caveats for every layer. |
+| `scripts/upload_r2.sh` | Mirrors `sources/` + `data/` to Cloudflare R2. |
+| `scripts/admin/cleanup_submission.sh` | Delete community submissions by name pattern (R2 + D1). |
+| `catalog.json` | Curated-layer index used by the viewer. Single source of truth. |
+| `REPORT.md` | Coverage + provenance + caveats per curated layer. |
 
-Large data files (`sources/`, `data/`) are **not in git** — they live in R2 (`geodata-data` bucket, urbanmorph account). See `scripts/fetch.sh` to rebuild locally.
-
-## Layers
-
-13 admin layers across three providers — LGD (authoritative), SOI, Bhuvan — plus geoBoundaries as a cross-check. Full provenance and caveats in [REPORT.md](./REPORT.md).
-
-LGD codes are the join key. Never join on names.
+Large data files (`sources/`, `data/`) are not in git — they live in R2. See `scripts/fetch.sh` to rebuild locally.
 
 ## Stack
 
-- **Frontend**: vanilla TypeScript, Vite, MapLibre GL JS, PMTiles. Zero framework runtime.
-- **Storage**: Cloudflare R2 for parquets + PMTiles. Zero egress fees.
-- **Hosting**: Cloudflare Pages (static).
-- **Data pipeline**: DuckDB + `spatial` extension.
+| Layer | Tech |
+|---|---|
+| Frontend | Vanilla TypeScript, Vite, MapLibre GL JS, PMTiles, DuckDB-WASM (lazy) |
+| Static hosting | Cloudflare Pages |
+| Edge functions | Cloudflare Pages Functions (`web/functions/`) — submit, vote, sitemap, edge-rendered `/c/<id>` |
+| Storage | Cloudflare R2 (open data, no egress) |
+| Submissions DB | Cloudflare D1 (SQLite at the edge) |
+| Anti-abuse | Cloudflare Turnstile + per-IP rate limits |
+| CI/CD | GitHub Actions — tests + build + auto-deploy on push to `main` |
 
 ## Develop
 
 ```bash
-# pull data (large — ~1.3 GB)
-bash scripts/fetch.sh
-
-# per-state geojson extracts (optional)
-python3 scripts/extract_per_state.py
-
-# viewer
-cd web && npm install && npm run dev
+# clone + viewer-only dev (no submissions, no D1)
+git clone git@github.com:urbanmorph/geodata.git
+cd geodata/web
+npm install
+npm run dev    # http://localhost:5173
+npm test       # 167 vitest tests
 ```
 
-## Deploy
+For the full submission flow (D1 + R2 + Turnstile + Pages Functions), see [docs/full-dev.md](./docs/full-dev.md) (TODO) or read `wrangler.toml` + `.dev.vars.example`.
+
+## Contributing
+
+1. Branch off `main`: `git checkout -b feat/short-name`
+2. Write a test first if you're adding logic to `web/functions/lib/*`. Pure functions are tested via vitest in `web/tests/`.
+3. Make sure `npm test` and `npm run build` both pass.
+4. Open a PR against `main`. CI runs tests + build automatically.
+5. The maintainer reviews and merges. Merge to main = auto-deploy.
+
+Commit messages: short subject, body explains *why* not *what*. Examples in `git log`.
+
+## Tests
 
 ```bash
-cd web && npm run build
-wrangler pages deploy ./dist --project-name=geodata
+cd web && npm test
 ```
+
+167 tests across validators, token generation, vote tally, render-view HTML, etc. See [`web/tests/`](./web/tests/).
 
 ## Roadmap
 
-- [x] v1 — viewer + parquet downloads
-- [ ] v2 — in-browser slicing (DuckDB-WASM): filter by bbox / polygon, export
-- [ ] v3 — user submissions: drag-drop verify (client-only) + submit for inclusion (moderated)
-- [ ] v4 — side-by-side LGD vs SOI vs Bhuvan compare
+- [x] v1 — pan-India admin layers, parquet + PMTiles downloads
+- [x] v2 — DuckDB-WASM filter & export per state
+- [x] v3 — submission flow: drag-drop verify, anonymous token, auto-moderation, /c/[id] view page, mixed catalog, votes
+- [ ] v4 — public API + MCP server + Claude Code plugin
+
+## Security
+
+Report vulnerabilities to **sathya@urbanmorph.com** instead of opening a public issue. Acknowledgement within 72 hours.
 
 ## Licence
 
-Code: MIT. Data: see each layer's `licence` field in `catalog.json` (LGD upstream is CC-BY-4.0).
+Code: [MIT](./LICENSE). Data: each layer carries its own open licence — see the per-card line on the [catalog](https://bharatlas.com/). Curated data is sourced under CC0-1.0 / CC-BY-4.0 / GODL-India depending on provider.
+
+## Use of data
+
+The platform doesn't warrant accuracy or fitness for any purpose. Boundaries shown are for reference, not legal authority — refer to LGD, SOI, Bhuvan or the state revenue department for official use. Community submissions are auto-moderated, not editorially curated; verify provenance via the source link on each card. See [/about → Use of data](https://bharatlas.com/about#use-of-data).
 
 ## Credits
 
-- [yashveeeeeeer/india-geodata](https://github.com/yashveeeeeeer/india-geodata) — upstream parquet + PMTiles publisher
-- [LGD](https://lgdirectory.gov.in/), [SOI](https://surveyofindia.gov.in/), [Bhuvan](https://bhuvan.nrsc.gov.in/) — primary sources
-- [geoBoundaries](https://www.geoboundaries.org/) — cross-check
+- [yashveeeeeeer/india-geodata](https://github.com/yashveeeeeeer/india-geodata) — upstream parquet + PMTiles publisher.
+- [LGD](https://lgdirectory.gov.in/), [SOI](https://surveyofindia.gov.in/), [Bhuvan](https://bhuvan.nrsc.gov.in/) — primary government sources.
+- [geoBoundaries](https://www.geoboundaries.org/) — independent cross-check.
+- [mdshare](https://mdshare.dev/) — the anonymous-token contribution pattern lineage.
+
+Built by [Urban Morph](https://urbanmorph.com) · [@sathyasankaran](https://linkedin.com/in/sathyasankaran). Drop a ⭐ if you find it useful.
+
+## Status
+
+**Alpha.** The submission flow is live and accepting contributions, but the schema and API may change before v4. Community submissions are permanent under the open licence the contributor selected.

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,95 +1,53 @@
-# India admin-boundary extraction — gap report
+# Curated data — coverage + caveats
 
-Date: 2026-05-19
-Project root: `~/GitHub/geodata/`
+Coverage report for bharatlas's curated admin layers. For implementation details (directory layout, refresh commands) see the [README](./README.md). For per-card licence + attribution see the [catalog](https://bharatlas.com/).
+
+Last verified: 2026-05-19.
 
 ## TL;DR
 
-Pan-India admin polygons from **state → village** are in `sources/`, totalling ~1.6 GB across three independent providers (LGD, SOI, Bhuvan). LGD is the gold standard because it carries the full state→district→block→village code chain. Per-state convenience extracts for CG/JH/OD live under `data/boundaries/<level>/`.
+Pan-India admin polygons from **state → village** across three providers (LGD, SOI, Bhuvan). LGD is the gold standard because it carries the full state→district→block→village code chain.
 
-Cross-checked against 63 villages in 30 blocks / 16 districts (CG/JH/OD): 100% match by LGD code at every level. Village polygons: 584,615 pan-India in `LGD_Villages.parquet`.
+Cross-checked against a 63-village reference set across 30 blocks / 16 districts in CG / JH / OD: **100% match by LGD code at every level.**
 
-## Directory layout
+## What's included
 
-```
-~/GitHub/geodata/
-├── REPORT.md                          # this file
-├── scripts/
-│   ├── fetch.sh                       # pull all admin parquets from india-geodata
-│   └── extract_per_state.py           # slice parquets → per-state geojson
-│
-├── sources/                           # raw downloads (large, gitignore candidate)
-│   ├── india-geodata/                 # github.com/yashveeeeeeer/india-geodata
-│   │   ├── LGD_States.parquet            7 MB
-│   │   ├── SOI_States.parquet           11 MB
-│   │   ├── bhuvan_states.parquet         2 MB
-│   │   ├── LGD_Districts.parquet        21 MB
-│   │   ├── SOI_Districts.parquet        27 MB
-│   │   ├── bhuvan_districts.parquet     35 MB
-│   │   ├── LGD_Subdistricts.parquet     63 MB
-│   │   ├── SOI_Subdistricts.parquet     54 MB
-│   │   ├── LGD_Blocks.parquet           66 MB
-│   │   ├── bhuvan_blocks.parquet        93 MB
-│   │   ├── PMGSY_Blocks.parquet        121 MB
-│   │   ├── LGD_Villages.parquet        474 MB · 584,615 polygons
-│   │   └── SOI_VILLAGE_POINT.parquet    26 MB · centroids
-│   └── geoboundaries/                 # cross-check
-│       └── IND_ADM{1,2,3,4}.geojson   ~310 MB
-│
-└── data/boundaries/                   # per-state extracts (CG / JH / OD)
-    ├── states/        lgd_states_{cg,jh,od}.geojson
-    ├── districts/     lgd_districts_{cg,jh,od}.geojson
-    ├── subdistricts/  lgd_subdistricts_{cg,jh,od}.geojson
-    ├── blocks/        lgd_blocks_{cg,jh,od}.geojson
-    └── villages/      lgd_villages_{cg,jh,od}.geojson  (158/126/241 MB)
-```
+### Primary — yashveeeeeeer/india-geodata (CC-BY-4.0)
 
-The two large pre-existing files (`LGD_Villages.parquet`, `SOI_VILLAGE_POINT.parquet`) are hardlinks shared with `~/GitHub/village/data/geo/`. No extra disk cost; either path resolves to the same inode.
+A curated republication of openly-licensed Indian geospatial data. Each admin level offered as `.parquet`, `.geojsonl.7z`, and `.pmtiles`.
 
-## What was extracted
-
-### Primary source — yashveeeeeeer/india-geodata (GitHub Releases, CC-BY-4.0)
-
-A curated republication of openly-licensed Indian geospatial data. Each admin level is offered as `.parquet`, `.geojsonl.7z`, and `.pmtiles` from up to three providers (LGD / SOI / Bhuvan), plus PMGSY for blocks.
-
-| Level | Source | Rows | File | Has names? | Has LGD codes? | Has parent chain? |
-|---|---|---:|---|---|---|---|
-| State | LGD | 36 | `LGD_States.parquet` | yes | yes | n/a |
-| State | SOI | 40 | `SOI_States.parquet` | yes | yes | n/a |
-| State | Bhuvan | 37 | `bhuvan_states.parquet` | yes | own codes | n/a |
-| District | LGD | **785** | `LGD_Districts.parquet` | yes | yes | ↑ state |
-| District | SOI | 742 | `SOI_Districts.parquet` | yes | partial | ↑ state |
-| District | Bhuvan | 663 | `bhuvan_districts.parquet` | yes | own codes | ↑ state |
-| Sub-district | LGD | **6,471** | `LGD_Subdistricts.parquet` | yes | yes | ↑ state+dist |
-| Sub-district | SOI | 4,723 | `SOI_Subdistricts.parquet` | yes (tehsil) | partial | ↑ state+dist |
-| Block (CD) | LGD | **7,146** | `LGD_Blocks.parquet` | yes | yes (full) | ↑ state+dist |
-| Block (CD) | Bhuvan | 6,393 | `bhuvan_blocks.parquet` | yes | own codes | ↑ state+dist |
-| Block (CD) | PMGSY | 6,637 | `PMGSY_Blocks.parquet` | **no — IDs only** | yes | ↑ state+dist |
-| Village | LGD | **584,615** | `LGD_Villages.parquet` | yes | yes (full) | ↑ state+dist+subdt+block+GP |
-| Village (point) | SOI | ~600k | `SOI_VILLAGE_POINT.parquet` | yes | partial | ↑ state+dist+subdt |
+| Level | Source | Rows | Has names? | Has LGD codes? | Has parent chain? |
+|---|---|---:|---|---|---|
+| State | LGD | 36 | yes | yes | n/a |
+| State | SOI | 40 | yes | yes | n/a |
+| State | Bhuvan | 37 | yes | own codes | n/a |
+| District | LGD | **785** | yes | yes | ↑ state |
+| District | SOI | 742 | yes | partial | ↑ state |
+| District | Bhuvan | 663 | yes | own codes | ↑ state |
+| Sub-district | LGD | **6,471** | yes | yes | ↑ state+dist |
+| Sub-district | SOI | 4,723 | yes (tehsil) | partial | ↑ state+dist |
+| Block (CD) | LGD | **7,146** | yes | yes (full) | ↑ state+dist |
+| Block (CD) | Bhuvan | 6,393 | yes | own codes | ↑ state+dist |
+| Block (CD) | PMGSY | 6,637 | **no — IDs only** | yes | ↑ state+dist |
+| Village | LGD | **584,615** | yes | yes (full) | ↑ state+dist+subdt+block+GP |
+| Village (point) | SOI | ~600k | yes | partial | ↑ state+dist+subdt |
 
 LGD layers carry: `state_lgd`, `dist_lgd`, `subdt_lgd`, `block_lgd`, `vil_lgd`, plus 2011 Census codes (`stcode11`, `dtcode11`, …). Bhuvan uses its own codes only.
 
-### Secondary source — geoBoundaries (CC-BY 4.0)
+### Secondary — geoBoundaries (CC-BY-4.0)
 
-Useful as a cross-check; properties are name-only (no parent linkage). The version pinned in `9469f09` is from 2018–2021, sourced "Pathways Data Pvt. Ltd., lgdirectory.gov.in" — i.e. derived from the same LGD upstream.
+Independent cross-check; properties are name-only (no parent linkage). Pinned at commit `9469f09`, sourced "Pathways Data Pvt. Ltd., lgdirectory.gov.in" — i.e. derived from the same LGD upstream.
 
 | Layer | Rows | Year | Note |
 |---|---:|---|---|
 | ADM1 (state) | 36 | 2021 | name-only |
 | ADM2 (district) | 735 | 2021 | name-only |
 | ADM3 (sub-district / block) | 6,824 | 2018 | name-only |
-| ADM4 | 7,143 | 2019 | **not village-level** — equivalent to blocks despite the level number |
+| ADM4 | 7,143 | 2019 | **mislabelled — not village-level; equivalent to blocks** |
 
-### Per-state geojson extracts (CG / JH / OD)
+## Coverage QA — SOTH + BON villages in CG / JH / OD
 
-LGD-source slices, all admin levels, in `data/boundaries/`. Total ~680 MB across the three states. These are direct-use GeoJSON files; the pan-India authoritative store remains the parquets.
-
-Largest are villages: CG 158 MB · JH 126 MB · OD 241 MB.
-
-## Coverage check (sample — SOTH+BON villages in CG/JH/OD)
-
-Validated against the 63-village reference set from the village dashboard:
+Validated against a 63-village reference set:
 
 | Match | Count | Method |
 |---|---:|---|
@@ -98,52 +56,32 @@ Validated against the 63-village reference set from the village dashboard:
 | Villages found in `LGD_Villages.parquet` | **63 / 63** | by `vil_lgd` |
 | Blocks found in `bhuvan_blocks.parquet` | 28 / 32 | by name (spelling drift on Kusmi, Bakawand, Durgukondal, Lamtaput) |
 
-The 32 block-records-for-30-blocks reflects three different `block_lgd` codes registered for "Nandapur, Koraput" — LGD has historical re-codings; use the latest `block_ver` when joining.
+The 32-block-records-for-30-blocks reflects three different `block_lgd` codes registered for "Nandapur, Koraput" — LGD has historical re-codings; use the latest `block_ver` when joining.
 
-## Gaps and caveats
+## Known gaps + caveats
 
-1. **Panchayats not pulled.** `admin/panchayats` exists (LGD 368 MB compressed, Bhuvan 629 MB, eGramSwaraj 309 MB). Skipped to keep the initial pull lean. Uncomment the line in `scripts/fetch.sh` to add them.
+1. **Panchayats not pulled.** Available upstream (LGD 368 MB compressed, Bhuvan 629 MB, eGramSwaraj 309 MB). Skipped to keep the initial pull lean.
 
-2. **Habitations / settlements not pulled.** Huge files (1+ GB each: Karma Shapes polygons 900 MB, GatiShakti 2.5 GB, ESRI Sentinel-2 built-up 545 MB). Worth a dedicated decision before pulling.
+2. **Habitations / settlements not pulled.** Multi-GB files (Karma Shapes 900 MB, GatiShakti 2.5 GB, ESRI Sentinel-2 built-up 545 MB). Worth a dedicated decision.
 
-3. **SOI and Bhuvan village polygons not pulled.** Only LGD villages (474 MB) was retained. SOI villages parquet is 602 MB; Bhuvan villages parquet is 792 MB. Useful only when cross-validating polygon disputes — LGD-by-code is the working source.
+3. **SOI and Bhuvan village polygons not pulled.** Only LGD villages (474 MB) retained. SOI villages 602 MB; Bhuvan villages 792 MB. Useful only when cross-validating polygon disputes — LGD-by-code is the working source.
 
-4. **PMGSY_Blocks has IDs but no names.** Joinable only via a separate PMGSY masterdata CSV (also in the india-geodata releases under `admin/habitations/PMGSY_Masterdata.csv`). Not pulled.
+4. **PMGSY_Blocks has IDs but no names.** Joinable only via a separate PMGSY masterdata CSV (`admin/habitations/PMGSY_Masterdata.csv` in india-geodata releases). Not pulled.
 
-5. **Bhuvan under-counts blocks in several states** vs LGD:
-   - Gujarat 181 vs 251 · Karnataka 173 vs 234 · Telangana 443 vs 588 · Assam 185 vs 232
-   - Bhuvan's release predates several recent re-divisions. Prefer LGD as the modern authority.
+5. **Bhuvan under-counts blocks in several states** vs LGD: Gujarat 181 vs 251 · Karnataka 173 vs 234 · Telangana 443 vs 588 · Assam 185 vs 232. Bhuvan's release predates several recent re-divisions. Prefer LGD as the modern authority.
 
-6. **geoBoundaries ADM4 is mislabeled.** Despite the level number, it's not village-level (7,143 features). Use it as a redundant block layer or ignore.
+6. **geoBoundaries ADM4 is mislabelled.** Despite the level number, it's block-level (7,143 features). Use as redundant block layer or ignore.
 
-7. **Cross-source name spellings drift.** "Odisha" (LGD) vs "Orissa" (Bhuvan); "Durgukondal" (LGD) vs "Durgkondal" (Bhuvan likely). Always join on LGD codes when possible — never on names.
+7. **Cross-source name spellings drift.** "Odisha" (LGD) vs "Orissa" (Bhuvan); "Durgukondal" vs "Durgkondal". **Always join on LGD codes — never on names.**
 
-8. **2011 Census codes vs LGD codes.** Both are present in LGD layers (`stcode11`, `dtcode11`, etc. for Census 2011; `state_lgd`, `dist_lgd`, etc. for current LGD). The codes diverge after every reorganisation. Decide which is authoritative for downstream joins (LGD is current; Census 2011 is stable but stale).
+8. **2011 Census codes vs current LGD codes.** Both are present in LGD layers. They diverge after every reorganisation. LGD is current; Census 2011 is stable but stale. Decide which is authoritative for your joins.
 
-9. **Survey of India (SOI) gold copy not freely available.** SoI Open Data Series shapefiles are gated. The "SOI" files here are community-prepared derivatives from authoritative SoI village-point publications (CC-BY-4.0 per the india-geodata repo).
+9. **Survey of India (SOI) gold copy not freely available.** SoI Open Data Series shapefiles are gated. The "SOI" files here are community-prepared derivatives from authoritative SoI village-point publications (CC-BY-4.0).
 
 10. **Polygon precision varies.** LGD polygons are simplified (`MaxSimpTol` field present). For precise area / boundary work prefer SOI; for joins-and-display LGD is sufficient.
 
-## Sources cited
+## How to read freshness
 
-- **india-geodata** — github.com/yashveeeeeeer/india-geodata · CC-BY-4.0 / CC-BY-SA / CC0
-- **geoBoundaries** — geoboundaries.org · CC-BY-4.0 · pinned commit `9469f09`
-- **LGD** — Local Government Directory, lgdirectory.gov.in (upstream master)
-- **SOI** — Survey of India open data series (derivative)
-- **Bhuvan** — NRSC/ISRO Bhuvan Panchayat portal (derivative)
-- **PMGSY** — Pradhan Mantri Gram Sadak Yojana (Rural Roads), blocks layer
+Each curated layer's `fetched_at` timestamp appears as the "freshness pill" on the catalog card. Anything past 180 days renders as stale. The pipeline does not auto-refresh; running `scripts/fetch.sh` re-pulls the upstream parquets and updates the catalog.
 
-## How to refresh
-
-```bash
-# from ~/GitHub/geodata/
-bash scripts/fetch.sh                 # pull all admin parquets
-python3 scripts/extract_per_state.py  # per-state geojson convenience extracts
-```
-
-To add a new state, append to `STATES` in `scripts/extract_per_state.py` (state code is the LGD `State_LGD`, e.g. 27 = Maharashtra). To add panchayats / SOI or Bhuvan villages, uncomment lines in `scripts/fetch.sh`.
-
-## Related
-
-- `~/GitHub/district` — existing state + district visualization (Astro).
-- `~/GitHub/village` — village dashboard sourcing the same `LGD_Villages.parquet` (hardlinked).
+For corrections or new layers, open an issue at github.com/urbanmorph/geodata or contribute via [/submit](https://bharatlas.com/submit) (community-tier — won't be marked curated until promoted).

--- a/web/about.template.html
+++ b/web/about.template.html
@@ -67,8 +67,8 @@
     <ul>
       <li><strong>A visual catalog</strong> — every state, district, subdistrict, block and village under LGD codes, with side-by-side comparison of SOI, Bhuvan and geoBoundaries. Each layer renders on a map and downloads as Parquet, GeoJSON or KML.</li>
       <li><strong>A drag-drop verifier</strong> — drop any file (GeoJSON, KML, KMZ, Parquet, up to 500 MB) and the browser tells you what's wrong before it leaves your machine. Wrong CRS, broken geometries, features outside India — flagged inline.</li>
-      <li><strong>Anonymous contribution</strong> — submit your own layer with no signup, no email, no API key. The site returns an admin token (saved to your browser, downloaded as a backup <code>.txt</code>) that you keep forever. Auto-moderation handles licence, attribution and validity server-side. Open licences only. <em>(coming in v3.1)</em></li>
-      <li><strong>Mixed catalog</strong> — accepted submissions appear in the main catalog within a build cycle, badged <code>[community]</code>, sortable by recency or thumbs-up rating. Curated and community layers share the same view and download surface. <em>(coming in v3.2)</em></li>
+      <li><strong>Anonymous contribution</strong> — submit your own layer with no signup, no email, no API key. The site returns an admin token (saved to your browser, downloaded as a backup <code>.txt</code>) that you keep forever. Auto-moderation handles licence, attribution and validity server-side. Open licences only.</li>
+      <li><strong>Mixed catalog</strong> — accepted submissions appear in the main catalog within a build cycle, badged <code>[community]</code>, sortable by recency or thumbs-up rating. Curated and community layers share the same view and download surface.</li>
     </ul>
     <p>
       Everything is open: the <a href="https://github.com/urbanmorph/geodata">code</a> under MIT,
@@ -92,7 +92,7 @@
       <li>Filter any LGD-coded layer by state and instant-download as <strong>Parquet</strong>, <strong>GeoJSON</strong>, or <strong>KML</strong> (Google Earth ready).</li>
       <li>Cross-compare <strong>LGD</strong>, <strong>SOI</strong>, <strong>Bhuvan</strong> and <strong>geoBoundaries</strong> side by side.</li>
       <li><a href="/verify">Verify</a> drag-dropped files in your browser before sharing — GeoJSON, KML, KMZ or Parquet, up to 500 MB.</li>
-      <li>Submit your own geo content under an <strong>open licence</strong>, get a shareable URL plus admin token in seconds, no signup. <em>(coming in v3.1)</em></li>
+      <li>Submit your own geo content under an <strong>open licence</strong>, get a shareable URL plus admin token in seconds, no signup.</li>
     </ul>
 
     <h2>How it works</h2>

--- a/web/about.template.html
+++ b/web/about.template.html
@@ -135,6 +135,14 @@
       <a href="/">catalog</a>.
     </p>
 
+    <h2 id="use-of-data">Use of data</h2>
+    <ul>
+      <li><strong>Provided as-is, no warranty.</strong> Express or implied guarantees of accuracy, completeness or fitness for a particular purpose are not made by this site or its maintainers.</li>
+      <li><strong>Boundaries are for reference, not legal authority.</strong> For official, administrative or land-record use, refer directly to LGD, SOI, Bhuvan or the state revenue department.</li>
+      <li><strong>Curated layers reflect the upstream source at fetch time</strong> — see the freshness pill on each card. Upstream sources change; the catalog can lag.</li>
+      <li><strong>Community submissions are auto-moderated, not editorially curated.</strong> The platform checks licence, format and basic geometry validity. It does not verify accuracy, completeness or authorship beyond the contributor's self-attestation. Verify provenance via the source link on each card before relying on community data.</li>
+    </ul>
+
     <h2 style="text-transform:none;letter-spacing:0;color:var(--fg);font-size:var(--fs-xl);margin-top:var(--sp-7)">Built by</h2>
     <div class="built-by">
       <a href="https://urbanmorph.com" rel="noopener" aria-label="Urban Morph">

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -79,7 +79,7 @@ function licenseUrl(id) {
   return map[first] || undefined;
 }
 function seoHead(o) {
-  const title = `${o.title} · geodata`;
+  const title = `${o.title} · bharatlas`;
   const image = o.image || ORIGIN + '/og-default.png';
   const type = o.type || 'website';
   const ld = o.structuredData
@@ -479,7 +479,7 @@ async function renderPage(name, seoOpts, extra = {}, navKey = name) {
 await renderPage('about', {
   title: 'About',
   description:
-    "geodata combines a visual catalog, a drag-drop verifier, and an anonymous contribution flow for India's geo data — admin boundaries from state to village, plus community-submitted layers under open licences. No signup, no API key, no tracking.",
+    "Bharatlas — a visual catalog, drag-drop verifier, and anonymous contribution flow for India's geo data. Admin boundaries from state to village, plus community-submitted layers under open licences. No signup, no API key, no tracking.",
   url: ORIGIN + '/about',
   structuredData: {
     '@context': 'https://schema.org',
@@ -491,7 +491,7 @@ await renderPage('about', {
 
 await renderPage('verify', {
   title: 'Verify · drop a geo file',
-  description: 'Drag-drop a GeoJSON, KML, KMZ or Parquet file to render it on a map and check CRS, geometry validity, properties — all in your browser, nothing uploaded.',
+  description: 'Drag-drop a GeoJSON, KML, KMZ, GPX, TCX or Parquet file to render it on a map and check CRS, geometry validity, properties — all in your browser, nothing uploaded.',
   url: ORIGIN + '/verify',
   structuredData: {
     '@context': 'https://schema.org',


### PR DESCRIPTION
## Summary

Polish pass tightening everything to OSS-launch-ready quality.

5 commits:

- `95be813` **fix(seo)** — page titles + descriptions now say `bharatlas` (were `geodata`); added GPX/TCX to /verify description.
- `e0e117a` **feat(about)** — new 'Use of data' section with four disclaimers: as-is, not legal authority, freshness caveat, community auto-moderation note.
- `4d4b949` **docs(readme)** — P0/P1 OSS-best-practice fixes: updated stale Deploy + Roadmap, added Contributing / Tests / Security / Status / 'Use of data' sections, license + status badges, LICENSE file at repo root.
- `b59b74e` **docs(report)** — REPORT.md trimmed from 149 → 87 lines; dropped sections that duplicated README + /about.
- `f9b8adc` **fix(about)** — dropped stale `(coming in v3.1)` / `(coming in v3.2)` labels; submit flow + mixed catalog are shipped.

## Test plan

- [x] vitest run — 167 tests passing locally (no test changes; copy + docs only)
- [x] npm run build — clean
- [ ] CI tests + build on the branch — runs automatically when this PR opens
- [ ] After merge: CI auto-deploys to bharatlas.com — verify wordmark, /about disclaimers, README + LICENSE on the repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)