### PR TITLE
Cron auto-rebuild + submit-latency note + liability disclaimer + cross-source framing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,57 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual trigger button in the GitHub Actions UI — useful when you've
+  # accepted a community submission and want to push a rebuild faster
+  # than the hourly cron would.
+  workflow_dispatch:
+  # Hourly rebuild to pick up new accepted community submissions, which
+  # are baked into the home page at build time (prerender.mjs queries D1).
+  # The check-community-queue job below short-circuits this run when D1
+  # has nothing new, so CF Pages build minutes are only consumed for
+  # rebuilds that actually carry payload.
+  schedule:
+    - cron: '17 * * * *'
 
 jobs:
+  # Gate job: for scheduled runs only, query D1 to see if any submissions
+  # were accepted in the overlap window (cron interval + 10 min slack so
+  # nothing falls through a boundary). Skipped for push / pull_request /
+  # workflow_dispatch — those always proceed.
+  check-community-queue:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      has-new: ${{ steps.check.outputs.has-new }}
+    steps:
+      - name: query D1 for recent accepted submissions
+        id: check
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          npm install -g wrangler@4 >/dev/null 2>&1
+          RAW=$(wrangler d1 execute geodata-submissions --remote --json \
+            --command "SELECT COUNT(*) AS n FROM submissions WHERE status='accepted' AND created_at >= datetime('now', '-70 minutes')")
+          COUNT=$(echo "$RAW" | jq -r '.[0].results[0].n // 0')
+          echo "Found $COUNT new submission(s) in the last 70 min"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "has-new=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-new=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test-and-deploy:
-    name: tests + build${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && ' + deploy' || '' }}
+    needs: [check-community-queue]
+    # Run when:
+    #  - the gate job was skipped (i.e. this is push/PR/workflow_dispatch), OR
+    #  - the gate ran and found new community submissions.
+    # always() lets us evaluate the if even though the dependency was skipped.
+    if: >-
+      ${{ always() && (needs.check-community-queue.result == 'skipped' ||
+          needs.check-community-queue.outputs.has-new == 'true') }}
+    name: tests + build${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && ' + deploy' || (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && ' + deploy' || '' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -29,21 +76,25 @@ jobs:
         run: npm test
 
       - name: build
-        # For production builds (push to main), the secrets feed real values
-        # into the prerender so the deployed dist has the right Turnstile site
-        # key + queries the remote D1 for community submissions. For PRs the
-        # build still runs (with the always-pass test key + local fallback)
-        # to verify nothing's broken.
+        # Any build that will be deployed needs the real Turnstile site key +
+        # remote D1 query for community cards. Pull-request builds run with
+        # the always-pass test key + local D1 fallback (nothing to deploy,
+        # just verifying the build doesn't break).
         env:
           TURNSTILE_SITEKEY: ${{ secrets.TURNSTILE_SITEKEY || '1x00000000000000000000AA' }}
-          COMMUNITY_FROM: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'remote' || 'local' }}
+          COMMUNITY_FROM: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' && 'remote' || 'local' }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: npm run build
 
       - name: deploy to cloudflare pages
-        # Only on push to main. PRs build but don't deploy.
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        # Deploy when:
+        #  - push to main (normal commit-driven deploy)
+        #  - workflow_dispatch (manual rebuild button)
+        #  - schedule (hourly community-queue rebuild; only reaches this step
+        #    when check-community-queue found new submissions)
+        # PRs build but don't deploy.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/web/about.template.html
+++ b/web/about.template.html
@@ -115,10 +115,9 @@
 
     <h2 id="use-of-data">Use of data</h2>
     <ul>
-      <li><strong>Provided as-is, no warranty.</strong> Express or implied guarantees of accuracy, completeness or fitness for a particular purpose are not made by this site or its maintainers.</li>
-      <li><strong>Boundaries are for reference, not legal authority.</strong> For official, administrative or land-record use, refer directly to LGD, SOI, Bhuvan or the state revenue department.</li>
       <li><strong>Curated layers reflect the upstream source at fetch time.</strong> See the freshness pill on each card. Upstream sources change; the catalog can lag.</li>
       <li><strong>Community submissions are auto-moderated, not editorially curated.</strong> Licence, format and basic geometry validity are checked; accuracy and authorship are not. Verify via the source link on each card before relying on community data.</li>
