### PR TITLE
v4.5: embed iframe + PNG image export per map

### DIFF
--- a/web/index.template.html
+++ b/web/index.template.html
@@ -518,6 +518,13 @@
 
       /* Map popups are a single look — fed by hover on pointer devices and
          by tap on touch devices. No separate hover/tap variants. */
+
+      /* Embed mode: served at /embed/<layerId>. Hide all chrome and let the
+         map fill the iframe viewport. */
+      body.embed { overflow: hidden; margin: 0; }
+      body.embed > *:not(#map-overlay) { display: none !important; }
+      body.embed #map-overlay { display: flex; position: fixed; inset: 0; z-index: 0; }
+      body.embed #map-overlay header.map-bar { display: none; }
       #map { flex: 1; background: var(--bg); position: relative; }
       #map-loading { color: var(--muted); padding: 16px; }
       .map-loader {

--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -1,3 +1,8 @@
 /verify     /preview   301
 /submit     /preview   301
 /contribute /preview   301
+
+# /embed/<layerId> serves the home page; main.ts detects the path and forces
+# embed mode (no chrome, layer auto-opened). Internal rewrite — URL stays
+# /embed/<id> in the browser. 200 = rewrite, not redirect.
+/embed/*    /index.html 200

--- a/web/src/embed-snippet.ts
+++ b/web/src/embed-snippet.ts
@@ -1,0 +1,10 @@
+export function embedIframeHtml(layerId: string, origin: string): string {
+  const src = `${origin}/embed/${encodeURIComponent(layerId)}`;
+  return `<iframe src="${src}" width="100%" height="520" loading="lazy" frameborder="0" style="border:1px solid #e5e5e5;border-radius:8px;" allowfullscreen></iframe>`;
+}
+
+export function isEmbedPath(pathname: string): { embed: true; layerId: string } | { embed: false } {
+  const m = pathname.match(/^\/embed\/([^/?#]+)\/?$/);
+  if (!m) return { embed: false };
+  return { embed: true, layerId: decodeURIComponent(m[1]) };
+}

--- a/web/src/image-export.ts
+++ b/web/src/image-export.ts
@@ -1,0 +1,34 @@
+export function imageFilename(layerId: string, now: Date = new Date()): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  // YYYYMMDD-HHmm: short, sortable, filesystem-friendly.
+  const stamp =
+    now.getUTCFullYear().toString() +
+    pad(now.getUTCMonth() + 1) +
+    pad(now.getUTCDate()) +
+    '-' +
+    pad(now.getUTCHours()) +
+    pad(now.getUTCMinutes());
+  const safe = layerId.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return `bharatlas-${safe}-${stamp}.png`;
+}
+
+export function dataUrlToBlob(dataUrl: string): Blob {
+  const m = dataUrl.match(/^data:([^;]+);base64,(.*)$/);
+  if (!m) throw new Error('not a base64 data URL');
+  const bin = atob(m[2]);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new Blob([bytes], { type: m[1] });
+}
+
+export function triggerDownload(blob: Blob, filename: string, doc: Document = document): void {
+  const url = URL.createObjectURL(blob);
+  const a = doc.createElement('a');
+  a.href = url;
+  a.download = filename;
+  doc.body.appendChild(a);
+  a.click();
+  doc.body.removeChild(a);
+  // Defer revoke so Safari has time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,5 +1,6 @@
 // Tiny entry: hash-based map routing + hover-prefetch of the map chunk.
 // Map code is in a separate chunk; only loaded when the user opens a map.
+import { isEmbedPath } from './embed-snippet';
 
 const overlay = document.getElementById('map-overlay')!;
 const mapTitle = document.getElementById('map-title')!;
@@ -7,6 +8,24 @@ const mapCloseBtn = document.getElementById('map-close') as HTMLButtonElement;
 
 // Dynamic imports are cached by the loader, so we don't need our own cache.
 const loadMap = () => import('./map');
+
+// /embed/<layerId>: Cloudflare Pages rewrites the path to /index.html, so the
+// same bundle serves both contexts. Detect via the unrewritten URL.
+{
+  const probe = isEmbedPath(location.pathname);
+  if (probe.embed) {
+    document.body.classList.add('embed');
+    // noindex duplicate embed pages; Google honors JS-set robots meta for
+    // client-rendered pages.
+    const m = document.createElement('meta');
+    m.name = 'robots';
+    m.content = 'noindex, nofollow';
+    document.head.appendChild(m);
+    if (!location.hash.startsWith('#view/')) {
+      history.replaceState(null, '', `#view/${encodeURIComponent(probe.layerId)}`);
+    }
+  }
+}
 
 async function showMap(layerId: string) {
   overlay.classList.add('open');

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -7,6 +7,8 @@ import { getCatalog } from './catalog';
 import { escapeHtml } from './util';
 import { availableDownloads, fmtBytes } from './format-hints';
 import { BASEMAPS, getStoredBasemap, setStoredBasemap, type BasemapId } from './basemaps';
+import { embedIframeHtml } from './embed-snippet';
+import { imageFilename, dataUrlToBlob, triggerDownload } from './image-export';
 
 type Layer = {
   id: string;
@@ -97,6 +99,9 @@ export async function openLayer(layerId: string, opts: { titleEl: HTMLElement })
     bounds: INDIA_BOUNDS,
     fitBoundsOptions: { padding: 20 },
     attributionControl: { compact: true },
+    // Required so map.getCanvas().toDataURL() returns pixels for the
+    // "Export image (PNG)" menu entry. Tiny perf cost; acceptable here.
+    preserveDrawingBuffer: true,
   });
   map.addControl(new maplibregl.NavigationControl({ visualizePitch: false }), 'top-right');
   map.addControl(new maplibregl.ScaleControl({ unit: 'metric' }));
@@ -261,26 +266,61 @@ function wireDownloadButton(layer: Layer): void {
   const popover = document.getElementById('map-download-popover');
   if (!btn || !popover) return;
   const downloads = availableDownloads(layer);
-  if (!downloads.length) {
-    btn.classList.remove('shown');
-    popover.classList.remove('open');
-    popover.innerHTML = '';
-    return;
-  }
   btn.classList.add('shown');
   popover.innerHTML =
-    `<div class="map-popover__title">Download whole layer</div>` +
-    downloads
-      .map(
-        (d) =>
-          `<a class="map-popover__item" href="${escapeHtml(d.url)}" download>
-            <span class="map-popover__fmt">${escapeHtml(d.label)}</span>
-            <span class="map-popover__size">${escapeHtml(fmtBytes(d.bytes))}</span>
-            <span class="map-popover__hint">${escapeHtml(d.hint)}</span>
-          </a>`,
-      )
-      .join('') +
-    `<div class="map-popover__foot">Need a slice? Use <strong>Filter &amp; export</strong> for state-scoped GeoJSON &amp; KML.</div>`;
+    (downloads.length
+      ? `<div class="map-popover__title">Download whole layer</div>` +
+        downloads
+          .map(
+            (d) =>
+              `<a class="map-popover__item" href="${escapeHtml(d.url)}" download>
+                <span class="map-popover__fmt">${escapeHtml(d.label)}</span>
+                <span class="map-popover__size">${escapeHtml(fmtBytes(d.bytes))}</span>
+                <span class="map-popover__hint">${escapeHtml(d.hint)}</span>
+              </a>`,
+          )
+          .join('') +
+        `<div class="map-popover__foot">Need a slice? Use <strong>Filter &amp; export</strong> for state-scoped GeoJSON &amp; KML.</div>`
+      : '') +
+    `<div class="map-popover__title">Share this view</div>` +
+    `<button class="map-popover__item map-popover__item--btn" data-action="copy-embed">
+      <span class="map-popover__fmt">Copy embed code</span>
+      <span class="map-popover__hint">paste into a blog post or report</span>
+    </button>` +
+    `<button class="map-popover__item map-popover__item--btn" data-action="export-png">
+      <span class="map-popover__fmt">Export image (PNG)</span>
+      <span class="map-popover__hint">current viewport, your active base map</span>
+    </button>`;
+  const copyBtn = popover.querySelector<HTMLButtonElement>('[data-action="copy-embed"]');
+  const exportBtn = popover.querySelector<HTMLButtonElement>('[data-action="export-png"]');
+  copyBtn?.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    const snippet = embedIframeHtml(layer.id, location.origin);
+    try {
+      await navigator.clipboard.writeText(snippet);
+      const fmt = copyBtn.querySelector<HTMLElement>('.map-popover__fmt');
+      if (fmt) {
+        const original = fmt.textContent;
+        fmt.textContent = '✓ Copied';
+        setTimeout(() => { if (original) fmt.textContent = original; }, 1400);
+      }
+    } catch {
+      // Clipboard may be blocked (insecure context); fall back to a prompt.
+      prompt('Copy this iframe snippet:', snippet);
+    }
+  });
+  exportBtn?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (!map) return;
+    // preserveDrawingBuffer: true on init means the canvas is always
+    // readable; no need to triggerRepaint or wait for a 'render' event.
+    try {
+      const url = map.getCanvas().toDataURL('image/png');
+      triggerDownload(dataUrlToBlob(url), imageFilename(layer.id));
+    } catch (err) {
+      console.error('PNG export failed', err);
+    }
+  });
   bindPopover(btn, popover);
 }
 

--- a/web/tests/embed-snippet.test.ts
+++ b/web/tests/embed-snippet.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { embedIframeHtml, isEmbedPath } from '../src/embed-snippet';
+
+describe('embed-snippet — embedIframeHtml', () => {
+  it('emits a sane iframe snippet with the encoded layer id', () => {
+    const html = embedIframeHtml('lgd_states', 'https://bharatlas.com');
+    expect(html).toMatch(/^<iframe /);
+    expect(html).toContain('src="https://bharatlas.com/embed/lgd_states"');
+    expect(html).toContain('width="100%"');
+    expect(html).toContain('height="520"');
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('allowfullscreen');
+  });
+
+  it('URL-encodes spicy ids in the src', () => {
+    expect(embedIframeHtml('wards@chennai', 'https://x')).toContain('src="https://x/embed/wards%40chennai"');
+  });
+});
+
+describe('embed-snippet — isEmbedPath', () => {
+  it('recognises /embed/<id>', () => {
+    expect(isEmbedPath('/embed/lgd_villages')).toEqual({ embed: true, layerId: 'lgd_villages' });
+  });
+
+  it('recognises a trailing slash', () => {
+    expect(isEmbedPath('/embed/lgd_villages/')).toEqual({ embed: true, layerId: 'lgd_villages' });
+  });
+
+  it('decodes URI-encoded ids', () => {
+    expect(isEmbedPath('/embed/wards%40chennai')).toEqual({ embed: true, layerId: 'wards@chennai' });
+  });
+
+  it('rejects bare /embed', () => {
+    expect(isEmbedPath('/embed')).toEqual({ embed: false });
+    expect(isEmbedPath('/embed/')).toEqual({ embed: false });
+  });
+
+  it('rejects unrelated paths', () => {
+    expect(isEmbedPath('/about')).toEqual({ embed: false });
+    expect(isEmbedPath('/')).toEqual({ embed: false });
+  });
+
+  it('rejects nested paths under /embed/<id>/something', () => {
+    expect(isEmbedPath('/embed/lgd_villages/extra')).toEqual({ embed: false });
+  });
+});

--- a/web/tests/image-export.test.ts
+++ b/web/tests/image-export.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { imageFilename, dataUrlToBlob } from '../src/image-export';
+
+describe('image-export — imageFilename', () => {
+  it('formats a sortable timestamp with UTC parts', () => {
+    const d = new Date(Date.UTC(2026, 4, 22, 9, 7));
+    expect(imageFilename('lgd_villages', d)).toBe('bharatlas-lgd_villages-20260522-0907.png');
+  });
+
+  it('sanitises spicy filename characters', () => {
+    const d = new Date(Date.UTC(2026, 0, 1, 0, 0));
+    expect(imageFilename('wards/chennai 2025', d)).toBe('bharatlas-wards_chennai_2025-20260101-0000.png');
+  });
+
+  it('zero-pads single-digit month, day, hour, minute', () => {
+    const d = new Date(Date.UTC(2026, 0, 5, 3, 4));
+    expect(imageFilename('x', d)).toBe('bharatlas-x-20260105-0304.png');
+  });
+
+  it('ends in .png', () => {
+    expect(imageFilename('x')).toMatch(/\.png$/);
+  });
+});
+
+describe('image-export — dataUrlToBlob', () => {
+  it('round-trips a tiny base64 PNG', () => {
+    // 1×1 transparent PNG.
+    const dataUrl =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=';
+    const blob = dataUrlToBlob(dataUrl);
+    expect(blob.type).toBe('image/png');
+    expect(blob.size).toBeGreaterThan(0);
+  });
+
+  it('throws on a non-base64 data URL', () => {
+    expect(() => dataUrlToBlob('not-a-data-url')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Two shareability features folded into the existing **Download** dropdown in the map header.

- **/embed/<layerId>** — Cloudflare Pages rewrites the path to `/index.html`; `main.ts` detects via `location.pathname`, sets `body.embed`, hides all chrome, and force-opens the layer. Reuses every existing code path — no new Vite entry, no edge function. Embed pages get a `noindex` meta tag so the rewrites don't pollute search.
- **Export image (PNG)** — `map.getCanvas().toDataURL('image/png')` on click. `preserveDrawingBuffer: true` added to MapLibre init so the canvas stays readable. Filename is `bharatlas-<layerId>-<UTC stamp>.png`.

Download menu now has two semantic sections:
- **Download whole layer** — file formats (parquet, pmtiles, geojson)
- **Share this view** — Copy embed code + Export image (PNG)

The Share section appears even for layers without downloadable files, so every map can be embedded / exported.

## Implementation

- `embed-snippet.ts` + `image-export.ts` are pure (no DOM access in the test surface).
- Tier-1 + Tier-2 simplifier findings applied: dropped unused `width`/`height` opts on `embedIframeHtml`, inlined `embedUrl`, removed an unnecessary `triggerRepaint()` made redundant by `preserveDrawingBuffer`.
- 12 new unit tests cover URL encoding, iframe HTML shape, embed-path matching, filename generation, and base64→Blob round-trip.

## Test plan

- [ ] Open any layer; Download dropdown shows file formats + "Share this view" section
- [ ] "Copy embed code" → snippet lands in clipboard; the entry briefly flashes "✓ Copied"
- [ ] Paste snippet into a test HTML page → the iframe renders the map
- [ ] "Export image (PNG)" → PNG downloads with the active base map
- [ ] `/embed/lgd_states` (or any layer id) loads with no header chrome, layer auto-opens
- [ ] `view-source:/embed/...` shows the noindex meta tag once JS runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)