### PR TITLE
fix(sitemap): include /privacy + /terms

### DIFF
--- a/web/functions/sitemap.xml.ts
+++ b/web/functions/sitemap.xml.ts
@@ -13,6 +13,8 @@ const STATIC: Array<{ loc: string; changefreq: string; priority: string }> = [
   { loc: ORIGIN + '/', changefreq: 'weekly', priority: '1.0' },
   { loc: ORIGIN + '/about', changefreq: 'monthly', priority: '0.8' },
   { loc: ORIGIN + '/preview', changefreq: 'monthly', priority: '0.8' },
+  { loc: ORIGIN + '/privacy', changefreq: 'yearly', priority: '0.3' },
+  { loc: ORIGIN + '/terms', changefreq: 'yearly', priority: '0.3' },
 ];
 
 const escXml = (s: string) =>


### PR DESCRIPTION
Edge function in functions/sitemap.xml.ts overrides the static public/sitemap.xml at CF Pages level. v4.x added /privacy + /terms to the prerendered fallback but the edge function still listed only 3 static URLs (/ + /about + /preview), so production was missing them.

After deploy: sitemap.xml lists 5 static URLs + 40 curated /view + community /c entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)