### PR TITLE
feat(vote): single-direction "Useful" vote (task #61) + a11y cleanup

### DIFF
--- a/web/functions/api/c/[id]/rate.ts
+++ b/web/functions/api/c/[id]/rate.ts
@@ -1,8 +1,11 @@
-// /api/c/:id/rate — anonymous up/down voting.
-//   GET  → { up, down, score, myVote } for this IP (read-only).
-//   POST { vote: 1 | -1 | 0 } → records / changes / clears the vote.
+// /api/c/:id/rate — anonymous single-direction "Useful" voting.
+//   GET  → { up, down, score, myVote } for this IP (down stays for back-
+//         compat reads of pre-existing rows; new writes can't add down).
+//   POST { vote: 1 | 0 } → records or clears the "Useful" mark.
 // (submission_id, ip_hash) is the primary key, so votes are idempotent
-// and reversible per IP.
+// and reversible per IP. Downvote previously existed but was retired
+// (brigading risk on an open-contribution platform with no moderation
+// team) — see task #61 for the migration rationale.
 
 import type { Env as MiddlewareEnv } from '../../_middleware';
 import { getSubmissionForView } from '../../../lib/submissions';
@@ -44,8 +47,8 @@ export const onRequestPost: PagesFunction<Env, keyof Params> = async (ctx) => {
     return j(400, { error: 'invalid JSON body' });
   }
   const vote = body.vote;
-  if (vote !== 1 && vote !== -1 && vote !== 0) {
-    return j(400, { error: 'vote must be 1, -1, or 0' });
+  if (vote !== 1 && vote !== 0) {
+    return j(400, { error: 'vote must be 1 (useful) or 0 (clear)' });
   }
 
   const sub = await getSubmissionForView(ctx.env.DB, id);

--- a/web/functions/c/[id].ts
+++ b/web/functions/c/[id].ts
@@ -26,7 +26,9 @@ export const onRequestGet: PagesFunction<Env, keyof Params> = async (ctx) => {
     getSubmissionForView(ctx.env.DB, id),
     countVotes(ctx.env.DB, id),
   ]);
-  const ratingsCount = tally.score;
+  // Display count = upvotes only ("N useful"). Legacy downvote totals in
+  // pre-existing rows are intentionally ignored — see task #61.
+  const ratingsCount = tally.up;
 
   if (!submission) {
     return new Response(NOT_FOUND_HTML, {

--- a/web/functions/lib/ratings.ts
+++ b/web/functions/lib/ratings.ts
@@ -1,10 +1,13 @@
-// Reddit-style up/down voting on community submissions.
+// Single-direction "Useful" voting on community submissions.
 // (submission_id, ip_hash) is the primary key — one vote per IP per
-// submission, mutable: vote=1 (up), -1 (down), or 0 (clear → delete row).
+// submission, mutable: vote=1 (useful) or 0 (clear → delete row).
+// The Tally type retains `down` + `score` for back-compat reads of
+// pre-existing rows; new writes cannot add downvotes (api/rate.ts
+// rejects vote=-1).
 
 type RunnableD1 = Pick<D1Database, 'prepare'>;
 
-export type Vote = 1 | -1 | 0;
+export type Vote = 1 | 0;
 export type Tally = { up: number; down: number; score: number };
 
 export async function recordVote(

--- a/web/functions/lib/render-view.ts
+++ b/web/functions/lib/render-view.ts
@@ -211,12 +211,11 @@ export function renderViewPage(opts: RenderOpts): string {
       a.btn.primary { background: var(--accent-fill); border-color: var(--accent-fill); color: #fff; }
       a.btn:hover, button.btn:hover { border-color: var(--accent); }
       button.btn:disabled { opacity: .55; cursor: default; border-color: var(--line); }
-      .vote-group { display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--line); border-radius: var(--radius-md); padding: 2px 6px; background: var(--bg); }
-      .vote { background: transparent; border: 0; padding: 4px 6px; font: inherit; cursor: pointer; color: var(--muted); border-radius: var(--radius-sm); line-height: 1; }
-      .vote:hover { color: var(--fg); background: var(--bg-card); }
-      .vote[aria-pressed=true].vote-up { color: var(--accent); }
-      .vote[aria-pressed=true].vote-down { color: #ef4444; }
-      .vote-score { font-weight: 600; font-variant-numeric: tabular-nums; min-width: 18px; text-align: center; }
+      .vote-useful { display: inline-flex; align-items: center; gap: 8px; border: 1px solid var(--line); border-radius: var(--radius-md); padding: 6px 12px; background: var(--bg); font: inherit; cursor: pointer; color: var(--muted); line-height: 1; min-height: 36px; }
+      .vote-useful:hover { color: var(--fg); border-color: var(--accent); }
+      .vote-useful[aria-pressed=true] { color: var(--accent); border-color: var(--accent); }
+      .vote-useful .vote-count { font-weight: 600; font-variant-numeric: tabular-nums; }
+      .vote-useful .vote-label { font-weight: 500; }
       .site-footer { margin-top: var(--sp-8); padding-top: var(--sp-5); border-top: 1px solid var(--line);
         font-size: var(--fs-sm); color: var(--muted); line-height: 1.6; }
       .site-footer a { color: var(--muted); text-decoration: underline; text-underline-offset: 2px; }
@@ -250,11 +249,11 @@ export function renderViewPage(opts: RenderOpts): string {
     <div class="actions">
       <a class="btn primary" href="${esc(verifyUrl)}">View on map →</a>
       <a class="btn" href="${esc(r2Path)}" download="${esc(filename)}">Download <code>.${esc(s.format)}</code></a>
-      <div class="vote-group" role="group" aria-label="vote on this submission">
-        <button class="vote vote-up" id="vote-up" type="button" aria-pressed="false" aria-label="upvote">▲</button>
-        <span class="vote-score" id="vote-score">${ratingsCount}</span>
-        <button class="vote vote-down" id="vote-down" type="button" aria-pressed="false" aria-label="downvote">▼</button>
-      </div>
+      <button class="vote-useful" id="vote-useful" type="button" aria-pressed="false">
+        <span aria-hidden="true">👍</span>
+        <span class="vote-count" id="vote-count">${ratingsCount}</span>
+        <span class="vote-label">useful</span>
+      </button>
     </div>
 
     <footer class="site-footer">
@@ -266,23 +265,23 @@ export function renderViewPage(opts: RenderOpts): string {
     <script>
       (() => {
         const id = document.body.dataset.submissionId;
-        const upBtn = document.getElementById('vote-up');
-        const downBtn = document.getElementById('vote-down');
-        const score = document.getElementById('vote-score');
-        if (!upBtn || !downBtn || !score) return;
+        const btn = document.getElementById('vote-useful');
+        const count = document.getElementById('vote-count');
+        if (!btn || !count) return;
 
+        // Display count = up votes only. Existing legacy downvotes in D1
+        // are ignored in the UI per task #61 (single-direction Useful vote).
         let myVote = 0;
         const apply = (s) => {
-          score.textContent = String(s.score);
-          myVote = s.myVote;
-          upBtn.setAttribute('aria-pressed', s.myVote === 1 ? 'true' : 'false');
-          downBtn.setAttribute('aria-pressed', s.myVote === -1 ? 'true' : 'false');
+          count.textContent = String(s.up || 0);
+          myVote = s.myVote === 1 ? 1 : 0;
+          btn.setAttribute('aria-pressed', myVote === 1 ? 'true' : 'false');
         };
 
         fetch('/api/c/' + id + '/rate').then(r => r.ok ? r.json() : null).then(s => s && apply(s)).catch(() => {});
 
         const send = async (vote) => {
-          upBtn.disabled = true; downBtn.disabled = true;
+          btn.disabled = true;
           try {
             const r = await fetch('/api/c/' + id + '/rate', {
               method: 'POST',
@@ -291,12 +290,10 @@ export function renderViewPage(opts: RenderOpts): string {
             });
             if (r.ok) apply(await r.json());
           } catch {}
-          upBtn.disabled = false; downBtn.disabled = false;
+          btn.disabled = false;
         };
-        // Cancel-on-opposite: if you've already voted (either way), clicking
-        // any button clears your vote. Click again to set the new direction.
-        upBtn.addEventListener('click', () => send(myVote === 0 ? 1 : 0));
-        downBtn.addEventListener('click', () => send(myVote === 0 ? -1 : 0));
+        // Click to mark useful; click again to clear.
+        btn.addEventListener('click', () => send(myVote === 1 ? 0 : 1));
       })();
     </script>
   </body>

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -112,8 +112,7 @@
       .comm-card__title a { color: inherit; text-decoration: none; }
       .comm-card__title a:hover { color: var(--accent); }
       .comm-card__score { font-variant-numeric: tabular-nums; font-weight: 600; color: var(--muted); font-size: 13px; }
-      .comm-card__score .up { color: var(--accent-strong); }
-      .comm-card__score .down { color: #b91c1c; }
+      .comm-card__score .useful { color: var(--accent-strong); }
       .comm-card__desc { color: var(--muted); font-size: 13px; margin: 6px 0 8px; }
       .comm-card__meta { color: var(--muted); font-size: 12px; }
 
@@ -688,8 +687,8 @@
           <button class="filter-toggle" id="map-download" aria-label="Download this layer" aria-expanded="false" aria-haspopup="menu">Download</button>
           <div class="map-popover" id="map-download-popover" role="menu"></div>
         </div>
-        <button class="filter-toggle" id="map-filter" aria-label="Open filter and export">Filter &amp; export</button>
-        <button class="close" id="map-close" aria-label="Close map">← back</button>
+        <button class="filter-toggle" id="map-filter">Filter &amp; export</button>
+        <button class="close" id="map-close">← back</button>
       </header>
       <div id="map"><div id="map-loading">loading map…</div></div>
     </div>

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -560,7 +560,9 @@ function fetchCommunitySubmissions() {
 const community = fetchCommunitySubmissions();
 
 function renderCommunityCard(s, opts = {}) {
-  const score = s.score;
+  // Single-direction "Useful" voting (task #61). Display + sort key both
+  // use up_count only; existing down_count rows in D1 are ignored here.
+  const useful = s.up_count;
   const cat = s.category || 'other';
   const collapsed = opts.collapsed ? ' row--collapsed' : '';
   // Build searchable haystack the same way curated cards do, so search
@@ -575,7 +577,7 @@ function renderCommunityCard(s, opts = {}) {
   ].join(' ')).toLowerCase();
   const dataAttrs = [
     `data-id="${esc(s.id)}"`,
-    `data-score="${score}"`,
+    `data-useful="${useful}"`,
     `data-created="${esc(s.created_at)}"`,
     `data-category="${esc(cat)}"`,
     `data-provenance="community"`,
@@ -585,8 +587,8 @@ function renderCommunityCard(s, opts = {}) {
   return `<article class="comm-card${collapsed}" ${dataAttrs}>
     <div class="comm-card__head">
       <div class="comm-card__title"><a href="/c/${esc(s.id)}">${esc(s.name)}</a><span class="badge badge--community">community</span></div>
-      <div class="comm-card__score" title="up ${s.up_count} · down ${s.down_count}">
-        <span class="up">▲ ${s.up_count}</span> · <span class="down">▼ ${s.down_count}</span>
+      <div class="comm-card__score" title="${useful} found this useful">
+        <span class="useful">👍 ${useful}</span>
       </div>
     </div>
     ${s.description ? `<p class="comm-card__desc">${esc(s.description)}</p>` : ''}

--- a/web/tests/render-view.test.ts
+++ b/web/tests/render-view.test.ts
@@ -70,11 +70,13 @@ describe('renderViewPage', () => {
     expect(html).toContain(encodeURIComponent('/api/r2/'));
   });
 
-  it('renders up + down buttons with the current score', () => {
+  it('renders a single Useful button with the current count', () => {
+    // v4.x (task #61): single-direction "Useful" vote replaced ▲/▼.
     const html = renderViewPage({ submission: row(), origin: ORIGIN, ratingsCount: 42, alreadyRated: false });
-    expect(html).toMatch(/id="vote-up"/);
-    expect(html).toMatch(/id="vote-down"/);
-    expect(html).toMatch(/id="vote-score">42</);
+    expect(html).toMatch(/id="vote-useful"/);
+    expect(html).toMatch(/id="vote-count">42</);
+    expect(html).not.toMatch(/id="vote-down"/);
+    expect(html).not.toMatch(/aria-label="downvote"/);
   });
 
   it('escapes HTML in name / description / attribution', () => {


### PR DESCRIPTION
## Summary

Replaces the ▲/▼ vote pair with a single "👍 Useful" button across /c/<id> and the catalog comm-card. Closes the brigading risk for an open-contribution platform without a moderation team.

## Why

- **Original v3 intent was thumbs-up only** (per `supporting-docs/v3-plan.md`). The downvote ▼ was added later and drifted from the design.
- **Anti-brigading**: one rejected submitter could systematically downvote everyone else's submissions. With no moderation team and no time-decay sort, we have no recovery mechanism.
- **Reddit/HN/Lobsters pattern**: list = passive score, detail = interactive control. The catalog already follows this; the vote semantics now match.

## What ships

### API (`web/functions/api/c/[id]/rate.ts`)
- POST now rejects `vote: -1` (`400 vote must be 1 (useful) or 0 (clear)`)
- GET still returns `{up, down, score, myVote}` — `down` + `score` retained for back-compat reads of pre-existing rows; UI ignores them
- `ratings.ts` `Vote` type narrowed to `1 | 0`

### UI
- **`/c/<id>`** (`render-view.ts`): the ▲/score/▼ trio is now a single `👍 N useful` pill. Click to mark useful, click again to clear. Display count = up votes only.
- **Catalog comm-card** (`prerender.mjs`): `▲ N · ▼ M` → `👍 N`. `data-score` data attribute renamed to `data-useful`.
- **Server-render hydration** (`functions/c/[id].ts`): `ratingsCount = tally.up` (was `tally.score`) so the SSR value matches the JS hydration.

### Data
- **Pre-existing downvote rows in D1 are NOT migrated.** They stay archived. The UI ignores them, the API can't add more.
- If you ever need them back (controversy + community moderation lands), the raw votes are still in `submission_ratings`.

### A11y bonus
- Removed redundant `aria-label="Open filter and export"` / `aria-label="Close map"` on `#map-filter` / `#map-close`. Visible text "Filter & export" / "← back" IS the accessible name; the previous aria-labels triggered Lighthouse's `label-content-name-mismatch` warning. Clean now.

## Tests

- `render-view.test.ts` updated — asserts single Useful button shape, explicitly checks for absence of `vote-down` / `aria-label="downvote"`
- Full suite: **359/359 green**

## Watch trigger to revisit

If a notable submission attracts genuinely controversial content, may need a downvote-style signal for community pushback. Defer until that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)