### PR TITLE
feat(favicon): bharatlas indigo 'b' mark

### DIFF
--- a/web/about.template.html
+++ b/web/about.template.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
     <!-- SEO_HEAD -->
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🗺%3C/text%3E%3C/svg%3E" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0b0b0d" media="(prefers-color-scheme: dark)" />
     <style>

--- a/web/functions/lib/render-view.ts
+++ b/web/functions/lib/render-view.ts
@@ -126,7 +126,7 @@ export function renderViewPage(opts: RenderOpts): string {
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="${esc(s.name)}" />
     <meta name="twitter:description" content="${esc(description)}" />
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🗺%3C/text%3E%3C/svg%3E" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <script type="application/ld+json">${JSON.stringify(ld).replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026')}</script>
     <style>
       /* Edge-rendered — inlines the same tokens as scripts/shared-chrome.mjs.

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
     <!-- SEO_HEAD -->
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🗺%3C/text%3E%3C/svg%3E" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev" crossorigin />
     <link rel="preconnect" href="https://tile.openstreetmap.org" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="bharatlas">
+  <!-- bharatlas favicon — indigo rounded square with white 'b' wordmark seed.
+       Indigo matches the in-product accent (#6366f1). Same mark for light +
+       dark mode; rendered solid so it reads at 16x16 tab size. -->
+  <rect width="64" height="64" rx="14" fill="#6366f1"/>
+  <!-- 'b' as a path so it renders identically regardless of system fonts. -->
+  <path
+    d="M 22 13
+       L 22 51
+       L 28 51
+       L 28 47
+       Q 31 52 38 52
+       Q 50 52 50 38
+       Q 50 24 38 24
+       Q 31 24 28 29
+       L 28 13
+       Z
+       M 36 30
+       Q 44 30 44 38
+       Q 44 46 36 46
+       Q 28 46 28 38
+       Q 28 30 36 30 Z"
+    fill="#ffffff"
+    fill-rule="evenodd"/>
+</svg>

--- a/web/submit.template.html
+++ b/web/submit.template.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
     <!-- SEO_HEAD -->
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🗺%3C/text%3E%3C/svg%3E" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0b0b0d" media="(prefers-color-scheme: dark)" />
     <style>

--- a/web/verify.template.html
+++ b/web/verify.template.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
     <!-- SEO_HEAD -->
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🗺%3C/text%3E%3C/svg%3E" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0b0b0d" media="(prefers-color-scheme: dark)" />
     <style>


### PR DESCRIPTION
## Summary

Replaces the placeholder 🗺 emoji favicon with a bharatlas-specific mark — indigo (#6366f1, matches the in-product accent) rounded square with a white lowercase 'b' rendered as an SVG path.

- One SVG file (786 bytes) — scales from 16×16 (browser tab) to 512×512 (PWA install) without rasterisation.
- Same icon referenced from all four prerendered surfaces + the edge-rendered `/c/<id>` view page.
- Path-rendered, not text, so it doesn't depend on system fonts.

## Test plan

- [x] Local build clean
- [x] All 5 pages reference `/favicon.svg`
- [x] favicon.svg lands in `dist/` (Vite copies from `web/public/`)
- [ ] After merge: tab favicon shows the indigo 'b' on bharatlas.com (may need hard refresh — browsers cache favicons aggressively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)