### PR TITLE
v4.2.1: code-simplifier pass + live-probe numeric coercion

### DIFF
--- a/scripts/build_filter_stats.py
+++ b/scripts/build_filter_stats.py
@@ -95,9 +95,9 @@ def stats_for_parquet(path: Path, con: duckdb.DuckDBPyConnection) -> dict | None
             'null_frac': round(float(null_frac or 0), 4),
         }
         if min_v is not None:
-            entry['min'] = _coerce_minmax(min_v, norm)
+            entry['min'] = _coerce(min_v, norm)
         if max_v is not None:
-            entry['max'] = _coerce_minmax(max_v, norm)
+            entry['max'] = _coerce(max_v, norm)
 
         if 2 <= entry['distinct'] <= FACET_THRESHOLD:
             try:
@@ -110,7 +110,7 @@ def stats_for_parquet(path: Path, con: duckdb.DuckDBPyConnection) -> dict | None
                     LIMIT {MAX_TOP_VALUES}
                 """).fetchall()
                 entry['top_values'] = [
-                    {'v': _coerce_value(v, norm), 'n': int(n)} for v, n in top
+                    {'v': _coerce(v, norm), 'n': int(n)} for v, n in top
                 ]
             except duckdb.Error as e:
                 print(f'  filter_stats: top_values failed on {col_name} — {e}')
@@ -120,21 +120,7 @@ def stats_for_parquet(path: Path, con: duckdb.DuckDBPyConnection) -> dict | None
     return {'row_count': int(row_count), 'columns': columns}
 
 
-def _coerce_minmax(v: str, norm: str) -> str | float | int:
-    if norm == 'int':
-        try:
-            return int(v)
-        except (ValueError, TypeError):
-            return v
-    if norm == 'float':
-        try:
-            return float(v)
-        except (ValueError, TypeError):
-            return v
-    return v
-
-
-def _coerce_value(v: str | None, norm: str) -> str | float | int | None:
+def _coerce(v, norm: str):
     if v is None:
         return None
     if norm == 'int':

--- a/web/src/filter-probe.ts
+++ b/web/src/filter-probe.ts
@@ -96,14 +96,19 @@ export async function describeParquet(url: string): Promise<ProbeResult> {
 
   const topValues: Record<string, Array<{ v: string | number; n: number }>> = {};
   for (const d of lowCardCols) {
+    const norm = normaliseType(d.column_type);
     try {
+      // Cast numeric columns back to native types — otherwise the MapLibre
+      // filter (`['in', ['get', col], ['literal', values]]`) compares the
+      // baked strings against tile-property numbers and silently matches
+      // nothing. Strings/dates stay as VARCHAR.
       const rows = await query<{ v: unknown; n: bigint | number }>(
         `SELECT ${escIdent(d.column_name)}::VARCHAR AS v, COUNT(*) AS n
          FROM '${url}' WHERE ${escIdent(d.column_name)} IS NOT NULL
          GROUP BY 1 ORDER BY n DESC LIMIT ${MAX_TOP_VALUES}`,
       );
       topValues[d.column_name] = rows.map((r) => ({
-        v: String(r.v),
+        v: coerceMinMax(String(r.v), norm),
         n: Number(r.n),
       }));
     } catch {

--- a/web/src/filter-schema.ts
+++ b/web/src/filter-schema.ts
@@ -27,7 +27,7 @@ export type ColumnStats = {
 
 export type Affordance =
   | { kind: 'facet'; values: Array<{ v: string | number; n: number; label?: string }> }
-  | { kind: 'searchable'; sampleValues: Array<string | number> }
+  | { kind: 'searchable' }
   | { kind: 'search' }
   | { kind: 'range'; min: number; max: number }
   | { kind: 'boolean' }
@@ -93,12 +93,7 @@ export function pickAffordance(col: ColumnStats, rowCount: number): Affordance {
   }
 
   if (col.distinct <= 50) return { kind: 'facet', values: col.topValues ?? [] };
-  if (col.distinct <= 2000) {
-    return {
-      kind: 'searchable',
-      sampleValues: (col.topValues ?? []).slice(0, 10).map((v) => v.v),
-    };
-  }
+  if (col.distinct <= 2000) return { kind: 'searchable' };
   return { kind: 'search' };
 }
 

--- a/web/src/filter-where.ts
+++ b/web/src/filter-where.ts
@@ -55,6 +55,31 @@ export function buildWhereSQL(filters: ActiveFilter[]): string {
   return parts.length ? 'WHERE ' + parts.join(' AND ') : '';
 }
 
+// Resolve an ActiveFilter to the LGD state codes it selects, when (and only
+// when) the user picked exactly one IN filter on a known state column. Used
+// by both the R2 pre-baked-extract fast path (filter.ts) and the camera
+// fly-to (map.ts). Returns [] when the filter doesn't address state.
+const STATE_CODE_COL = /^state_lgd$/i;
+const STATE_NAME_COL = /^(stname|state|state_name)$/i;
+
+export function resolveStateCodes(
+  filters: ActiveFilter[],
+  stateNameToCode: Map<string, number>,
+): number[] {
+  if (filters.length !== 1) return [];
+  const f = filters[0];
+  if (f.kind !== 'in') return [];
+  if (STATE_CODE_COL.test(f.col)) {
+    return f.values.map((v) => (typeof v === 'number' ? v : Number(v))).filter(Number.isFinite);
+  }
+  if (STATE_NAME_COL.test(f.col)) {
+    return f.values
+      .map((v) => stateNameToCode.get(String(v).toLowerCase()))
+      .filter((c): c is number => c != null);
+  }
+  return [];
+}
+
 export type MaplibreFilter = unknown[] | null;
 
 // MapLibre tile-property filter. Returns null when no filter applies, or

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1,11 +1,8 @@
-// v4.2 commit 5: generic FilterPanel.
-// Reads ColumnStats[] (from catalog.filter_stats or live describeParquet)
-// and renders an affordance per ranked column — facet chips, range inputs,
-// debounced search box, or boolean toggle. Maintains an ActiveFilter[] that
-// drives both the in-tile map repaint (via buildMaplibreFilter) and the
-// DuckDB export queries (via buildWhereSQL). Pre-baked R2 extracts still
-// short-circuit DuckDB when the active filter is exactly one IN on the
-// state_lgd column with one value.
+// Generic FilterPanel: renders one affordance per ranked column (facet chips,
+// range inputs, debounced search box, boolean toggle) and maintains an
+// ActiveFilter[] that drives both the in-tile MapLibre repaint and the
+// DuckDB-WASM count/export queries. Single-state filters short-circuit to a
+// pre-baked R2 extract when one exists.
 
 import {
   exportFilteredParquet,
@@ -21,6 +18,7 @@ import { pickAffordance, type Affordance, type ColumnStats } from './filter-sche
 import {
   buildMaplibreFilter,
   buildWhereSQL,
+  resolveStateCodes,
   type ActiveFilter,
   type MaplibreFilter,
 } from './filter-where';
@@ -142,8 +140,6 @@ export function mountFilterPanel(
     }
   }
 
-  // Render columns by ranked usefulness; pickAffordance lives in the schema
-  // module so the test surface stays pure.
   for (const col of ranked) {
     const aff = pickAffordance(col, rowCount);
     if (aff.kind === 'drop') continue;
@@ -183,16 +179,15 @@ export function mountFilterPanel(
       if (!active.length) return;
       const fmt = btn.dataset.fmt as 'parquet' | 'geojson' | 'kml';
 
-      // Fast path: hand off to a pre-baked R2 file when the active filter
-      // is exactly one IN on a state column with one value (and the bake
-      // exists). Accepts either the legacy numeric state_lgd or a string
-      // name column (STNAME, state, state_name) — names are translated to
-      // codes via the catalog.states lookup.
-      const stateCode = matchSingleStateFilter(active, stateNameToCode);
-      if (stateCode != null) {
-        const bake = extracts[String(stateCode)]?.[fmt];
+      // Pre-baked R2 fast path: skip DuckDB entirely when the user picked
+      // exactly one state (single value on a known state column) and a
+      // matching bake exists.
+      const stateCodes = resolveStateCodes(active, stateNameToCode);
+      if (stateCodes.length === 1) {
+        const code = stateCodes[0];
+        const bake = extracts[String(code)]?.[fmt];
         if (bake?.url) {
-          const fn = `${layer.id}__state${stateCode}.${fmt}`;
+          const fn = `${layer.id}__state${code}.${fmt}`;
           downloadUrl(bake.url, fn);
           status.innerHTML = `<span class="filter-panel__ok">Downloaded ${escapeHtml(fn)} (${formatSize(bake.bytes)}, pre-baked).</span>`;
           return;
@@ -236,27 +231,6 @@ export function mountFilterPanel(
   });
 }
 
-// Detect a single-state filter so we can short-circuit DuckDB and hand off
-// to the pre-baked R2 extract. Supports both the (legacy) numeric state_lgd
-// column and any sibling string state-name column (STNAME / state /
-// state_name) — names are translated via the catalog.states map.
-function matchSingleStateFilter(
-  filters: ActiveFilter[],
-  stateNameToCode: Map<string, number>,
-): number | null {
-  if (filters.length !== 1) return null;
-  const f = filters[0];
-  if (f.kind !== 'in' || f.values.length !== 1) return null;
-  if (/^state_lgd$/i.test(f.col)) {
-    const v = f.values[0];
-    return typeof v === 'number' ? v : Number(v);
-  }
-  if (/^(stname|state|state_name)$/i.test(f.col)) {
-    return stateNameToCode.get(String(f.values[0]).toLowerCase()) ?? null;
-  }
-  return null;
-}
-
 // ───── Per-affordance renderers ─────
 
 function renderField(
@@ -289,14 +263,13 @@ function renderFacet(
   const wrap = document.createElement('div');
   wrap.className = 'filter-chips';
   const selected = new Set<string>();
-  for (const { v, n } of aff.values) {
+  for (const { v, n, label } of aff.values) {
     const chip = document.createElement('button');
     chip.type = 'button';
     chip.className = 'filter-chip';
     chip.dataset.value = String(v);
-    const display = aff.values.find((x) => x.v === v)?.label ?? String(v);
     chip.innerHTML =
-      `<span class="filter-chip__v">${escapeHtml(display)}</span>` +
+      `<span class="filter-chip__v">${escapeHtml(label ?? String(v))}</span>` +
       `<span class="filter-chip__n">${n.toLocaleString('en-IN')}</span>`;
     chip.addEventListener('click', () => {
       const key = String(v);

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -9,6 +9,7 @@ import { availableDownloads, fmtBytes } from './format-hints';
 import { BASEMAPS, getStoredBasemap, setStoredBasemap, type BasemapId } from './basemaps';
 import { embedIframeHtml } from './embed-snippet';
 import { imageFilename, dataUrlToBlob, triggerDownload } from './image-export';
+import { resolveStateCodes, type ActiveFilter, type MaplibreFilter } from './filter-where';
 
 type Layer = {
   id: string;
@@ -471,13 +472,12 @@ function panelAwarePadding(): { top: number; bottom: number; left: number; right
   return { top: base, bottom: base, left: base, right: base + r.width };
 }
 
-// Apply the active filter set to the map's fill+line layers. Uses the
-// MapLibre filter that filter-where.ts produced, plus a fitBounds special
-// case for the legacy state-filter (we know each state's bbox from the
-// catalog, so the camera flies to it just like before).
+// Apply the active filter set to the map's fill+line layers and fly the
+// camera to the union bbox when the filter selects one-or-more known states
+// (so the user lands on the right region, not on India-wide).
 function applyActiveFilters(
-  filters: import('./filter-where').ActiveFilter[],
-  mapFilter: import('./filter-where').MaplibreFilter,
+  filters: ActiveFilter[],
+  mapFilter: MaplibreFilter,
   fullCatalog?: {
     state_bounds?: Record<string, [number, number, number, number]>;
     states?: Array<{ code: number; name: string }>;
@@ -490,40 +490,26 @@ function applyActiveFilters(
     }
   }
   const padding = panelAwarePadding();
-  // State fly-to. Accepts both the numeric state_lgd column and the string
-  // state-name columns (STNAME / state / state_name) — names are translated
-  // to codes via catalog.states. For multi-state selection, compute the
-  // union bbox across all selected states.
-  if (filters.length === 1 && filters[0].kind === 'in' && filters[0].values.length >= 1) {
-    const f = filters[0];
-    let codes: string[] = [];
-    if (/^state_lgd$/i.test(f.col)) {
-      codes = f.values.map(String);
-    } else if (/^(stname|state|state_name)$/i.test(f.col) && fullCatalog?.states) {
-      const byName = new Map(fullCatalog.states.map((s) => [s.name.toLowerCase(), s.code]));
-      codes = f.values
-        .map((v) => byName.get(String(v).toLowerCase()))
-        .filter((c): c is number => c != null)
-        .map(String);
+
+  if (fullCatalog?.state_bounds && fullCatalog.states) {
+    const byName = new Map(fullCatalog.states.map((s) => [s.name.toLowerCase(), s.code]));
+    const codes = resolveStateCodes(filters, byName);
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const c of codes) {
+      const b = fullCatalog.state_bounds[String(c)];
+      if (b) {
+        if (b[0] < minX) minX = b[0];
+        if (b[1] < minY) minY = b[1];
+        if (b[2] > maxX) maxX = b[2];
+        if (b[3] > maxY) maxY = b[3];
+      }
     }
-    if (codes.length && fullCatalog?.state_bounds) {
-      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-      for (const c of codes) {
-        const b = fullCatalog.state_bounds[c];
-        if (b) {
-          if (b[0] < minX) minX = b[0];
-          if (b[1] < minY) minY = b[1];
-          if (b[2] > maxX) maxX = b[2];
-          if (b[3] > maxY) maxY = b[3];
-        }
-      }
-      if (minX !== Infinity) {
-        map.fitBounds([[minX, minY], [maxX, maxY]], { padding, duration: 600 });
-        return;
-      }
+    if (minX !== Infinity) {
+      map.fitBounds([[minX, minY], [maxX, maxY]], { padding, duration: 600 });
+      return;
     }
   }
-  // Filter cleared → fly back to India.
+
   if (!filters.length) {
     map.fitBounds(INDIA_BOUNDS, { padding, duration: 600 });
   }


### PR DESCRIPTION
## Summary

Catch-up on the dev-process steps I should have run before merging v4.2 — code-simplifier audit + bug it surfaced.

### Tier-1 simplifications (-35 LOC, 0 new imports in eager chunk)

- **Drop unread `Affordance.searchable.sampleValues`** — `filter-schema.ts`. No caller; renderField treats `searchable` and `search` identically.
- **Extract `resolveStateCodes(filters, byName)`** into `filter-where.ts` — was duplicated between `filter.ts::matchSingleStateFilter` and `map.ts::applyActiveFilters` with subtly different shapes.
- **Merge `_coerce_minmax` + `_coerce_value`** in `build_filter_stats.py` (only differed in None-passthrough).
- **Trim WHAT-narration headers** in `filter.ts` and `map.ts`.

### Tier-2 correctness fix

`filter-probe.ts` now coerces `topValues.v` to native int/float for numeric columns (matching the Python baker). Previously the live probe shipped `String("29")` for a numeric `ward_no`, so MapLibre `setFilter` compared `"29"` against the integer `29` in tile properties — silently matched nothing.

Only visible on opencity layers (and future community uploads) that fall back to the live probe; baked layers already had correctly-typed values.

## Why this is a separate PR

The simplifier + tests + lighthouse pass should have run pre-merge on v4.2; I shortcut them. Following up here so v4.2 in production gets the cleaner code path before any user finds the live-probe bug.

## Test plan

- [ ] CI green
- [ ] Open `/#view/wards_chennai` (opencity, live probe) → filter button appears; pick a `ward_no` facet chip → polygons highlight on the map (regression: previously silently no-op)
- [ ] Open `/#view/lgd_villages` (baked) → STNAME facet still works exactly as it did pre-fix
- [ ] All 286 existing tests stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)