### PR TITLE
docs: post-v4.7 drift + about page polish + founder narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,18 @@ A visual catalog, drag-drop verifier, and anonymous contribution flow for India'
 **Live**: https://bharatlas.com
 
 ```
-catalog          → state · district · subdistrict · block · village (LGD-coded)
-verify           → drop GeoJSON · KML · KMZ · GPX · TCX · Parquet → render + validate
-submit           → contribute under an open licence · anonymous · admin-token model
-view (/c/<id>)   → public page per submission, ▲/▼ vote, JSON-LD indexed
+catalog               → state · district · subdistrict · block · village (LGD)
+                        + city wards (Bengaluru, Chennai, Hyderabad, Mumbai, …)
+                        + electoral constituencies, wildlife, eco-zones
+preview               → drop GeoJSON · KML · KMZ · GPX · TCX · Parquet →
+                        render + validate → optional Publish
+filter & export       → dynamic facets / range / search per layer schema,
+                        slice by what the data actually contains, export
+                        as Parquet · GeoJSON · KML
+view (/view/<id>)     → curated layer with per-layer OG card
+view (/c/<id>)        → community submission, edge-rendered HTML, ▲/▼ vote,
+                        per-submission OG card
+embed                 → /embed/<id> iframe + PNG export from any map
 ```
 
 ## What's in this repo
@@ -51,7 +59,7 @@ git clone git@github.com:urbanmorph/geodata.git
 cd geodata/web
 npm install
 npm run dev    # http://localhost:5173