+      <li><strong>Boundaries and place names render exactly as the upstream source publishes them.</strong> bharatlas does not edit, correct or editorialize. Where you disagree with a depiction (including for J&amp;K, the Line of Actual Control or any disputed territory), raise it with the source; each catalog card lists alternative sources so you can compare. See <a href="/terms#liability">Limitation of liability</a> for the warranty disclaimer, damages cap and full terms.</li>
     </ul>
 
     <h2 style="text-transform:none;letter-spacing:0;color:var(--fg);font-size:var(--fs-xl);margin-top:var(--sp-7)">Built by</h2>

--- a/web/about.template.html
+++ b/web/about.template.html
@@ -57,14 +57,14 @@
     <p>
       Maps live everywhere online, but you can't tell what they actually show, who
       maintains them, or whether to trust them. Pulling out just the slice you need
-      means booting QGIS or wading through Google Maps menus. Viewing is its own ordeal
-      — sign in, navigate the menus, import. The format question alone — KML? KMZ?
-      GeoJSON? Parquet? — feels gatekept. And if you've made a map yourself and want to
+      means booting QGIS or wading through Google Maps menus. Viewing is its own ordeal:
+      sign in, navigate the menus, import. The format question alone (KML? KMZ?
+      GeoJSON? Parquet?) feels gatekept. And if you've made a map yourself and want to
       share it, you have to stand up your own website to host it.
     </p>
     <p>
-      <a href="https://www.sathyasankaran.com" target="_blank" rel="noopener">Sathya</a> kept hitting the same wall. Bharatlas flattens all of that —
-      <strong>the wiki for India's maps.</strong> View any layer in your browser. Filter
+      <a href="https://www.sathyasankaran.com" target="_blank" rel="noopener">Sathya</a> kept hitting the same wall. Bharatlas flattens all of that.
+      <strong>The wiki for India's maps.</strong> View any layer in your browser. Filter
       what you need. Download in whatever format your tool reads. Liked it? Upvote so
       others find it. Have a map worth sharing? Drag and drop it onto the page. Every
       layer carries its source, licence and freshness on the same card.
@@ -72,23 +72,23 @@
 
     <h2>Who it's for</h2>
     <ul>
-      <li><strong>Journalists + researchers</strong> — pull a state's districts, villages or constituencies in ten seconds; download as GeoJSON or Parquet.</li>
-      <li><strong>Civic technologists</strong> — share city-scale layers (wards, bike lanes, polling booths) with attribution baked in.</li>
-      <li><strong>App developers</strong> — direct PMTiles URLs, no rate limits, no API key.</li>
+      <li><strong>Journalists + researchers:</strong> pull a state's districts, villages or constituencies in ten seconds; download as GeoJSON or Parquet.</li>
+      <li><strong>Civic technologists:</strong> share city-scale layers (wards, bike lanes, polling booths) with attribution baked in.</li>
+      <li><strong>App developers:</strong> direct PMTiles URLs, no rate limits, no API key.</li>
     </ul>
 
     <h2>What you can do today</h2>
     <ul>
       <li>View every admin level from <strong>state</strong> to <strong>village</strong> on a map, plus city wards across <strong>15 Indian cities</strong> (Bengaluru, Chennai, Hyderabad, Mumbai and more), constituencies, wildlife sanctuaries.</li>
-      <li>Filter any layer by what its columns actually contain — state, zone, area, anything — and export the slice as <strong>Parquet</strong>, <strong>GeoJSON</strong> or <strong>KML</strong>.</li>
-      <li><a href="/preview">Drop a file</a> to see it on a map and validate it. Optionally publish under an open licence — no signup; you get an admin token to keep forever.</li>
+      <li>Filter any layer by what its columns actually contain (state, zone, area, anything) and export the slice as <strong>Parquet</strong>, <strong>GeoJSON</strong> or <strong>KML</strong>.</li>
+      <li><a href="/preview">Drop a file</a> to see it on a map and validate it. Optionally publish under an open licence. No signup; you get an admin token to keep forever.</li>
       <li>Embed any map in a blog post or report (iframe snippet + PNG export, one click each).</li>
     </ul>
 
     <h2>Open source</h2>
     <p>
       Code: <a href="https://github.com/urbanmorph/geodata">github.com/urbanmorph/geodata</a> · MIT.<br />
-      Data: each layer carries its own open licence — see the per-card line on the
+      Data: each layer carries its own open licence; see the per-card line on the
       <a href="/">catalog</a>.
     </p>
 
