### PR TITLE
revert(csp): drop CSP — surfaced DuckDB-WASM crash

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -2,14 +2,19 @@
 # union of all matching blocks (later blocks add headers; same header in
 # later block overrides earlier).
 
-# Security headers + sensible defaults applied to every route.
-# Lighthouse Best Practices ~50 → ~85 with this block.
+# Security headers applied to every route.
+# Lighthouse Best Practices ~50 → ~75 with this block.
+#
+# NOTE: Content-Security-Policy was temporarily removed after it surfaced
+# a DuckDB-WASM runtime error in production ("Out of bounds call_indirect").
+# Hardening CSP needs proper debugging of DuckDB worker init + WASM
+# module loading — tracked in the v4.0.2 follow-on. The other headers
+# below are safe and stay.
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.r2.dev https://tile.openstreetmap.org https://*.tile.openstreetmap.org https://github.com; font-src 'self' data:; connect-src 'self' blob: data: https://*.r2.dev https://cdn.jsdelivr.net https://challenges.cloudflare.com https://tile.openstreetmap.org https://*.tile.openstreetmap.org; frame-src https://challenges.cloudflare.com; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
 
 # Hashed Vite assets — safe to cache forever.
 /assets/*

--- a/web/tests/security-headers.test.ts
+++ b/web/tests/security-headers.test.ts
@@ -36,35 +36,10 @@ describe('Security headers — Cloudflare Pages _headers file', () => {
     }
   });
 
-  it('sets Content-Security-Policy with the bharatlas allowlist', () => {
-    // Permissive enough to allow inline JSON-LD, Turnstile (CF), MapLibre
-    // (OSM tiles + our R2 PMTiles), and DuckDB-WASM (jsdelivr CDN).
-    // Tighter CSP with nonces is post-launch work — for now we just need
-    // the header to exist so Lighthouse Best Practices scores it.
-    const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/);
-    expect(csp, 'CSP missing').not.toBeNull();
-    const v = csp![1];
-    expect(v).toMatch(/default-src 'self'/);
-    expect(v).toMatch(/challenges\.cloudflare\.com/);   // Turnstile
-    expect(v).toMatch(/tile\.openstreetmap\.org/);      // MapLibre basemap
-    expect(v).toMatch(/cdn\.jsdelivr\.net/);            // DuckDB-WASM
-    expect(v).toMatch(/r2\.dev/);                       // our R2 PMTiles + parquet
-    expect(v).toMatch(/frame-ancestors 'none'/);        // clickjacking guard
-  });
-
-  it('CSP allows DuckDB-WASM + MapLibre tile fetches via connect-src', () => {
-    // These were missed in the initial v4.0.1 CSP — DuckDB-WASM fetches
-    // its WASM binary from jsdelivr (script-src isn't enough; binary
-    // arrives via fetch() which is gated by connect-src), and MapLibre
-    // fetches OSM tiles via fetch(), not as <img>. Without these, /preview
-    // hung on "loading DuckDB..." and the basemap stayed blank in prod.
-    const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/)![1];
-    const connect = csp.match(/connect-src([^;]+)/)![1];
-    expect(connect, 'connect-src missing jsdelivr').toMatch(/cdn\.jsdelivr\.net/);
-    expect(connect, 'connect-src missing OSM tiles').toMatch(/tile\.openstreetmap\.org/);
-    // wasm-unsafe-eval is the modern (Chrome 90+) directive that lets WASM
-    // modules compile without 'unsafe-eval' on script-src.
-    expect(csp).toMatch(/'wasm-unsafe-eval'/);
+  // CSP temporarily removed pending v4.0.2 DuckDB debugging.
+  // Tests will reinstate once we know the safe directive set.
+  it('CSP is intentionally OFF — re-enable in v4.0.2 after debugging DuckDB worker init', () => {
+    expect(headersFile).not.toMatch(/^\s*Content-Security-Policy:/m);
   });
 
   it('keeps X-Content-Type-Options nosniff (already on by CF default; pin it)', () => {


### PR DESCRIPTION
## Summary

Production /preview broken after v4.0.1 + first hotfix:

> ✗ Out of bounds call_indirect (evaluating 'u(..._)')

DuckDB-WASM dies during init. CSP allowed the binary fetch + WASM compilation but something deeper in worker spawn or WASM module loading is wrong. Investigating took longer than is reasonable to leave prod half-broken, so dropping CSP and keeping the other security headers:

✓ Strict-Transport-Security · ✓ X-Content-Type-Options nosniff · ✓ Referrer-Policy · ✓ Permissions-Policy

**Lighthouse Best Practices:** ~75 (was hoping for ~85 with CSP; up from 50 baseline at least).

**CSP returns in v4.0.2** — task #54. Likely fix: pin DuckDB-WASM to a local bundle (no jsdelivr dep) so all script + worker + binary URLs are same-origin, then enforce a tight CSP.

Tests updated: previous "CSP shape" assertions inverted to assert CSP is absent until v4.0.2 re-adds it.

## Test plan

- [ ] Merge + deploy
- [ ] `curl https://bharatlas.com/` headers — no `content-security-policy`, others present
- [ ] Reload `/preview?url=<community-r2-key>` — DuckDB loads, parquet renders on map
- [ ] /preview drag-drop a local file — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)