### PR TITLE
v4.8: Your submissions panel + paste-back recovery

### DIFF
--- a/web/functions/api/c/[id]/summary.ts
+++ b/web/functions/api/c/[id]/summary.ts
@@ -1,0 +1,36 @@
+// GET /api/c/:id/summary — public metadata for an accepted submission.
+// Used by the /preview "Your submissions" panel to (1) refresh stale names
+// after an edit, and (2) verify a paste-back URL before adding it locally.
+
+import type { Env } from '../../_middleware';
+import { getSubmissionForView } from '../../../lib/submissions';
+
+type Params = { id: string };
+
+const notFound = () => new Response(
+  JSON.stringify({ error: 'not found' }),
+  { status: 404, headers: { 'content-type': 'application/json' } },
+);
+
+export const onRequestGet: PagesFunction<Env, keyof Params> = async (ctx) => {
+  const id = ctx.params.id as string;
+  if (!/^[A-Za-z0-9_-]{8,16}$/.test(id)) return notFound();
+
+  const row = await getSubmissionForView(ctx.env.DB, id);
+  if (!row) return notFound();
+
+  return new Response(
+    JSON.stringify({
+      id: row.id,
+      name: row.name,
+      status: row.status,
+      created_at: row.created_at,
+    }),
+    {
+      headers: {
+        'content-type': 'application/json',
+        'cache-control': 'public, max-age=30, stale-while-revalidate=300',
+      },
+    },
+  );
+};

--- a/web/preview.template.html
+++ b/web/preview.template.html
@@ -186,6 +186,69 @@
       .map-loader__verb { font: 500 13px/1.2 ui-sans-serif, system-ui, sans-serif; color: var(--muted); }
       @keyframes ml-spin { to { transform: rotate(360deg); } }
 
+      /* === Your submissions (v4.8) ========================================== */
+      #my-subs {
+        display: block; max-width: 640px; margin: 18px auto 0;
+        background: var(--bg-card); border: 1px solid var(--line);
+        border-radius: 10px; padding: 12px 14px;
+      }
+      #my-subs[hidden] { display: none; }
+      #my-subs h2 {
+        font-size: 11px; font-weight: 600; letter-spacing: .08em;
+        text-transform: uppercase; color: var(--muted); margin: 0 0 8px;
+      }
+      #my-subs-list { display: flex; flex-direction: column; }
+      .my-subs-row {
+        display: grid; grid-template-columns: 1fr auto auto; gap: 12px;
+        align-items: center;
+        padding: 8px 4px; font-size: 13px;
+        color: inherit; text-decoration: none;
+        border-bottom: 1px solid var(--line);
+      }
+      .my-subs-row:last-child { border-bottom: 0; }
+      .my-subs-row:hover .my-subs-name { color: var(--accent); }
+      .my-subs-name {
+        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+        font-weight: 500;
+      }
+      .my-subs-pill {
+        font: 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+        letter-spacing: .08em; color: var(--muted-strong, var(--muted));
+        background: var(--bg); border: 1px solid var(--line);
+        padding: 3px 6px; border-radius: 999px;
+      }
+      .my-subs-when {
+        font-size: 11px; color: var(--muted);
+        font-variant-numeric: tabular-nums;
+      }
+      #paste-back-toggle {
+        margin-top: 8px;
+        background: transparent; border: 0; cursor: pointer;
+        color: var(--muted); font: inherit; font-size: 12px;
+        padding: 6px 4px;
+      }
+      #paste-back-toggle:hover { color: var(--fg); }
+      #paste-back-form {
+        display: flex; gap: 6px; margin-top: 8px;
+      }
+      #paste-back-form[hidden] { display: none; }
+      #paste-back-form input {
+        flex: 1; padding: 7px 9px; font: inherit; font-size: 13px;
+        background: var(--bg); color: var(--fg);
+        border: 1px solid var(--line); border-radius: 6px;
+      }
+      #paste-back-form input:focus { outline: none; border-color: var(--accent); }
+      #paste-back-form button {
+        background: var(--accent); color: #fff; border: 0;
+        padding: 7px 14px; border-radius: 6px;
+        font: inherit; font-size: 13px; cursor: pointer;
+      }
+      .paste-back-status { font-size: 12px; color: var(--muted); margin-top: 6px; min-height: 16px; }
+      .paste-back-status.err { color: var(--err); }
+      @media (max-width: 720px) {
+        #my-subs { margin-left: 0; margin-right: 0; }
+      }
+
       .helper { margin-top: 32px; padding-top: 16px; border-top: 1px dashed var(--line); font-size: 12px; color: var(--muted); line-height: 1.6; }
       .helper code { font: 11px ui-monospace, SFMono-Regular, monospace; background: var(--card-bg); padding: 1px 4px; border-radius: 3px; }
 