@@ -104,20 +104,20 @@
       <dd>Curated layers carry CC0-1.0, CC-BY-4.0 or GODL-India depending on the upstream source. Community submissions choose from an open-licence allowlist: CC0, CC-BY, CC-BY-SA, ODbL, ODC-PDDL or GODL-India. Proprietary or "all rights reserved" content is rejected at submit.</dd>
 
       <dt>Is my file uploaded when I drop it?</dt>
-      <dd>No — not until you click <strong>Publish</strong>. Parsing, validation and the map render all happen in your browser. Only the explicit Publish action ships the file to R2 and records metadata in D1.</dd>
+      <dd>No, not until you click <strong>Publish</strong>. Parsing, validation and the map render all happen in your browser. Only the explicit Publish action ships the file to R2 and records metadata in D1.</dd>
 
       <dt>How can I trust community submissions?</dt>
       <dd>Each carries a source URL, attribution and an open licence on the card and the view page. The platform auto-moderates licence, attribution and basic geometry validity, but it does not verify accuracy beyond the contributor's self-attestation. For sensitive use, follow the source link on the card to confirm provenance.</dd>
 
       <dt>Can AI assistants read and recommend bharatlas?</dt>
-      <dd>Yes. The robots.txt explicitly allows GPTBot, ClaudeBot, PerplexityBot, Google-Extended and other major AI crawlers. The catalog and every <code>/c/&lt;id&gt;</code> view page are server-rendered as plain HTML with JSON-LD <code>Dataset</code> structured data — easy for LLMs to ingest.</dd>
+      <dd>Yes. The robots.txt explicitly allows GPTBot, ClaudeBot, PerplexityBot, Google-Extended and other major AI crawlers. The catalog and every <code>/c/&lt;id&gt;</code> view page are server-rendered as plain HTML with JSON-LD <code>Dataset</code> structured data, easy for LLMs to ingest.</dd>
     </dl>
 
     <h2 id="use-of-data">Use of data</h2>
     <ul>
       <li><strong>Provided as-is, no warranty.</strong> Express or implied guarantees of accuracy, completeness or fitness for a particular purpose are not made by this site or its maintainers.</li>
       <li><strong>Boundaries are for reference, not legal authority.</strong> For official, administrative or land-record use, refer directly to LGD, SOI, Bhuvan or the state revenue department.</li>
-      <li><strong>Curated layers reflect the upstream source at fetch time</strong> — see the freshness pill on each card. Upstream sources change; the catalog can lag.</li>
+      <li><strong>Curated layers reflect the upstream source at fetch time.</strong> See the freshness pill on each card. Upstream sources change; the catalog can lag.</li>
       <li><strong>Community submissions are auto-moderated, not editorially curated.</strong> Licence, format and basic geometry validity are checked; accuracy and authorship are not. Verify via the source link on each card before relying on community data.</li>
     </ul>
 

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -225,6 +225,12 @@
       .row__source { color: var(--muted); font-size: 12px; margin: 0 0 10px; }
       .row__source a { color: var(--fg); }
       .row__source .dot { color: var(--line); }
+      /* Alternative sources for the same level. Signals plurality without
+         claiming any single source as canonical. Lighter than the primary
+         attribution; lifts on hover so they read as clickable. */
+      .row__alts { color: var(--muted); }
+      .row__alts a { color: var(--muted); text-decoration: underline; text-underline-offset: 2px; }
+      .row__alts a:hover { color: var(--accent); }
       .row__freshness { font-variant-numeric: tabular-nums; cursor: help; }
       .row__freshness.stale { color: #d97706; }
       .badge {

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -645,7 +645,7 @@
     <header class="hero">
       <h1 class="hero__title">Find a map. Or share one.</h1>
       <p class="hero__sub">
-        India's curated boundaries, environment, electoral, postal and infrastructure layers — plus whatever the
+        India's curated boundaries, environment, electoral, postal and infrastructure layers, plus whatever the
         community uploads. Drop your own file to verify before publishing.
       </p>
     </header>

--- a/web/preview.template.html
+++ b/web/preview.template.html
@@ -157,6 +157,10 @@
         padding: 10px 12px; word-break: break-all; margin: 10px 0;
       }
       #success .actions { display: flex; gap: 8px; flex-wrap: wrap; margin: 10px 0 24px; }
+      #success .ok-meta {
+        color: var(--fg); font-size: 13px; font-weight: 500;
+        margin: -16px 0 24px; line-height: 1.5;
+      }
       #success a.cta {
         display: inline-block; background: var(--accent); color: #fff; text-decoration: none;
         padding: 10px 20px; border-radius: 6px; font-weight: 500; font-size: 14px;