-npm test       # 167 vitest tests
+npm test       # 320+ vitest tests
 ```
 
 For the full submission flow (D1 + R2 + Turnstile + Pages Functions), see [docs/full-dev.md](./docs/full-dev.md) (TODO) or read `wrangler.toml` + `.dev.vars.example`.
@@ -72,14 +80,16 @@ Commit messages: short subject, body explains *why* not *what*. Examples in `git
 cd web && npm test
 ```
 
-167 tests across validators, token generation, vote tally, render-view HTML, etc. See [`web/tests/`](./web/tests/).
+320+ tests across validators, token generation, vote tally, render-view HTML, filter affordances, OG template, and more. See [`web/tests/`](./web/tests/).
 
 ## Roadmap
 
-- [x] v1 — pan-India admin layers, parquet + PMTiles downloads
+- [x] v1 — pan-India admin layers, Parquet + PMTiles downloads
 - [x] v2 — DuckDB-WASM filter & export per state
 - [x] v3 — submission flow: drag-drop verify, anonymous token, auto-moderation, /c/[id] view page, mixed catalog, votes
-- [ ] v4 — public API + MCP server + Claude Code plugin
+- [x] v4 — SEO/AEO pass, opencity ingest (city wards), dynamic filters from schema, basemap toggle, format-hinted downloads, embed iframe + PNG export, unified edge OG renderer (per-layer + per-submission cards)
+- [ ] **next**: "Your submissions" panel · CSP re-enable · a11y to 95+ · privacy + ToS
+- [ ] v5 — public REST API + MCP server + Claude Code plugin
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,6 @@ For the full submission flow (D1 + R2 + Turnstile + Pages Functions), see [docs/
 
 Commit messages: short subject, body explains *why* not *what*. Examples in `git log`.
 
-## Tests
-
-```bash
-cd web && npm test
-```
-
-320+ tests across validators, token generation, vote tally, render-view HTML, filter affordances, OG template, and more. See [`web/tests/`](./web/tests/).
-
 ## Roadmap
 
 - [x] v1 — pan-India admin layers, Parquet + PMTiles downloads
@@ -101,7 +93,7 @@ Code: [MIT](./LICENSE). Data: each layer carries its own open licence — see th
 
 ## Use of data
 
-The platform doesn't warrant accuracy or fitness for any purpose. Boundaries shown are for reference, not legal authority — refer to LGD, SOI, Bhuvan or the state revenue department for official use. Community submissions are auto-moderated, not editorially curated; verify provenance via the source link on each card. See [/about → Use of data](https://bharatlas.com/about#use-of-data).
+Provided as-is, no warranty. For legal/administrative use, go to the upstream source. Full disclaimers: [/about → Use of data](https://bharatlas.com/about#use-of-data).
 
 ## Credits
 
@@ -112,6 +104,4 @@ The platform doesn't warrant accuracy or fitness for any purpose. Boundaries sho
 
 Built by [Urban Morph](https://urbanmorph.com) · [@sathyasankaran](https://linkedin.com/in/sathyasankaran). Drop a ⭐ if you find it useful.
 
-## Status
-
-**Alpha.** The submission flow is live and accepting contributions, but the schema and API may change before v4. Community submissions are permanent under the open licence the contributor selected.
+**Status:** alpha. Submission flow is live and accepting contributions; the schema and external API may shift before v5. Community submissions are permanent under the open licence the contributor selected.

--- a/web/about.template.html
+++ b/web/about.template.html
@@ -43,72 +43,47 @@
   <body>
     <!-- NAV -->
 
-    <p class="eyebrow" style="font-size:13px;letter-spacing:.04em;color:var(--accent);margin:8px 0 4px">geodata</p>
+    <p class="eyebrow" style="font-size:13px;letter-spacing:.04em;color:var(--accent);margin:8px 0 4px">bharatlas</p>
     <h1 class="hero">India's open atlas.</h1>
     <p class="lede">
-      Find a map, see it on a map, slice out what you need, and download. Submit your own
-      by dropping it on the page. No signup, no API key, no SQL.
+      Browse, slice, and download India's official map layers. Submit your own by dropping
+      it onto the page. No signup, no API key, no SQL.
+    </p>
+    <p style="margin:0 0 var(--sp-6)">
+      <a href="/" class="cta" style="display:inline-block;background:var(--fg);color:var(--bg);padding:10px 18px;border-radius:var(--radius-md);font-weight:500;text-decoration:none">Browse the catalog →</a>
     </p>
 
     <h2>Why bharatlas exists</h2>
     <p>
-      Sathya kept hitting the same wall. Maps lived everywhere online, but you couldn't
-      tell what they actually showed, who maintained them, or whether to trust them.
-      Pulling out just the slice he needed meant booting QGIS or wading through Google
-      Maps menus. Viewing was its own ordeal — sign in, navigate the menus, import.
-      The format question alone — KML? KMZ? GeoJSON? Parquet? — felt gatekept. And if
-      you'd made a map yourself and wanted to share it, you had to stand up your own
-      website to host it.
+      Maps live everywhere online, but you can't tell what they actually show, who
+      maintains them, or whether to trust them. Pulling out just the slice you need
+      means booting QGIS or wading through Google Maps menus. Viewing is its own ordeal
+      — sign in, navigate the menus, import. The format question alone — KML? KMZ?
+      GeoJSON? Parquet? — feels gatekept. And if you've made a map yourself and want to
+      share it, you have to stand up your own website to host it.
     </p>
     <p>
-      Bharatlas is the idea to flatten all of that. <strong>The wiki for India's maps.</strong>
-      View any layer in your browser. Filter what you need. Download in whatever format
-      your tool reads. Liked it? Upvote so others find it. Have a map worth sharing? Drag
-      and drop it onto the page. Every layer carries its source, licence and freshness on
-      the same card.
+      Sathya kept hitting the same wall. Bharatlas flattens all of that —
+      <strong>the wiki for India's maps.</strong> View any layer in your browser. Filter
+      what you need. Download in whatever format your tool reads. Liked it? Upvote so
+      others find it. Have a map worth sharing? Drag and drop it onto the page. Every
+      layer carries its source, licence and freshness on the same card.
     </p>
 
     <h2>Who it's for</h2>
     <ul>
       <li><strong>Journalists + researchers</strong> — pull a state's districts, villages or constituencies in ten seconds; download as GeoJSON or Parquet.</li>
       <li><strong>Civic technologists</strong> — share city-scale layers (wards, bike lanes, polling booths) with attribution baked in.</li>
-      <li><strong>App developers</strong> — direct PMTiles URLs, no rate limits, no key.</li>
+      <li><strong>App developers</strong> — direct PMTiles URLs, no rate limits, no API key.</li>
     </ul>
 
     <h2>What you can do today</h2>
     <ul>
-      <li>View every admin level from <strong>state</strong> to <strong>village</strong> on a map, plus city wards (Bengaluru, Chennai, Hyderabad, Mumbai, +12 more), constituencies, wildlife sanctuaries.</li>
+      <li>View every admin level from <strong>state</strong> to <strong>village</strong> on a map, plus city wards across <strong>15 Indian cities</strong> (Bengaluru, Chennai, Hyderabad, Mumbai and more), constituencies, wildlife sanctuaries.</li>
       <li>Filter any layer by what its columns actually contain — state, zone, area, anything — and export the slice as <strong>Parquet</strong>, <strong>GeoJSON</strong> or <strong>KML</strong>.</li>
       <li><a href="/preview">Drop a file</a> to see it on a map and validate it. Optionally publish under an open licence — no signup; you get an admin token to keep forever.</li>
       <li>Embed any map in a blog post or report (iframe snippet + PNG export, one click each).</li>
     </ul>
-
-    <h2>Where the curated data comes from</h2>
-    <div class="source-grid">
-      <span class="name"><a href="https://lgdirectory.gov.in/" target="_blank" rel="noopener">LGD</a></span>
-      <span class="meta">Local Government Directory — authoritative, with full code chain. <code>CC0-1.0</code> / <code>CC-BY-4.0</code></span>
-      <span class="name"><a href="https://surveyofindia.gov.in/" target="_blank" rel="noopener">SOI</a></span>
-      <span class="meta">Survey of India open-data series, community-republished. <code>CC0-1.0</code></span>
-      <span class="name"><a href="https://bhuvanpanchayat.nrsc.gov.in/" target="_blank" rel="noopener">Bhuvan</a></span>
-      <span class="meta">NRSC/ISRO Bhuvan panchayat portal. <code>CC0-1.0</code></span>
-      <span class="name"><a href="https://omms.nic.in/" target="_blank" rel="noopener">PMGSY</a></span>
-      <span class="meta">Pradhan Mantri Gram Sadak Yojana — rural roads, blocks. <code>CC0-1.0</code></span>
-      <span class="name"><a href="https://www.geoboundaries.org/" target="_blank" rel="noopener">geoBoundaries</a></span>
-      <span class="meta">Independent cross-check, name-only attributes. <code>CC-BY-4.0</code></span>
-    </div>
-    <p style="color:var(--muted);font-size:13px">
-      Re-publication pipeline by <a href="https://github.com/yashveeeeeeer/india-geodata" target="_blank" rel="noopener">yashveeeeeeer/india-geodata</a>.
-      See <a href="https://github.com/urbanmorph/geodata/blob/main/REPORT.md">REPORT.md</a> for full provenance and caveats.
-    </p>
-
-    <h2>Roadmap</h2>
-    <ul>
-      <li>"Your submissions" — return to a layer you uploaded, edit or re-share.</li>
-      <li>Typed layers — boundary, point, network, area — so any well-shaped file can join the catalog without a fixed admin hierarchy.</li>
-      <li>Public REST API + MCP server + Claude Code plugin.</li>
-      <li>Shapefile (.zip) support in <a href="/preview">/preview</a>.</li>
-    </ul>
-
 
     <h2>Open source</h2>
     <p>
@@ -119,9 +94,6 @@
 
     <h2 id="faq">Frequently asked</h2>
     <dl class="faq">
-      <dt>What is bharatlas?</dt>
-      <dd>An open visualiser, in-browser verifier and anonymous contribution flow for India's geospatial data. Browse curated admin boundaries from state to village, drop a file to render and validate it, or publish your own layer under an open licence.</dd>
-
       <dt>Do I need to sign up?</dt>
       <dd>No. Viewing, slicing, downloading and contributing all work without an account. When you publish a layer you receive a one-time admin token (also downloadable as a <code>.txt</code> backup) that you keep forever to edit or delete that submission.</dd>
 
@@ -146,7 +118,7 @@
       <li><strong>Provided as-is, no warranty.</strong> Express or implied guarantees of accuracy, completeness or fitness for a particular purpose are not made by this site or its maintainers.</li>
       <li><strong>Boundaries are for reference, not legal authority.</strong> For official, administrative or land-record use, refer directly to LGD, SOI, Bhuvan or the state revenue department.</li>
       <li><strong>Curated layers reflect the upstream source at fetch time</strong> — see the freshness pill on each card. Upstream sources change; the catalog can lag.</li>
-      <li><strong>Community submissions are auto-moderated, not editorially curated.</strong> The platform checks licence, format and basic geometry validity. It does not verify accuracy, completeness or authorship beyond the contributor's self-attestation. Verify provenance via the source link on each card before relying on community data.</li>
+      <li><strong>Community submissions are auto-moderated, not editorially curated.</strong> Licence, format and basic geometry validity are checked; accuracy and authorship are not. Verify via the source link on each card before relying on community data.</li>
     </ul>
 
     <h2 style="text-transform:none;letter-spacing:0;color:var(--fg);font-size:var(--fs-xl);margin-top:var(--sp-7)">Built by</h2>

--- a/web/about.template.html
+++ b/web/about.template.html
@@ -44,66 +44,44 @@
     <!-- NAV -->
 
     <p class="eyebrow" style="font-size:13px;letter-spacing:.04em;color:var(--accent);margin:8px 0 4px">geodata</p>
-    <h1 class="hero">Open-source visualiser for India's geo data.</h1>
+    <h1 class="hero">India's open atlas.</h1>
     <p class="lede">
-      Find, view, slice and contribute India's official admin-boundary datasets — and
-      community-contributed geo layers — without an account, without an API key, without
-      a single SQL query.
+      Find a map, see it on a map, slice out what you need, and download. Submit your own
+      by dropping it on the page. No signup, no API key, no SQL.
     </p>
 
-    <h2>What makes this different</h2>
+    <h2>Why bharatlas exists</h2>
     <p>
-      India has plenty of geo data. The hard part has always been finding it, validating it,
-      and adding to it.
+      Sathya kept hitting the same wall. Maps lived everywhere online, but you couldn't
+      tell what they actually showed, who maintained them, or whether to trust them.
+      Pulling out just the slice he needed meant booting QGIS or wading through Google
+      Maps menus. Viewing was its own ordeal — sign in, navigate the menus, import.
+      The format question alone — KML? KMZ? GeoJSON? Parquet? — felt gatekept. And if
+      you'd made a map yourself and wanted to share it, you had to stand up your own
+      website to host it.
     </p>
     <p>
-      The official portals lock data behind logins, restrict derivatives, or require Windows
-      plugins. The community efforts — <a href="https://github.com/datameet/maps" target="_blank" rel="noopener">DataMeet</a>,
-      the dozens of GitHub scrapes — sit in repos with no preview, no validation, no way for
-      anyone else to add. The drag-and-drop viewers (<a href="https://geojson.io" target="_blank" rel="noopener">geojson.io</a>,
-      <a href="https://kepler.gl" target="_blank" rel="noopener">Kepler</a>,
-      the late <a href="https://macwright.com/2023/11/13/placemark" target="_blank" rel="noopener">Placemark</a>)
-      handle a single file at a time and choke past about 8,000 features. None of them
-      combine catalog, viewer, validator, and contribution flow under one roof — and none of
-      them do it for India specifically.
-    </p>
-    <p>geodata is that combination:</p>
-    <ul>
-      <li><strong>A visual catalog</strong> — every state, district, subdistrict, block and village under LGD codes, with side-by-side comparison of SOI, Bhuvan and geoBoundaries. Each layer renders on a map and downloads as Parquet, GeoJSON or KML.</li>
-      <li><strong>A drag-drop verifier</strong> — drop any file (GeoJSON, KML, KMZ, Parquet, up to 500 MB) and the browser tells you what's wrong before it leaves your machine. Wrong CRS, broken geometries, features outside India — flagged inline.</li>
-      <li><strong>Anonymous contribution</strong> — submit your own layer with no signup, no email, no API key. The site returns an admin token (saved to your browser, downloaded as a backup <code>.txt</code>) that you keep forever. Auto-moderation handles licence, attribution and validity server-side. Open licences only.</li>
-      <li><strong>Mixed catalog</strong> — accepted submissions appear in the main catalog within a build cycle, badged <code>[community]</code>, sortable by recency or thumbs-up rating. Curated and community layers share the same view and download surface.</li>
-    </ul>
-    <p>
-      Everything is open: the <a href="https://github.com/urbanmorph/geodata">code</a> under MIT,
-      curated data under each upstream's open licence (CC0-1.0, CC-BY-4.0, GODL-India),
-      community submissions under whichever open licence the contributor picks. No login,
-      no tracking cookies, no third-party analytics.
+      Bharatlas is the idea to flatten all of that. <strong>The wiki for India's maps.</strong>
+      View any layer in your browser. Filter what you need. Download in whatever format
+      your tool reads. Liked it? Upvote so others find it. Have a map worth sharing? Drag
+      and drop it onto the page. Every layer carries its source, licence and freshness on
+      the same card.
     </p>
 
-    <h2>Who is it for</h2>
+    <h2>Who it's for</h2>
     <ul>
-      <li><strong>Journalists</strong> — pull a state's district boundaries in ten seconds for a story map.</li>
-      <li><strong>Researchers</strong> — slice 584,615 village polygons by state, export as GeoJSON or Parquet.</li>
-      <li><strong>Civic technologists</strong> — share city-scale infrastructure datasets (bike lanes, parks, polling booths) with attribution and download.</li>
-      <li><strong>Educators</strong> — render any of India's 7,146 community-development blocks on a map for a classroom demo.</li>
-      <li><strong>App developers</strong> — direct PMTiles URLs, no rate limits, no API key.</li>
+      <li><strong>Journalists + researchers</strong> — pull a state's districts, villages or constituencies in ten seconds; download as GeoJSON or Parquet.</li>
+      <li><strong>Civic technologists</strong> — share city-scale layers (wards, bike lanes, polling booths) with attribution baked in.</li>
+      <li><strong>App developers</strong> — direct PMTiles URLs, no rate limits, no key.</li>
     </ul>
 
     <h2>What you can do today</h2>
     <ul>
-      <li>View every admin level from <strong>state</strong> down to <strong>village</strong> on a map.</li>
-      <li>Filter any LGD-coded layer by state and instant-download as <strong>Parquet</strong>, <strong>GeoJSON</strong>, or <strong>KML</strong> (Google Earth ready).</li>
-      <li>Cross-compare <strong>LGD</strong>, <strong>SOI</strong>, <strong>Bhuvan</strong> and <strong>geoBoundaries</strong> side by side.</li>
-      <li><a href="/preview">Preview</a> a file — drag-drop a GeoJSON / KML / KMZ / Parquet (up to 500 MB) and see it on a map, validate it, and optionally publish under an open licence in seconds. No signup, no email; you get an admin token you can keep forever.</li>
+      <li>View every admin level from <strong>state</strong> to <strong>village</strong> on a map, plus city wards (Bengaluru, Chennai, Hyderabad, Mumbai, +12 more), constituencies, wildlife sanctuaries.</li>
+      <li>Filter any layer by what its columns actually contain — state, zone, area, anything — and export the slice as <strong>Parquet</strong>, <strong>GeoJSON</strong> or <strong>KML</strong>.</li>
+      <li><a href="/preview">Drop a file</a> to see it on a map and validate it. Optionally publish under an open licence — no signup; you get an admin token to keep forever.</li>
+      <li>Embed any map in a blog post or report (iframe snippet + PNG export, one click each).</li>
     </ul>
-
-    <h2>How it works</h2>
-    <p>
-      Static site on Cloudflare Pages · data on R2 · in-browser <code>DuckDB-WASM</code> for slicing ·
-      <code>MapLibre</code> + <code>PMTiles</code> for rendering · Pages Functions + D1 SQLite for the
-      contribution flow. Code on GitHub. No tracking, no third-party analytics, no fingerprinting.
-    </p>
 
     <h2>Where the curated data comes from</h2>
     <div class="source-grid">
@@ -125,11 +103,12 @@
 
     <h2>Roadmap</h2>
     <ul>
-      <li>Side-by-side compare of curated sources.</li>
-      <li>Custom <code>WHERE</code> / attribute filter.</li>
-      <li>Panchayat + habitation layers from upstream.</li>
+      <li>"Your submissions" — return to a layer you uploaded, edit or re-share.</li>
+      <li>Typed layers — boundary, point, network, area — so any well-shaped file can join the catalog without a fixed admin hierarchy.</li>
+      <li>Public REST API + MCP server + Claude Code plugin.</li>
       <li>Shapefile (.zip) support in <a href="/preview">/preview</a>.</li>
     </ul>
+
 
     <h2>Open source</h2>
     <p>

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -733,7 +733,7 @@ const ABOUT_FAQ = [
 await renderPage('about', {
   title: 'About',
   description:
-    "Bharatlas — open catalog, in-browser verifier, and anonymous contribution flow for India's geo data. Admin boundaries plus community layers, all open.",
+    "Bharatlas is the wiki for India's maps. View any layer, slice out what you need, download in any format, or contribute your own. Open licences, no signup.",
   url: ORIGIN + '/about',
   image: ORIGIN + '/og-about.png',
   structuredData: {


### PR DESCRIPTION
## Summary

Documentation refresh after v4.7 landed. Pulls the README + /about page back in sync with what's actually shipped, adds a founder narrative to the about, and applies a critical-pass polish for voice and CTAs.

## About page (web/about.template.html: 198 → 149 lines)

**Content:**
- Founder narrative added — universal problem first (so readers feel the pain), then "Sathya kept hitting the same wall" bridges into the solution
- Eyebrow brand fix: "geodata" → "bharatlas" (stale repo name was leaking above the hero)
- Lede tightened — dropped the "find a map / see it on a map" stutter
- **"Browse the catalog →" CTA right after the lede** — the about page now has one obvious next-action

**Trimmed:**
- "Where the curated data comes from" section removed — every layer card already shows source + licence + freshness inline; FAQ summarises; this was the third redundant attribution surface
- "Roadmap" moved to README only — about is positioning; roadmap is dev-facing
- FAQ Q1 ("What is bharatlas?") dropped — redundant with hero + lede
- "Use of data" bullet 4 tightened

**Voice (Tom MacWright register — dry, civic, technically literate):**
- Present tense throughout "Why bharatlas exists" (the problem still IS, not was)
- "is the idea to flatten" → declarative "flattens"
- "+12 more" → "15 Indian cities" (confident count)
- "no key" → "no API key" (consistent with lede)

## README (117 → 107 lines)

- Test count drift: 167 → 320+
- Roadmap reflects current state (v4.x shipped, v5 = REST API + MCP + plugin) — was stuck at "v4 = API/MCP/plugin"
- URL list brought in line with shipped surfaces (/view, /embed, filter-by-schema)
- Dropped "Tests" section (info already in Develop)
- Folded "Status" into credits paragraph
- "Use of data" trimmed to one line + link to /about disclaimers

## SEO meta

- /about description refreshed: "Bharatlas is the wiki for India's maps. View any layer, slice out what you need, download in any format, or contribute your own. Open licences, no signup." (154/158 chars under the Google snippet budget)

## Local-only doc

`supporting-docs/v3-plan.md` (gitignored) updated separately: v4.1–4.7 marked shipped, v4.8 (Your Submissions) + v4.9 (production-readiness pack) sequenced, v5 deferred. Not in this PR since the file isn't tracked.

## Test plan

- [ ] CI green (no test/code changes; only HTML/MD)
- [ ] /about renders cleanly in browser; CTA button works
- [ ] /about social card still works (no meta-tag breakage)
- [ ] No 404 from removed sections (no internal links pointed at them — verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)