@@ -208,6 +271,17 @@
       <span class="hint">GeoJSON · KML · KMZ · GPX · TCX · Parquet · up to 500 MB</span>
       <input type="file" id="file" accept=".geojson,.json,.kml,.kmz,.gpx,.tcx,.parquet" />
     </label>
+
+    <aside id="my-subs" hidden aria-label="Your submissions">
+      <h2>Your submissions</h2>
+      <div id="my-subs-list"></div>
+      <button type="button" id="paste-back-toggle" aria-expanded="false" aria-controls="paste-back-form">+ Add an existing submission by admin URL</button>
+      <form id="paste-back-form" hidden>
+        <input type="text" id="paste-back-url" placeholder="https://bharatlas.com/c/Xa9Kp7n?key=adm_…" autocomplete="off" />
+        <button type="submit">Add</button>
+      </form>
+      <div id="paste-back-status" class="paste-back-status" role="status" aria-live="polite"></div>
+    </aside>
 
     <section id="workspace" aria-live="polite">
       <div id="map"></div>

--- a/web/src/my-submissions.ts
+++ b/web/src/my-submissions.ts
@@ -1,0 +1,137 @@
+// Per-submission localStorage store for "Your submissions" on /preview.
+//
+// One key per submission (geodata:submissions:<id> = JSON record) instead of a
+// single rolled-up array. Reasons: easier iteration, no read-modify-write race
+// across tabs, and no collision if two devices write the same id from a
+// .txt backup.
+//
+// Companion key geodata:tokens:<id> (single string token) still exists for
+// /c/<id> owner detection — hydrateLegacyTokens() back-fills minimal rows so
+// pre-v4.8 contributors see their submissions on first visit.
+
+export type StoredSubmission = {
+  id: string;
+  name: string;
+  token: string;
+  created_at: number;
+  permission: 'admin';
+};
+
+const PREFIX = 'geodata:submissions:';
+const TOKEN_PREFIX = 'geodata:tokens:';
+export const MAX_SUBMISSIONS = 50;
+
+function defaultStorage(): Storage | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSubmission(rec: StoredSubmission, storage?: Storage | null): void {
+  const s = storage ?? defaultStorage();
+  if (!s) return;
+  try {
+    s.setItem(PREFIX + rec.id, JSON.stringify(rec));
+    s.setItem(TOKEN_PREFIX + rec.id, rec.token);
+    enforceCap(s);
+  } catch {
+    /* private mode / quota — non-fatal */
+  }
+}
+
+export function listSubmissions(storage?: Storage | null): StoredSubmission[] {
+  const s = storage ?? defaultStorage();
+  if (!s) return [];
+  try {
+    const out: StoredSubmission[] = [];
+    for (let i = 0; i < s.length; i++) {
+      const k = s.key(i);
+      if (!k || !k.startsWith(PREFIX)) continue;
+      const raw = s.getItem(k);
+      if (!raw) continue;
+      try {
+        const rec = JSON.parse(raw) as StoredSubmission;
+        if (rec && typeof rec.id === 'string' && typeof rec.token === 'string') {
+          out.push(rec);
+        }
+      } catch {
+        /* corrupt entry — skip */
+      }
+    }
+    return out.sort((a, b) => b.created_at - a.created_at);
+  } catch {
+    return [];
+  }
+}
+
+export function getSubmission(id: string, storage?: Storage | null): StoredSubmission | null {
+  const s = storage ?? defaultStorage();
+  if (!s) return null;
+  try {
+    const raw = s.getItem(PREFIX + id);
+    if (!raw) return null;
+    return JSON.parse(raw) as StoredSubmission;
+  } catch {
+    return null;
+  }
+}
+
+export function removeSubmission(id: string, storage?: Storage | null): void {
+  const s = storage ?? defaultStorage();
+  if (!s) return;
+  try {
+    s.removeItem(PREFIX + id);
+    s.removeItem(TOKEN_PREFIX + id);
+  } catch {
+    /* no-op */
+  }
+}
+
+// Synthesise minimal rows for any geodata:tokens:<id> that lacks a rich record.
+// Pre-v4.8 contributors only had the token key — calling this on /preview init
+// keeps their submissions visible in the panel until they next visit /c/<id>
+// (which will refresh the name from the server).
+export function hydrateLegacyTokens(storage?: Storage | null, now: () => number = Date.now): void {
+  const s = storage ?? defaultStorage();
+  if (!s) return;
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < s.length; i++) {
+      const k = s.key(i);
+      if (k && k.startsWith(TOKEN_PREFIX)) keys.push(k);
+    }
+    for (const k of keys) {
+      const id = k.slice(TOKEN_PREFIX.length);
+      if (!id) continue;
+      if (s.getItem(PREFIX + id)) continue;
+      const token = s.getItem(k);
+      if (!token) continue;
+      const rec: StoredSubmission = {
+        id,
+        name: `Submission ${id}`,
+        token,
+        created_at: now(),
+        permission: 'admin',
+      };
+      s.setItem(PREFIX + id, JSON.stringify(rec));
+    }
+  } catch {
+    /* no-op */
+  }
+}
+
+function enforceCap(s: Storage): void {
+  // Fast path: count prefix-matching keys before doing the full sort.
+  let count = 0;
+  for (let i = 0; i < s.length; i++) {
+    const k = s.key(i);
+    if (k && k.startsWith(PREFIX)) count++;
+  }
+  if (count <= MAX_SUBMISSIONS) return;
+  for (const old of listSubmissions(s).slice(MAX_SUBMISSIONS)) {
+    try { s.removeItem(PREFIX + old.id); } catch { /* no-op */ }
+  }
+}

