### PR TITLE
hotfix: CSP allowlist — DuckDB-WASM + MapLibre tiles

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -9,7 +9,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.r2.dev https://tile.openstreetmap.org https://github.com; font-src 'self' data:; connect-src 'self' https://*.r2.dev https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.r2.dev https://tile.openstreetmap.org https://*.tile.openstreetmap.org https://github.com; font-src 'self' data:; connect-src 'self' blob: data: https://*.r2.dev https://cdn.jsdelivr.net https://challenges.cloudflare.com https://tile.openstreetmap.org https://*.tile.openstreetmap.org; frame-src https://challenges.cloudflare.com; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
 
 # Hashed Vite assets — safe to cache forever.
 /assets/*

--- a/web/tests/security-headers.test.ts
+++ b/web/tests/security-headers.test.ts
@@ -52,6 +52,21 @@ describe('Security headers — Cloudflare Pages _headers file', () => {
     expect(v).toMatch(/frame-ancestors 'none'/);        // clickjacking guard
   });
 
+  it('CSP allows DuckDB-WASM + MapLibre tile fetches via connect-src', () => {
+    // These were missed in the initial v4.0.1 CSP — DuckDB-WASM fetches
+    // its WASM binary from jsdelivr (script-src isn't enough; binary
+    // arrives via fetch() which is gated by connect-src), and MapLibre
+    // fetches OSM tiles via fetch(), not as <img>. Without these, /preview
+    // hung on "loading DuckDB..." and the basemap stayed blank in prod.
+    const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/)![1];
+    const connect = csp.match(/connect-src([^;]+)/)![1];
+    expect(connect, 'connect-src missing jsdelivr').toMatch(/cdn\.jsdelivr\.net/);
+    expect(connect, 'connect-src missing OSM tiles').toMatch(/tile\.openstreetmap\.org/);
+    // wasm-unsafe-eval is the modern (Chrome 90+) directive that lets WASM
+    // modules compile without 'unsafe-eval' on script-src.
+    expect(csp).toMatch(/'wasm-unsafe-eval'/);
+  });
+
   it('keeps X-Content-Type-Options nosniff (already on by CF default; pin it)', () => {
     expect(headersFile).toMatch(/X-Content-Type-Options:\s*nosniff/i);
   });


### PR DESCRIPTION
## Summary

PR #6's CSP was too tight and broke /preview in production. Symptoms:
- "loading DuckDB..." stuck forever (WASM binary fetched from jsdelivr is blocked)
- Map basemap stayed blank (OSM tile fetches blocked)

Three additions:
- **`script-src 'wasm-unsafe-eval'`** — modern Chrome 90+ directive that lets WASM compile
- **`connect-src https://cdn.jsdelivr.net https://tile.openstreetmap.org https://*.tile.openstreetmap.org blob: data:`** — DuckDB-WASM fetches its binary via `fetch()`, MapLibre fetches tiles via `fetch()`
- **`img-src` + `child-src`** belt-and-suspenders additions

New test in `security-headers.test.ts` locks the three required permissions in place.

**197 tests green.** Plan: merge → deploy → re-test /preview with a community submission to confirm map renders + DuckDB loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)