@@ -193,6 +197,10 @@
         border-radius: 10px; padding: 12px 14px;
       }
       #my-subs[hidden] { display: none; }
+      /* When the user has dropped a file (workspace.show), the verify flow
+         takes over the canvas; hide the past-submissions panel so they don't
+         stack and overlap the map. Returns when workspace.show is removed. */
+      body:has(#workspace.show) #my-subs { display: none; }
       #my-subs h2 {
         font-size: 11px; font-weight: 600; letter-spacing: .08em;
         text-transform: uppercase; color: var(--muted); margin: 0 0 8px;
@@ -264,7 +272,7 @@
     <!-- NAV -->
 
     <h1 class="page-title">View, verify, or publish a geo file</h1>
-    <p class="page-sub">Drop a file to render it on a map and check it. Optionally publish to the open catalog — nothing is uploaded unless you click <strong>Publish</strong>.</p>
+    <p class="page-sub">Drop a file to render it on a map and check it. Optionally publish to the open catalog. Nothing is uploaded unless you click <strong>Publish</strong>.</p>
 
     <label id="drop" for="file">
       <strong>Drop a file or click to choose</strong>
@@ -293,7 +301,7 @@
         <div id="publish-cta">
           <p class="cta-line">Want to share this with others?</p>
           <button type="button" class="primary" id="publish-open">Publish to catalog →</button>
-          <p class="cta-hint">Or leave it — nothing has been uploaded.</p>
+          <p class="cta-hint">Or leave it. Nothing has been uploaded.</p>
         </div>
 
         <!-- View-only banner shown when the file came from /c/[id] (?url=…) -->
@@ -320,7 +328,7 @@
           <div class="field">
             <label for="f-cat">Category <span class="req">*</span></label>
             <select id="f-cat" name="category" required>
-              <option value="">— pick one —</option>
+              <option value="">pick one</option>
               <option value="administrative">Administrative boundaries</option>
               <option value="people">People &amp; places</option>
               <option value="environment">Environment &amp; nature</option>
@@ -336,13 +344,13 @@
           <div class="field">
             <label for="f-lic">Licence <span class="req">*</span></label>
             <select id="f-lic" name="license" required>
-              <option value="">— pick one —</option>
-              <option value="CC0-1.0">CC0 1.0 — Public Domain Dedication</option>
-              <option value="CC-BY-4.0">CC BY 4.0 — Attribution</option>
-              <option value="CC-BY-SA-4.0">CC BY-SA 4.0 — Attribution-ShareAlike</option>
-              <option value="ODbL-1.0">ODbL 1.0 — Open Database License</option>
-              <option value="ODC-PDDL-1.0">ODC PDDL — Public Domain Dedication</option>
-              <option value="GODL-India">Government Open Data Licence — India</option>
+              <option value="">pick one</option>
+              <option value="CC0-1.0">CC0 1.0 (Public Domain Dedication)</option>
+              <option value="CC-BY-4.0">CC BY 4.0 (Attribution)</option>
+              <option value="CC-BY-SA-4.0">CC BY-SA 4.0 (Attribution-ShareAlike)</option>
+              <option value="ODbL-1.0">ODbL 1.0 (Open Database License)</option>
+              <option value="ODC-PDDL-1.0">ODC PDDL (Public Domain Dedication)</option>
+              <option value="GODL-India">Government Open Data Licence, India</option>
             </select>
             <div class="hint">Only open licences are accepted.</div>
           </div>
@@ -382,9 +390,10 @@
     <section id="success" aria-live="polite">
       <h2>✓ Your submission is live</h2>
       <p class="ok-line" id="success-url"></p>
+      <p class="ok-meta">Works immediately. Appears in the catalog home page within the hour.</p>
 
       <div class="warn">
-        <strong>Admin token — shown once. Save it.</strong>
+        <strong>Admin token (shown once). Save it.</strong>
         <div class="token" id="success-token"></div>
         <div class="actions">
           <button type="button" class="secondary" id="copy-token">Copy token</button>

--- a/web/preview.template.html
+++ b/web/preview.template.html
@@ -390,7 +390,7 @@
     <section id="success" aria-live="polite">
       <h2>✓ Your submission is live</h2>
       <p class="ok-line" id="success-url"></p>
-      <p class="ok-meta">Works immediately. Appears in the catalog home page within the hour.</p>
+      <p class="ok-meta">The link works immediately. Your submission will be listed in the home page catalog in the next hour.</p>
 
       <div class="warn">
         <strong>Admin token (shown once). Save it.</strong>

--- a/web/privacy.template.html
+++ b/web/privacy.template.html
@@ -34,9 +34,9 @@
 
     <h2>What we store</h2>
     <ul>
-      <li><strong>Community submissions</strong> you publish — the file, the metadata you typed, and the time. On Cloudflare R2 (file) and D1 (metadata). Linked to a one-way SHA-256 hash of your IP for rate-limit purposes only.</li>
-      <li><strong>In your browser</strong> — localStorage holds the admin tokens for any submissions you made from this device, plus your basemap preference. No cookies, no fingerprinting. Nothing leaves your browser until you click <strong>Publish</strong>.</li>
-      <li><strong>Server logs</strong> — Cloudflare's edge logs HTTP requests for around 24 hours. We don't aggregate them, sell them, or look at them unless investigating abuse.</li>
+      <li><strong>Community submissions</strong> you publish: the file, the metadata you typed, and the time. On Cloudflare R2 (file) and D1 (metadata). Linked to a one-way SHA-256 hash of your IP for rate-limit purposes only.</li>
+      <li><strong>In your browser:</strong> localStorage holds the admin tokens for any submissions you made from this device, plus your basemap preference. No cookies, no fingerprinting. Nothing leaves your browser until you click <strong>Publish</strong>.</li>
+      <li><strong>Server logs:</strong> Cloudflare's edge logs HTTP requests for around 24 hours. We don't aggregate them, sell them, or look at them unless investigating abuse.</li>
     </ul>
 
     <h2>What we don't do</h2>
@@ -58,7 +58,7 @@
     <p>
       We explicitly allow GPTBot, ClaudeBot, PerplexityBot, Google-Extended and other major
       LLM crawlers via <code>robots.txt</code>. The content is open under the licences
-      shown on each card; we want it to be discoverable to anyone — human or model — who
+      shown on each card; we want it to be discoverable to anyone (human or model) who
       can use it.
     </p>
 

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -348,8 +348,20 @@ function renderRow(level, layersForLevel, opts = {}) {
   const freshnessSpan = primary.fetched_at
     ? `<span class="row__freshness${isStale(primary.fetched_at) ? ' stale' : ''}" title="${esc(primary.fetched_at)}">${relativeTime(primary.fetched_at)}</span>`
     : '';
+  // Show alternate sources for the same level inline. This signals plurality
+  // at-a-glance — no single source is "the truth" for boundaries / names.
+  // Clicking jumps to /view/<id> for that source's version. See terms.html
+  // "Limitation of liability" for the editorial position on disputed depictions.
+  //
+  // Filter to map-renderable sources only (pmtiles or geojson). Parquet-only
+  // alternates (some SOI / Bhuvan layers) still exist in the data; their
+  // downloads surface in the <details class="alt"> "compare sources" block
+  // below. The inline "also:" list is exclusively for "you can view this".
+  const altSources = layersForLevel
+    .filter((l) => l !== primary && (l.pmtiles?.url || l.geojson?.url))
+    .map((l) => `<a href="/view/${esc(l.id)}">${esc(l.source)}</a>`);
   const sourceText = primary.attribution?.primary
-    ? `Source: <a href="${esc(primary.attribution.primary.url)}" target="_blank" rel="noopener">${esc(primary.attribution.primary.name)}</a>`
+    ? `Per <a href="${esc(primary.attribution.primary.url)}" target="_blank" rel="noopener">${esc(primary.attribution.primary.name)}</a>${altSources.length ? ` <span class="row__alts">also: ${altSources.join(', ')}</span>` : ''}`
     : '';
   const sourceLine =
     sourceText || freshnessSpan

--- a/web/terms.template.html
+++ b/web/terms.template.html
@@ -54,6 +54,15 @@
       <li>Community submissions are auto-moderated, not editorially curated. Verify provenance via the source link on each card before relying on community data.</li>
     </ul>
 
+    <h2 id="liability">Limitation of liability</h2>
+    <ul>
+      <li>The content on bharatlas is provided <strong>AS IS</strong>, without warranty of any kind, express or implied. This includes warranties of accuracy, completeness, merchantability, fitness for a particular purpose, non-infringement, and continuity of service.</li>
+      <li>To the maximum extent permitted by law, the maintainer (Sathya Sankaran / Urban Morph) is not liable for any direct, indirect, incidental, special, consequential or punitive damages arising from your use of the maps or data. You assume all risk associated with decisions or actions taken based on what you find here.</li>
+      <li><strong>Boundaries, place names, codes and nomenclature are rendered exactly as published by the upstream source</strong> (LGD, Survey of India, Bhuvan, geoBoundaries, OpenCity, etc.). bharatlas does not edit, correct, reconcile, or take an editorial position on what upstream sources publish. If you believe a boundary or name is wrong, the source is the place to raise it.</li>
+      <li>Specifically: depictions of Jammu and Kashmir, Ladakh, the Line of Actual Control, the Line of Control, areas under PoK administration, and any other disputed or politically sensitive territory follow the upstream source. Different sources may disagree. Our rendering is neither a political endorsement nor a claim to authoritative status.</li>
+      <li>Do not use any layer as legal authority for land, jurisdiction, electoral, taxation or regulatory purposes, or for safety-critical applications (navigation, emergency response, structural decisions), without independent verification against the official source.</li>
+    </ul>
+
     <h2>Acceptable use</h2>
     <ul>
       <li>Don't scrape rate-limited endpoints. The R2 PMTiles URLs are public and unrate-limited; use those for bulk reads.</li>

--- a/web/terms.template.html
+++ b/web/terms.template.html
@@ -44,7 +44,7 @@
     <ul>
       <li>You confirm you own the file or have the right to share it under the open licence you select.</li>
       <li>You accept that your contribution becomes permanently available under that licence. We can soft-delete a submission on your admin-token request or on legal request, but distribution that already happened under the open licence may continue downstream.</li>
-      <li>You attest that the file's content does not violate Indian law — no classified data, no content that violates someone's privacy, no copyrighted material presented as your own.</li>
+      <li>You attest that the file's content does not violate Indian law: no classified data, no content that violates someone's privacy, no copyrighted material presented as your own.</li>
     </ul>
 
     <h2>What we don't warrant</h2>
@@ -56,7 +56,7 @@
 
     <h2>Acceptable use</h2>
     <ul>
-      <li>Don't scrape rate-limited endpoints. The R2 PMTiles URLs are public and unrate-limited — use those for bulk reads.</li>
+      <li>Don't scrape rate-limited endpoints. The R2 PMTiles URLs are public and unrate-limited; use those for bulk reads.</li>
       <li>Don't submit malware, harmful files, or content that infringes others' rights.</li>
       <li>Don't attempt to bypass anti-abuse mechanisms (Turnstile, IP rate-limits).</li>
     </ul>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,6 +20,7 @@ function prerenderPlugin(): Plugin {
         resolve(server.config.root, 'index.template.html'),
         resolve(server.config.root, 'about.template.html'),
         resolve(server.config.root, 'preview.template.html'),
+        resolve(server.config.root, 'scripts', 'prerender.mjs'),
         resolve(server.config.root, '..', 'catalog.json'),
       ];
       watched.forEach((f) => server.watcher.add(f));
@@ -50,6 +51,11 @@ export default defineConfig({
       '^/c/.+': 'http://localhost:8788',
       '^/og/.+': 'http://localhost:8788',
       '^/view/.+': 'http://localhost:8788',
+      // wrangler-served pages (/view, /c, /og, …) reference dist hashed
+      // assets like /assets/main-XXX.js. Vite dev doesn't generate those
+      // (it serves /src/main.ts instead), so without this line the browser
+      // 404s on assets when navigating to any wrangler-proxied path.
+      '/assets': 'http://localhost:8788',
     },
   },
   build: {


### PR DESCRIPTION
## Summary

Three coherent shifts triggered by readying bharatlas for wider launch:

- **Auto-rebuild on new community submissions** so the home-page catalog stays current without manual deploys
- **User-facing latency note** on the submit success card so contributors don't think the platform is broken while the cron catches up
- **Liability disclaimer + cross-source framing** so "your map is wrong" complaints have a formal home and curated layers no longer read as "the source of truth"

Plus an em-dash sweep across all user-facing templates (no-em-dashes house rule), a layout-overlap fix on /preview, and two dev-environment fixes that surfaced during local verification.

## Commits

1. `bf2f0cf` **ci: hourly scheduled rebuild to pick up new community submissions**
   - GitHub Actions cron at minute :17 + workflow_dispatch button
   - New `check-community-queue` gate job queries D1 for accepted submissions in the last 70 min; skips build+deploy when nothing new
   - Reuses existing `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` secrets — zero new setup
   - Considered and rejected: CF Pages Deploy Hook (this Pages project is direct-upload mode, no hook UI exists), workflow_dispatch from /api/submit (silent failure modes, PAT to rotate)
   - Worst-case latency from accept to home-page card: ~1 hour. Self-healing if a cron run fails.

2. `91935ff` **copy(preview): inline submit-latency note + my-subs overlap fix + em-dash sweep**
   - Inline note under submission share URL: "The link works immediately. Your submission will be listed in the home page catalog in the next hour."
   - Fix: `body:has(#workspace.show) #my-subs { display: none }` — past-submissions panel was stacking on top of the verify workspace
   - Em-dash sweep across about / preview / privacy / terms / index per the no-em-dashes house rule (12 + 10 + 4 + 2 + 1 instances replaced with colons, periods, semicolons or parens per context)

3. `ef01468` **copy(legal+catalog): liability disclaimer + cross-source card framing**
   - **/terms** — new "Limitation of liability" section (#liability anchor) with AS-IS clause, damages exclusion, and explicit "rendered as upstream publishes" language. Calls out J&K, Ladakh, LoC, LAC, PoK by name as examples where the platform follows upstream, isn't editorial.
   - **/about** — trimmed "Use of data" from 5 bullets to 3, removing legal duplicates now living in /terms. Single new bullet links to /terms#liability for the formal language.
   - **Curated card framing** — `Source: LGD` → `Per LGD · also: geoBoundaries`. Each "also:" alt is clickable to /view/<id>. Plurality visible at-a-glance instead of hidden in a `<details>`. Filter: only map-renderable sources (pmtiles/geojson) appear as alts; parquet-only downloads (SOI, Bhuvan, PMGSY) remain discoverable via the existing `<details class="alt">` "compare sources" block.
   - **vite.config.ts** — added `/assets/` to wrangler proxy (fixes 404s on wrangler-served pages in dev) + added `scripts/prerender.mjs` to the prerender plugin's watched files (so editing it auto-reruns).

## Tests + verification

- ✅ 359/359 vitest tests pass
- ✅ actionlint clean on `.github/workflows/ci.yml`
- ✅ D1 gate query dry-run against prod returns `n: 0` (would skip cleanly today)
- ✅ Lighthouse desktop home unchanged: 100/100/100/100, LCP 0.6s, TBT 0, CLS 0
- ✅ Build clean (warning about >500KB chunk is pre-existing, map-vendor bundle)
- ✅ Local visual verification of submit success card + all /view/<id> alt links

## Test plan

- [ ] Merge → first cron fires at next :17, then hourly
- [ ] Submit a test file via /preview → wait until :17 → confirm card appears on home within ~5 min of the cron run
- [ ] Visit /terms#liability → confirm new section renders cleanly with anchor jump
- [ ] Visit /about → confirm shortened "Use of data" reads naturally, deep-link to /terms#liability works
- [ ] Click "geoBoundaries" alt on the States card → confirm map opens and renders
- [ ] Confirm `<details>` "compare sources" still shows all four sources including SOI/Bhuvan downloads

## Follow-up (already logged as Task #63)

Bake PMTiles for SOI / Bhuvan / PMGSY layers (8 layers, ~315 MB parquet → ~130 MB pmtiles output, ~30-45 min compute) so cross-source viewing matches the "view, slice, filter" product promise. The card-framing filter from this PR is forward-compatible: once those PMTiles land, alts auto-include SOI/Bhuvan/PMGSY with zero further code changes.

## Memory / docs updated

- `project_disputed_borders_policy.md` — render exactly what upstream publishes; complaints belong with the source
- `project_community_scaling_path.md` — DEF-01 + DEF-02 paths for community discovery scaling
- `supporting-docs/deferred-tasks.md` — DEF-01 / DEF-02 / DEF-03 + API stability rules
- `MEMORY.md` — index entries for the two new project memories

🤖 Generated with [Claude Code](https://claude.com/claude-code)