--- a/web/src/paste-back.ts
+++ b/web/src/paste-back.ts
@@ -1,0 +1,43 @@
+// Parse a pasted admin URL (e.g. https://bharatlas.com/c/Xa9Kp7n?key=adm_xxx)
+// into { id, key } for the paste-back recovery flow on /preview.
+//
+// Accepts: absolute http(s) URLs, scheme-less hosts (bharatlas.com/c/…),
+// and bare paths (/c/<id>?key=…). Validates the id shape and that the key
+// looks like an admin token. Domain is intentionally not whitelisted —
+// users may run their own forks or paste from preview deployments.
+
+export type ParseResult =
+  | { ok: true; id: string; key: string }
+  | { ok: false; reason: string };
+
+const ID_RX = /^[A-Za-z0-9_-]{8,16}$/;
+const KEY_RX = /^adm_[A-Za-z0-9_-]{8,}$/;
+
+export function parseAdminUrl(input: string): ParseResult {
+  const raw = input.trim();
+  if (!raw) return { ok: false, reason: "couldn't read that URL" };
+
+  let path: string;
+  let query: URLSearchParams;
+  try {
+    const u = raw.startsWith('http://') || raw.startsWith('https://') || raw.startsWith('/')
+      ? new URL(raw, 'https://bharatlas.com')
+      : new URL('https://' + raw);
+    path = u.pathname;
+    query = u.searchParams;
+  } catch {
+    return { ok: false, reason: "couldn't read that URL" };
+  }
+
+  const m = path.match(/^\/c\/([^/]+)\/?$/);
+  if (!m) return { ok: false, reason: 'not a submission URL' };
+
+  const id = m[1];
+  if (!ID_RX.test(id)) return { ok: false, reason: 'not a submission URL' };
+
+  const key = query.get('key') ?? '';
+  if (!key) return { ok: false, reason: 'missing key — paste the full admin URL' };
+  if (!KEY_RX.test(key)) return { ok: false, reason: 'key does not look like an admin token' };
+
+  return { ok: true, id, key };
+}

--- a/web/src/preview.ts
+++ b/web/src/preview.ts
@@ -18,6 +18,14 @@ import { fileToFC, type Format } from './parse-geo';
 import { popHandoff, stashForSubmit } from './handoff';
 import { overlayLoader, VERBS_VERIFY_RENDER, VERBS_VERIFY_FETCH, VERBS_ENGINE, inlineLoader } from './loading';
 import { escapeHtml } from './util';
+import {
+  saveSubmission,
+  listSubmissions,
+  getSubmission,
+  hydrateLegacyTokens,
+  type StoredSubmission,
+} from './my-submissions';
+import { parseAdminUrl } from './paste-back';
 
 type SuccessPayload = {
   id: string;
@@ -538,11 +546,14 @@ function renderSuccess(payload: SuccessPayload): void {
   drop.style.display = 'none';
   statusEl.textContent = '';
 
-  try {
-    localStorage.setItem(`geodata:tokens:${payload.id}`, payload.admin_token);
-  } catch {
-    /* private mode / quota — non-fatal */
-  }
+  const submittedName = (form.elements.namedItem('name') as HTMLInputElement | null)?.value?.trim() || payload.id;
+  saveSubmission({
+    id: payload.id,
+    name: submittedName,
+    token: payload.admin_token,
+    created_at: Date.now(),
+    permission: 'admin',
+  });
 
   // Always navigate via the current origin — in dev the server returns an
   // 8788 (wrangler) URL, but the user is on 5173 (vite). location.origin
@@ -586,7 +597,122 @@ function renderSuccess(payload: SuccessPayload): void {
 
   successEl.classList.add('show');
   window.scrollTo({ top: 0, behavior: 'smooth' });
+  renderMySubmissions();
 }
+
+// ---------- Your submissions panel ---------------------------------------
+function relativeTime(then: number, now: number = Date.now()): string {
+  const d = Math.max(0, now - then);
+  const day = 86_400_000;
+  if (d < day) return 'today';
+  const days = Math.floor(d / day);
+  if (days < 7) return `${days}d ago`;
+  if (days < 30) return `${Math.floor(days / 7)}w ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}
+
+function renderMySubmissions(): void {
+  const panel = document.getElementById('my-subs');
+  const listEl = document.getElementById('my-subs-list');
+  if (!panel || !listEl) return;
+  const rows = listSubmissions();
+  if (rows.length === 0) { panel.hidden = true; return; }
+  panel.hidden = false;
+  const now = Date.now();
+  listEl.innerHTML = rows
+    .map((r: StoredSubmission) =>
+      `<a class="my-subs-row" href="/c/${encodeURIComponent(r.id)}">` +
+        `<span class="my-subs-name">${escapeHtml(r.name)}</span>` +
+        `<span class="my-subs-pill">ADMIN</span>` +
+        `<span class="my-subs-when">${escapeHtml(relativeTime(r.created_at, now))}</span>` +
+      `</a>`,
+    )
+    .join('');
+}
+
+function wirePasteBack(): void {
+  const toggle = document.getElementById('paste-back-toggle');
+  const form = document.getElementById('paste-back-form') as HTMLFormElement | null;
+  const input = document.getElementById('paste-back-url') as HTMLInputElement | null;
+  const status = document.getElementById('paste-back-status');
+  if (!toggle || !form || !input || !status) return;
+
+  toggle.addEventListener('click', () => {
+    const open = form.hidden;
+    form.hidden = !open;
+    toggle.setAttribute('aria-expanded', String(open));
+    if (open) input.focus();
+  });
+
+  const fail = (msg: string) => {
+    status.textContent = msg;
+    status.classList.add('err');
+  };
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    status.textContent = '';
+    status.className = 'paste-back-status';
+    const parsed = parseAdminUrl(input.value);
+    if (!parsed.ok) return fail(parsed.reason);
+    if (getSubmission(parsed.id)) return fail('this device already has this submission');
+
+    status.textContent = 'verifying…';
+    let resp: Response;
+    try {
+      resp = await fetch(`/api/c/${encodeURIComponent(parsed.id)}/summary`);
+    } catch {
+      return fail('network error — try again');
+    }
+    if (resp.status === 404) return fail('submission not found');
+    if (!resp.ok) return fail(`server returned ${resp.status}`);
+
+    let body: { id: string; name: string; created_at: string };
+    try {
+      body = await resp.json();
+    } catch {
+      return fail('server returned non-JSON');
+    }
+    saveSubmission({
+      id: body.id,
+      name: body.name,
+      token: parsed.key,
+      created_at: Date.parse(body.created_at) || Date.now(),
+      permission: 'admin',
+    });
+    input.value = '';
+    form.hidden = true;
+    toggle.setAttribute('aria-expanded', 'false');
+    status.textContent = '';
+    renderMySubmissions();
+  });
+}
+
+// Best-effort: refresh stale names for the top few rows in the background.
+// 404s leave the local row untouched (handled separately at /c/<id> visit time).
+async function refreshSummaries(): Promise<void> {
+  const rows = listSubmissions().slice(0, 10);
+  if (rows.length === 0) return;
+  const results = await Promise.all(rows.map(async (r) => {
+    try {
+      const resp = await fetch(`/api/c/${encodeURIComponent(r.id)}/summary`);
+      if (!resp.ok) return false;
+      const body = await resp.json() as { name?: string };
+      if (body.name && body.name !== r.name) {
+        saveSubmission({ ...r, name: body.name });
+        return true;
+      }
+    } catch { /* swallow */ }
+    return false;
+  }));
+  if (results.some(Boolean)) renderMySubmissions();
+}
+
+hydrateLegacyTokens();
+renderMySubmissions();
+wirePasteBack();
+void refreshSummaries();
 
 // ---------- Utils --------------------------------------------------------
 function fmtBytes(n: number): string {

--- a/web/tests/my-submissions.test.ts
+++ b/web/tests/my-submissions.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  saveSubmission,
+  listSubmissions,
+  removeSubmission,
+  getSubmission,
+  hydrateLegacyTokens,
+  MAX_SUBMISSIONS,
+  type StoredSubmission,
+} from '../src/my-submissions';
+
+function memStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    get length() { return m.size; },
+    clear() { m.clear(); },
+    getItem(k) { return m.has(k) ? (m.get(k) as string) : null; },
+    key(i) { return [...m.keys()][i] ?? null; },
+    removeItem(k) { m.delete(k); },
+    setItem(k, v) { m.set(k, String(v)); },
+  } as Storage;
+}
+
+function rec(over: Partial<StoredSubmission> = {}): StoredSubmission {
+  return {
+    id: 'abc1234567',
+    name: 'Bengaluru bike lanes',
+    token: 'adm_xxxxxxxxxxxx',
+    created_at: 1_700_000_000_000,
+    permission: 'admin',
+    ...over,
+  };
+}
+
+describe('my-submissions — save & list', () => {
+  let s: Storage;
+  beforeEach(() => { s = memStorage(); });
+
+  it('save writes a record under geodata:submissions:<id>', () => {
+    saveSubmission(rec(), s);
+    const raw = s.getItem('geodata:submissions:abc1234567');
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!).name).toBe('Bengaluru bike lanes');
+  });
+
+  it('list returns saved submissions sorted by created_at desc', () => {
+    saveSubmission(rec({ id: 'old0000000', created_at: 1000 }), s);
+    saveSubmission(rec({ id: 'new0000000', created_at: 9000 }), s);
+    saveSubmission(rec({ id: 'mid0000000', created_at: 5000 }), s);
+    expect(listSubmissions(s).map((r) => r.id)).toEqual(['new0000000', 'mid0000000', 'old0000000']);
+  });
+
+  it('list returns [] when storage is empty', () => {
+    expect(listSubmissions(s)).toEqual([]);
+  });
+
+  it('list ignores unrelated keys', () => {
+    s.setItem('geodata:tokens:abc1234567', 'adm_legacy');
+    s.setItem('something:else', 'nope');
+    expect(listSubmissions(s)).toEqual([]);
+  });
+
+  it('list tolerates corrupt JSON entries (skips them silently)', () => {
+    s.setItem('geodata:submissions:bad0000000', '{not json');
+    saveSubmission(rec({ id: 'good0000000' }), s);
+    const got = listSubmissions(s);
+    expect(got.map((r) => r.id)).toEqual(['good0000000']);
+  });
+});
+
+describe('my-submissions — remove & get', () => {
+  let s: Storage;
+  beforeEach(() => { s = memStorage(); });
+
+  it('remove deletes the record', () => {
+    saveSubmission(rec(), s);
+    removeSubmission('abc1234567', s);
+    expect(listSubmissions(s)).toEqual([]);
+  });
+
+  it('get returns the record or null', () => {
+    saveSubmission(rec(), s);
+    expect(getSubmission('abc1234567', s)?.name).toBe('Bengaluru bike lanes');
+    expect(getSubmission('missing', s)).toBeNull();
+  });
+});
+
+describe('my-submissions — cap at 50', () => {
+  it('drops the oldest when over MAX_SUBMISSIONS', () => {
+    const s = memStorage();
+    for (let i = 0; i < MAX_SUBMISSIONS + 5; i++) {
+      saveSubmission(rec({ id: `id${String(i).padStart(8, '0')}`, created_at: i }), s);
+    }
+    const ids = listSubmissions(s).map((r) => r.id);
+    expect(ids).toHaveLength(MAX_SUBMISSIONS);
+    // The 5 oldest should have been evicted.
+    expect(ids).not.toContain('id00000000');
+    expect(ids).not.toContain('id00000004');
+    expect(ids[0]).toBe(`id${String(MAX_SUBMISSIONS + 4).padStart(8, '0')}`);
+  });
+});
+
+describe('my-submissions — storage unavailable', () => {
+  function throwingStorage(): Storage {
+    return {
+      get length() { return 0; },
+      clear() { throw new Error('nope'); },
+      getItem() { throw new Error('nope'); },
+      key() { throw new Error('nope'); },
+      removeItem() { throw new Error('nope'); },
+      setItem() { throw new Error('nope'); },
+    } as Storage;
+  }
+
+  it('listSubmissions returns [] when storage throws', () => {
+    expect(listSubmissions(throwingStorage())).toEqual([]);
+  });
+
+  it('saveSubmission is a no-op when storage throws', () => {
+    expect(() => saveSubmission(rec(), throwingStorage())).not.toThrow();
+  });
+
+  it('removeSubmission is a no-op when storage throws', () => {
+    expect(() => removeSubmission('abc1234567', throwingStorage())).not.toThrow();
+  });
+});
+
+describe('my-submissions — hydrateLegacyTokens', () => {
+  it('synthesises minimal records for orphan geodata:tokens:<id>', () => {
+    const s = memStorage();
+    s.setItem('geodata:tokens:legacy0001', 'adm_legacytoken');
+    s.setItem('geodata:tokens:legacy0002', 'adm_othertoken');
+    hydrateLegacyTokens(s, () => 12345);
+    const got = listSubmissions(s);
+    expect(got).toHaveLength(2);
+    expect(got[0].name).toMatch(/^Submission /);
+    expect(got[0].created_at).toBe(12345);
+  });
+
+  it('does not clobber existing rich records', () => {
+    const s = memStorage();
+    saveSubmission(rec({ id: 'rich0000001', name: 'Real name' }), s);
+    s.setItem('geodata:tokens:rich0000001', 'adm_xxxxxxxxxxxx');
+    hydrateLegacyTokens(s, () => 12345);
+    expect(getSubmission('rich0000001', s)?.name).toBe('Real name');
+  });
+});

--- a/web/tests/paste-back.test.ts
+++ b/web/tests/paste-back.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { parseAdminUrl } from '../src/paste-back';
+
+describe('parseAdminUrl — happy paths', () => {
+  it('parses an absolute bharatlas.com admin URL', () => {
+    const r = parseAdminUrl('https://bharatlas.com/c/Xa9Kp7nQ?key=adm_abcd1234efgh');
+    expect(r).toEqual({ ok: true, id: 'Xa9Kp7nQ', key: 'adm_abcd1234efgh' });
+  });
+
+  it('parses geodata-3ij.pages.dev fallback', () => {
+    const r = parseAdminUrl('https://geodata-3ij.pages.dev/c/Xa9Kp7nQ?key=adm_abcd1234efgh');
+    expect(r).toEqual({ ok: true, id: 'Xa9Kp7nQ', key: 'adm_abcd1234efgh' });
+  });
+
+  it('parses a relative path', () => {
+    const r = parseAdminUrl('/c/Xa9Kp7nQ?key=adm_abcd1234efgh');
+    expect(r).toEqual({ ok: true, id: 'Xa9Kp7nQ', key: 'adm_abcd1234efgh' });
+  });
+
+  it('parses a scheme-less host (bharatlas.com/c/…)', () => {
+    const r = parseAdminUrl('bharatlas.com/c/Xa9Kp7nQ?key=adm_abcd1234efgh');
+    expect(r).toEqual({ ok: true, id: 'Xa9Kp7nQ', key: 'adm_abcd1234efgh' });
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    const r = parseAdminUrl('   https://bharatlas.com/c/Xa9Kp7nQ?key=adm_abcd1234efgh  ');
+    expect(r).toEqual({ ok: true, id: 'Xa9Kp7nQ', key: 'adm_abcd1234efgh' });
+  });
+
+  it('accepts http (local dev) URLs', () => {
+    const r = parseAdminUrl('http://localhost:5173/c/Xa9Kp7nQ?key=adm_abcd1234efgh');
+    expect(r).toEqual({ ok: true, id: 'Xa9Kp7nQ', key: 'adm_abcd1234efgh' });
+  });
+});
+
+describe('parseAdminUrl — rejections', () => {
+  it('rejects empty / whitespace input', () => {
+    expect(parseAdminUrl('').ok).toBe(false);
+    expect(parseAdminUrl('   ').ok).toBe(false);
+  });
+
+  it('rejects garbage strings', () => {
+    const r = parseAdminUrl('not a url at all');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/couldn.?t read/i);
+  });
+
+  it('rejects URLs without a /c/<id> segment', () => {
+    const r = parseAdminUrl('https://bharatlas.com/about?key=adm_xxxxxxxxxxxx');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/submission/i);
+  });
+
+  it('rejects when the id segment is too short', () => {
+    const r = parseAdminUrl('https://bharatlas.com/c/abc?key=adm_xxxxxxxxxxxx');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects when key= is missing', () => {
+    const r = parseAdminUrl('https://bharatlas.com/c/Xa9Kp7nQ');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/missing key/i);
+  });
+
+  it('rejects when key= is empty', () => {
+    const r = parseAdminUrl('https://bharatlas.com/c/Xa9Kp7nQ?key=');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/missing key/i);
+  });
+
+  it('rejects when key= does not start with adm_', () => {
+    const r = parseAdminUrl('https://bharatlas.com/c/Xa9Kp7nQ?key=hello');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/key/i);
+  });
+
+  it('rejects when key= is too short for an admin token', () => {
+    const r = parseAdminUrl('https://bharatlas.com/c/Xa9Kp7nQ?key=adm_x');
+    expect(r.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the contributor-return gap. Today if you uploaded five maps from your laptop and want to return to one later, you have to remember the /c/<id> URL. v4.8 adds an inline "Your submissions" panel on /preview, populated automatically when you successfully publish, plus a paste-back recovery flow for the cross-device case.

## What ships

- Inline panel on /preview below the drop zone (hidden when empty, cap 50)
- Per-row: name + ADMIN pill + relative time, click → /c/<id>
- Paste-back: "+ Add an existing submission by admin URL" → server-verifies the id before writing localStorage
- Auto-save on submit success — writes both new `geodata:submissions:<id>` record and legacy `geodata:tokens:<id>` key (back-compat)
- New endpoint `GET /api/c/<id>/summary` (public metadata, 30s edge cache)

## mdshare-pattern departures (deliberate)

| | mdshare | bharatlas v4.8 |
|---|---|---|
| Save trigger | every doc view | only on successful submit |
| Cap | 10 | 50 |
| Storage | single JSON array | per-id key |
| Recovery | paste admin URL | same — kept |

## Tests + verification

- 27 new vitest tests (13 my-submissions + 14 paste-back), full suite 347/347 green
- Bundle delta: preview.js +1.42 KB gzip (within 3-5 KB budget)
- E2E curl: summary endpoint 200/404 paths verified against local D1
- Visual: confirmed with 6 real local-D1 submissions seeded into localStorage. Panel renders, rows clickable, paste-back form expands.
- Code-simplifier agent: 5 Tier-1 simplifications applied, Tier-2 surfaced

## Test plan

- [ ] CI green
- [ ] Production /preview shows panel once you have an accepted submission
- [ ] Submitting a new file auto-populates the panel
- [ ] Paste-back rejects malformed URLs / missing keys / unknown ids
- [ ] /c/<id> owner-detection still works for tokens written via new saveSubmission

🤖 Generated with [Claude Code](https://claude.com/claude-code)