### PR TITLE
Bake SOI/Bhuvan/PMGSY PMTiles + add bharatviz pincodes + render points correctly

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated": "2026-05-23T16:16:46.486302+00:00",
+  "generated": "2026-05-23T17:27:13.641685+00:00",
   "country": "IN",
   "r2_base": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev",
   "levels": {
@@ -789,7 +789,7 @@
       "category": "administrative",
       "provenance": "curated",
       "fetched_at": "2026-04-26T13:01:32.132923+00:00",
-      "notes": "SoI village centroids (point geometry). 5.76 lakh point features \u2014 every revenue village named by SoI."
+      "notes": "SoI village centroids (point geometry). 5.76 lakh point features. Coverage is dense in southern + western states and sparse in UP, Bihar, Jharkhand and several NE states (SoI source limitation, not a rendering issue)."
     },
     {
       "id": "lgd_parliament",
@@ -852,6 +852,34 @@
       "provenance": "curated",
       "fetched_at": "2026-05-21T10:31:17.416707+00:00",
       "notes": "State legislative assembly constituencies. Polygons keyed by ST_CODE."
+    },
+    {
+      "id": "bharatviz_pincodes",
+      "level": "pincode",
+      "source": "bharatviz",
+      "rows": 63864,
+      "parquet": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/postal/boundaries/bharatviz_pincodes.parquet",
+        "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/postal/boundaries/bharatviz_pincodes.parquet",
+        "bytes": 1762991
+      },
+      "pmtiles": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/postal/boundaries/bharatviz_pincodes.pmtiles",
+        "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/postal/boundaries/bharatviz_pincodes.pmtiles",
+        "bytes": 2362790
+      },
+      "licence": "MIT",
+      "attribution": {
+        "primary": {
+          "name": "bharatviz (Saket Choudhary)",
+          "url": "https://bharatviz.org/"
+        },
+        "publisher": null
+      },
+      "category": "infrastructure",
+      "provenance": "curated",
+      "fetched_at": "2026-05-23T17:18:45.854281+00:00",
+      "notes": "India Post pincode boundary polygons (simplified). 63,864 polygons. \u00a9 2025 Saket Choudhary, MIT-licensed via bharatviz.org. Source: bharatviz.org/India_pincodes_simplified.geojson; code repo github.com/saketlab/bharatviz."
     },
     {
       "id": "gs_wildlife",
@@ -936,10 +964,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -967,10 +992,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -998,10 +1020,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1029,10 +1048,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1060,10 +1076,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1091,10 +1104,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1122,10 +1132,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1153,10 +1160,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1184,10 +1188,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "people",
       "provenance": "curated",
@@ -1215,10 +1216,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1246,10 +1244,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1277,10 +1272,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1308,10 +1300,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1339,10 +1328,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1370,10 +1356,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1401,10 +1384,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1432,10 +1412,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -1463,10 +1440,7 @@
           "name": "OpenCity / Oorvani Foundation",
           "url": "https://data.opencity.in/"
         },
-        "publisher": {
-          "name": "yashveeeeeeer/india-geodata",
-          "url": "https://github.com/yashveeeeeeer/india-geodata"
-        }
+        "publisher": null
       },
       "category": "administrative",
       "provenance": "curated",
@@ -4137,7 +4111,47 @@
           "max": 36,
           "top_values": [
             {
-              "v": 34,
+              "v": 15,
+              "n": 1
+            },
+            {
+              "v": 20,
+              "n": 1
+            },
+            {
+              "v": 3,
+              "n": 1
+            },
+            {
+              "v": 4,
+              "n": 1
+            },
+            {
+              "v": 29,
+              "n": 1
+            },
+            {
+              "v": 14,
+              "n": 1
+            },
+            {
+              "v": 28,
+              "n": 1
+            },
+            {
+              "v": 25,
+              "n": 1
+            },
+            {
+              "v": 10,
+              "n": 1
+            },
+            {
+              "v": 33,
+              "n": 1
+            },
+            {
+              "v": 21,
               "n": 1
             },
             {
@@ -4153,19 +4167,63 @@
               "n": 1
             },
             {
-              "v": 3,
+              "v": 34,
               "n": 1
             },
             {
-              "v": 4,
+              "v": 18,
               "n": 1
             },
             {
-              "v": 15,
+              "v": 22,
               "n": 1
             },
             {
-              "v": 20,
+              "v": 1,
+              "n": 1
+            },
+            {
+              "v": 12,
+              "n": 1
+            },
+            {
+              "v": 6,
+              "n": 1
+            },
+            {
+              "v": 36,
+              "n": 1
+            },
+            {
+              "v": 2,
+              "n": 1
+            },
+            {
+              "v": 30,
+              "n": 1
+            },
+            {
+              "v": 27,
+              "n": 1
+            },
+            {
+              "v": 31,
+              "n": 1
+            },
+            {
+              "v": 11,
+              "n": 1
+            },
+            {
+              "v": 7,
+              "n": 1
+            },
+            {
+              "v": 9,
+              "n": 1
+            },
+            {
+              "v": 5,
               "n": 1
             },
             {
@@ -4174,22 +4232,6 @@
             },
             {
               "v": 24,
-              "n": 1
-            },
-            {
-              "v": 21,
-              "n": 1
-            },
-            {
-              "v": 25,
-              "n": 1
-            },
-            {
-              "v": 10,
-              "n": 1
-            },
-            {
-              "v": 33,
               "n": 1
             },
             {
@@ -4211,74 +4253,6 @@
             {
               "v": 23,
               "n": 1
-            },
-            {
-              "v": 18,
-              "n": 1
-            },
-            {
-              "v": 22,
-              "n": 1
-            },
-            {
-              "v": 1,
-              "n": 1
-            },
-            {
-              "v": 11,
-              "n": 1
-            },
-            {
-              "v": 2,
-              "n": 1
-            },
-            {
-              "v": 30,
-              "n": 1
-            },
-            {
-              "v": 27,
-              "n": 1
-            },
-            {
-              "v": 31,
-              "n": 1
-            },
-            {
-              "v": 6,
-              "n": 1
-            },
-            {
-              "v": 36,
-              "n": 1
-            },
-            {
-              "v": 29,
-              "n": 1
-            },
-            {
-              "v": 14,
-              "n": 1
-            },
-            {
-              "v": 28,
-              "n": 1
-            },
-            {
-              "v": 7,
-              "n": 1
-            },
-            {
-              "v": 9,
-              "n": 1
-            },
-            {
-              "v": 5,
-              "n": 1
-            },
-            {
-              "v": 12,
-              "n": 1
             }
           ]
         },
@@ -4291,19 +4265,7 @@
           "max": "WEST BENGAL",
           "top_values": [
             {
-              "v": "RAJASTHAN",
-              "n": 1
-            },
-            {
-              "v": "CHANDIGARH",
-              "n": 1
-            },
-            {
-              "v": "DELHI",
-              "n": 1
-            },
-            {
-              "v": "MADHYA PRADESH",
+              "v": "WEST BENGAL",
               "n": 1
             },
             {
@@ -4315,39 +4277,11 @@
               "n": 1
             },
             {
-              "v": "DADRA,NAGAR HAVELI,DAMAN & DIU",
+              "v": "DELHI",
               "n": 1
             },
             {
-              "v": "MIZORAM",
-              "n": 1
-            },
-            {
-              "v": "ARUNACHAL PRADESH",
-              "n": 1
-            },
-            {
-              "v": "UTTAR PRADESH",
-              "n": 1
-            },
-            {
-              "v": "MEGHALAYA",
-              "n": 1
-            },
-            {
-              "v": "ODISHA",
-              "n": 1
-            },
-            {
-              "v": "CHHATTISGARH",
-              "n": 1
-            },
-            {
-              "v": "HIMACHAL PRADESH",
-              "n": 1
-            },
-            {
-              "v": "PUNJAB",
+              "v": "MADHYA PRADESH",
               "n": 1
             },
             {
@@ -4368,6 +4302,74 @@
             },
             {
               "v": "UTTARAKHAND",
+              "n": 1
+            },
+            {
+              "v": "KARNATAKA",
+              "n": 1
+            },
+            {
+              "v": "MANIPUR",
+              "n": 1
+            },
+            {
+              "v": "TELANGANA",
+              "n": 1
+            },
+            {
+              "v": "SIKKIM",
+              "n": 1
+            },
+            {
+              "v": "BIHAR",
+              "n": 1
+            },
+            {
+              "v": "ODISHA",
+              "n": 1
+            },
+            {
+              "v": "ARUNACHAL PRADESH",
+              "n": 1
+            },
+            {
+              "v": "RAJASTHAN",
+              "n": 1
+            },
+            {
+              "v": "CHANDIGARH",
+              "n": 1
+            },
+            {
+              "v": "LAKSHADWEEP",
+              "n": 1
+            },
+            {
+              "v": "GUJARAT",
+              "n": 1
+            },
+            {
+              "v": "HARYANA",
+              "n": 1
+            },
+            {
+              "v": "ANDAMAN & NICOBAR",
+              "n": 1
+            },
+            {
+              "v": "UTTAR PRADESH",
+              "n": 1
+            },
+            {
+              "v": "MEGHALAYA",
+              "n": 1
+            },
+            {
+              "v": "DADRA,NAGAR HAVELI,DAMAN & DIU",
+              "n": 1
+            },
+            {
+              "v": "MIZORAM",
               "n": 1
             },
             {
@@ -4395,43 +4397,15 @@
               "n": 1
             },
             {
-              "v": "TELANGANA",
+              "v": "PUNJAB",
               "n": 1
             },
             {
-              "v": "SIKKIM",
+              "v": "CHHATTISGARH",
               "n": 1
             },
             {
-              "v": "BIHAR",
-              "n": 1
-            },
-            {
-              "v": "WEST BENGAL",
-              "n": 1
-            },
-            {
-              "v": "KARNATAKA",
-              "n": 1
-            },
-            {
-              "v": "MANIPUR",
-              "n": 1
-            },
-            {
-              "v": "LAKSHADWEEP",
-              "n": 1
-            },
-            {
-              "v": "GUJARAT",
-              "n": 1
-            },
-            {
-              "v": "HARYANA",
-              "n": 1
-            },
-            {
-              "v": "ANDAMAN & NICOBAR",
+              "v": "HIMACHAL PRADESH",
               "n": 1
             }
           ]
@@ -4453,27 +4427,15 @@
               "n": 1
             },
             {
-              "v": "29",
+              "v": "04",
               "n": 1
             },
             {
-              "v": "02",
+              "v": "06",
               "n": 1
             },
             {
-              "v": "14",
-              "n": 1
-            },
-            {
-              "v": "03",
-              "n": 1
-            },
-            {
-              "v": "17",
-              "n": 1
-            },
-            {
-              "v": "16",
+              "v": "12",
               "n": 1
             },
             {
@@ -4489,6 +4451,22 @@
               "n": 1
             },
             {
+              "v": "34",
+              "n": 1
+            },
+            {
+              "v": "22",
+              "n": 1
+            },
+            {
+              "v": "18",
+              "n": 1
+            },
+            {
+              "v": "11",
+              "n": 1
+            },
+            {
               "v": "33",
               "n": 1
             },
@@ -4497,7 +4475,47 @@
               "n": 1
             },
             {
-              "v": "11",
+              "v": "29",
+              "n": 1
+            },
+            {
+              "v": "02",
+              "n": 1
+            },
+            {
+              "v": "14",
+              "n": 1
+            },
+            {
+              "v": "32",
+              "n": 1
+            },
+            {
+              "v": "38",
+              "n": 1
+            },
+            {
+              "v": "23",
+              "n": 1
+            },
+            {
+              "v": "19",
+              "n": 1
+            },
+            {
+              "v": "13",
+              "n": 1
+            },
+            {
+              "v": "03",
+              "n": 1
+            },
+            {
+              "v": "17",
+              "n": 1
+            },
+            {
+              "v": "16",
               "n": 1
             },
             {
@@ -4529,51 +4547,7 @@
               "n": 1
             },
             {
-              "v": "32",
-              "n": 1
-            },
-            {
-              "v": "38",
-              "n": 1
-            },
-            {
-              "v": "23",
-              "n": 1
-            },
-            {
-              "v": "19",
-              "n": 1
-            },
-            {
-              "v": "13",
-              "n": 1
-            },
-            {
               "v": "21",
-              "n": 1
-            },
-            {
-              "v": "04",
-              "n": 1
-            },
-            {
-              "v": "06",
-              "n": 1
-            },
-            {
-              "v": "12",
-              "n": 1
-            },
-            {
-              "v": "34",
-              "n": 1
-            },
-            {
-              "v": "22",
-              "n": 1
-            },
-            {
-              "v": "18",
               "n": 1
             },
             {
@@ -4599,31 +4573,31 @@
           "max": 38,
           "top_values": [
             {
-              "v": 12,
+              "v": 34,
               "n": 1
             },
             {
-              "v": 36,
+              "v": 22,
               "n": 1
             },
             {
-              "v": 6,
+              "v": 1,
               "n": 1
             },
             {
-              "v": 11,
+              "v": 18,
               "n": 1
             },
             {
-              "v": 8,
+              "v": 24,
               "n": 1
             },
             {
-              "v": 17,
+              "v": 37,
               "n": 1
             },
             {
-              "v": 16,
+              "v": 35,
               "n": 1
             },
             {
@@ -4639,10 +4613,6 @@
               "n": 1
             },
             {
-              "v": 21,
-              "n": 1
-            },
-            {
               "v": 5,
               "n": 1
             },
@@ -4655,23 +4625,43 @@
               "n": 1
             },
             {
-              "v": 33,
+              "v": 21,
               "n": 1
             },
             {
-              "v": 10,
+              "v": 12,
               "n": 1
             },
             {
-              "v": 34,
+              "v": 3,
               "n": 1
             },
             {
-              "v": 20,
+              "v": 4,
               "n": 1
             },
             {
-              "v": 15,
+              "v": 11,
+              "n": 1
+            },
+            {
+              "v": 36,
+              "n": 1
+            },
+            {
+              "v": 6,
+              "n": 1
+            },
+            {
+              "v": 8,
+              "n": 1
+            },
+            {
+              "v": 17,
+              "n": 1
+            },
+            {
+              "v": 16,
               "n": 1
             },
             {
@@ -4691,15 +4681,11 @@
               "n": 1
             },
             {
-              "v": 24,
+              "v": 33,
               "n": 1
             },
             {
-              "v": 37,
-              "n": 1
-            },
-            {
-              "v": 35,
+              "v": 10,
               "n": 1
             },
             {
@@ -4723,23 +4709,11 @@
               "n": 1
             },
             {
-              "v": 22,
+              "v": 20,
               "n": 1
             },
             {
-              "v": 1,
-              "n": 1
-            },
-            {
-              "v": 18,
-              "n": 1
-            },
-            {
-              "v": 3,
-              "n": 1
-            },
-            {
-              "v": 4,
+              "v": 15,
               "n": 1
             }
           ]
@@ -4753,14 +4727,6 @@
           "max": "West Bengal",
           "top_values": [
             {
-              "v": "Tamil nadu",
-              "n": 1
-            },
-            {
-              "v": "Kerala",
-              "n": 1
-            },
-            {
               "v": "Chhattisgarh",
               "n": 1
             },
@@ -4769,71 +4735,11 @@
               "n": 1
             },
             {
-              "v": "Lakshadweep",
+              "v": "Madhya Pradesh",
               "n": 1
             },
             {
-              "v": "Delhi",
-              "n": 1
-            },
-            {
-              "v": "Mizoram",
-              "n": 1
-            },
-            {
-              "v": "Karnataka",
-              "n": 1
-            },
-            {
-              "v": "Punjab",
-              "n": 1
-            },
-            {
-              "v": "Odisha",
-              "n": 1
-            },
-            {
-              "v": "Gujarat",
-              "n": 1
-            },
-            {
-              "v": "Ladakh",
-              "n": 1
-            },
-            {
-              "v": "Uttar Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Jharkhand",
-              "n": 1
-            },
-            {
-              "v": "Andaman & Nicobar",
-              "n": 1
-            },
-            {
-              "v": "Andhra Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Maharashtra",
-              "n": 1
-            },
-            {
-              "v": "Rajasthan",
-              "n": 1
-            },
-            {
-              "v": "Bihar",
-              "n": 1
-            },
-            {
-              "v": "Uttarakhand",
-              "n": 1
-            },
-            {
-              "v": "Assam",
+              "v": "Sikkim",
               "n": 1
             },
             {
@@ -4853,7 +4759,15 @@
               "n": 1
             },
             {
-              "v": "Dadra,Nagar Haveli,Daman & Diu",
+              "v": "Lakshadweep",
+              "n": 1
+            },
+            {
+              "v": "Delhi",
+              "n": 1
+            },
+            {
+              "v": "Mizoram",
               "n": 1
             },
             {
@@ -4866,14 +4780,6 @@
             },
             {
               "v": "Nagaland",
-              "n": 1
-            },
-            {
-              "v": "Madhya Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Sikkim",
               "n": 1
             },
             {
@@ -4895,6 +4801,74 @@
             {
               "v": "Meghalaya",
               "n": 1
+            },
+            {
+              "v": "Uttarakhand",
+              "n": 1
+            },
+            {
+              "v": "Assam",
+              "n": 1
+            },
+            {
+              "v": "Rajasthan",
+              "n": 1
+            },
+            {
+              "v": "Bihar",
+              "n": 1
+            },
+            {
+              "v": "Kerala",
+              "n": 1
+            },
+            {
+              "v": "Tamil nadu",
+              "n": 1
+            },
+            {
+              "v": "Andaman & Nicobar",
+              "n": 1
+            },
+            {
+              "v": "Dadra,Nagar Haveli,Daman & Diu",
+              "n": 1
+            },
+            {
+              "v": "Andhra Pradesh",
+              "n": 1
+            },
+            {
+              "v": "Maharashtra",
+              "n": 1
+            },
+            {
+              "v": "Gujarat",
+              "n": 1
+            },
+            {
+              "v": "Ladakh",
+              "n": 1
+            },
+            {
+              "v": "Uttar Pradesh",
+              "n": 1
+            },
+            {
+              "v": "Jharkhand",
+              "n": 1
+            },
+            {
+              "v": "Karnataka",
+              "n": 1
+            },
+            {
+              "v": "Punjab",
+              "n": 1
+            },
+            {
+              "v": "Odisha",
+              "n": 1
             }
           ]
         },
@@ -4911,39 +4885,19 @@
               "n": 1
             },
             {
-              "v": "KERALA",
+              "v": "CHHATTISGARH",
               "n": 1
             },
             {
-              "v": "MAHARASHTRA",
+              "v": "HIMACHAL PRADESH",
               "n": 1
             },
             {
-              "v": "RAJASTHAN",
+              "v": "PUNJAB",
               "n": 1
             },
             {
-              "v": "CHANDIGARH",
-              "n": 1
-            },
-            {
-              "v": "KARNATAKA",
-              "n": 1
-            },
-            {
-              "v": "MANIPUR",
-              "n": 1
-            },
-            {
-              "v": "TELANGANA",
-              "n": 1
-            },
-            {
-              "v": "SIKKIM",
-              "n": 1
-            },
-            {
-              "v": "BIHAR",
+              "v": "ARUNACHAL PRADESH",
               "n": 1
             },
             {
@@ -4955,75 +4909,11 @@
               "n": 1
             },
             {
-              "v": "CHHATTISGARH",
+              "v": "KARNATAKA",
               "n": 1
             },
             {
-              "v": "HIMACHAL PRADESH",
-              "n": 1
-            },
-            {
-              "v": "DELHI",
-              "n": 1
-            },
-            {
-              "v": "MADHYA PRADESH",
-              "n": 1
-            },
-            {
-              "v": "PUNJAB",
-              "n": 1
-            },
-            {
-              "v": "UTTAR PRADESH",
-              "n": 1
-            },
-            {
-              "v": "MEGHALAYA",
-              "n": 1
-            },
-            {
-              "v": "LAKSHADWEEP",
-              "n": 1
-            },
-            {
-              "v": "GUJARAT",
-              "n": 1
-            },
-            {
-              "v": "HARYANA",
-              "n": 1
-            },
-            {
-              "v": "ANDAMAN & NICOBAR",
-              "n": 1
-            },
-            {
-              "v": "PUDUCHERRY",
-              "n": 1
-            },
-            {
-              "v": "TAMIL NADU",
-              "n": 1
-            },
-            {
-              "v": "GOA",
-              "n": 1
-            },
-            {
-              "v": "LADAKH",
-              "n": 1
-            },
-            {
-              "v": "UTTARAKHAND",
-              "n": 1
-            },
-            {
-              "v": "ARUNACHAL PRADESH",
-              "n": 1
-            },
-            {
-              "v": "ODISHA",
+              "v": "MANIPUR",
               "n": 1
             },
             {
@@ -5049,6 +4939,90 @@
             {
               "v": "TRIPURA",
               "n": 1
+            },
+            {
+              "v": "KERALA",
+              "n": 1
+            },
+            {
+              "v": "MAHARASHTRA",
+              "n": 1
+            },
+            {
+              "v": "ODISHA",
+              "n": 1
+            },
+            {
+              "v": "DELHI",
+              "n": 1
+            },
+            {
+              "v": "MADHYA PRADESH",
+              "n": 1
+            },
+            {
+              "v": "UTTAR PRADESH",
+              "n": 1
+            },
+            {
+              "v": "MEGHALAYA",
+              "n": 1
+            },
+            {
+              "v": "RAJASTHAN",
+              "n": 1
+            },
+            {
+              "v": "CHANDIGARH",
+              "n": 1
+            },
+            {
+              "v": "PUDUCHERRY",
+              "n": 1
+            },
+            {
+              "v": "TAMIL NADU",
+              "n": 1
+            },
+            {
+              "v": "GOA",
+              "n": 1
+            },
+            {
+              "v": "LADAKH",
+              "n": 1
+            },
+            {
+              "v": "UTTARAKHAND",
+              "n": 1
+            },
+            {
+              "v": "LAKSHADWEEP",
+              "n": 1
+            },
+            {
+              "v": "GUJARAT",
+              "n": 1
+            },
+            {
+              "v": "HARYANA",
+              "n": 1
+            },
+            {
+              "v": "ANDAMAN & NICOBAR",
+              "n": 1
+            },
+            {
+              "v": "TELANGANA",
+              "n": 1
+            },
+            {
+              "v": "SIKKIM",
+              "n": 1
+            },
+            {
+              "v": "BIHAR",
+              "n": 1
             }
           ]
         },
@@ -5061,27 +5035,87 @@
           "max": 36,
           "top_values": [
             {
+              "v": 16,
+              "n": 1
+            },
+            {
+              "v": 8,
+              "n": 1
+            },
+            {
+              "v": 17,
+              "n": 1
+            },
+            {
+              "v": 2,
+              "n": 1
+            },
+            {
+              "v": 30,
+              "n": 1
+            },
+            {
+              "v": 27,
+              "n": 1
+            },
+            {
+              "v": 31,
+              "n": 1
+            },
+            {
               "v": 21,
               "n": 1
             },
             {
-              "v": 15,
+              "v": 35,
               "n": 1
             },
             {
-              "v": 20,
+              "v": 24,
               "n": 1
             },
             {
-              "v": 12,
+              "v": 34,
               "n": 1
             },
             {
-              "v": 6,
+              "v": 7,
               "n": 1
             },
             {
-              "v": 36,
+              "v": 9,
+              "n": 1
+            },
+            {
+              "v": 5,
+              "n": 1
+            },
+            {
+              "v": 11,
+              "n": 1
+            },
+            {
+              "v": 25,
+              "n": 1
+            },
+            {
+              "v": 10,
+              "n": 1
+            },
+            {
+              "v": 33,
+              "n": 1
+            },
+            {
+              "v": 18,
+              "n": 1
+            },
+            {
+              "v": 22,
+              "n": 1
+            },
+            {
+              "v": 1,
               "n": 1
             },
             {
@@ -5105,83 +5139,15 @@
               "n": 1
             },
             {
-              "v": 18,
+              "v": 6,
               "n": 1
             },
             {
-              "v": 22,
+              "v": 36,
               "n": 1
             },
             {
-              "v": 1,
-              "n": 1
-            },
-            {
-              "v": 3,
-              "n": 1
-            },
-            {
-              "v": 4,
-              "n": 1
-            },
-            {
-              "v": 11,
-              "n": 1
-            },
-            {
-              "v": 34,
-              "n": 1
-            },
-            {
-              "v": 16,
-              "n": 1
-            },
-            {
-              "v": 8,
-              "n": 1
-            },
-            {
-              "v": 17,
-              "n": 1
-            },
-            {
-              "v": 7,
-              "n": 1
-            },
-            {
-              "v": 9,
-              "n": 1
-            },
-            {
-              "v": 5,
-              "n": 1
-            },
-            {
-              "v": 25,
-              "n": 1
-            },
-            {
-              "v": 10,
-              "n": 1
-            },
-            {
-              "v": 33,
-              "n": 1
-            },
-            {
-              "v": 2,
-              "n": 1
-            },
-            {
-              "v": 30,
-              "n": 1
-            },
-            {
-              "v": 27,
-              "n": 1
-            },
-            {
-              "v": 31,
+              "v": 12,
               "n": 1
             },
             {
@@ -5197,11 +5163,19 @@
               "n": 1
             },
             {
-              "v": 35,
+              "v": 15,
               "n": 1
             },
             {
-              "v": 24,
+              "v": 20,
+              "n": 1
+            },
+            {
+              "v": 3,
+              "n": 1
+            },
+            {
+              "v": 4,
               "n": 1
             }
           ]
@@ -5239,6 +5213,22 @@
           "max": 8199150.436219864,
           "top_values": [
             {
+              "v": 5767382.952231494,
+              "n": 1
+            },
+            {
+              "v": 6986715.763042983,
+              "n": 1
+            },
+            {
+              "v": 1445212.6114098737,
+              "n": 1
+            },
+            {
+              "v": 1305743.6492741685,
+              "n": 1
+            },
+            {
               "v": 3691262.239632214,
               "n": 1
             },
@@ -5248,62 +5238,6 @@
             },
             {
               "v": 2963355.7852354585,
-              "n": 1
-            },
-            {
-              "v": 3627756.7504065335,
-              "n": 1
-            },
-            {
-              "v": 3362506.6182253817,
-              "n": 1
-            },
-            {
-              "v": 2654010.5642531104,
-              "n": 1
-            },
-            {
-              "v": 5945590.302377821,
-              "n": 1
-            },
-            {
-              "v": 1765005.5137781699,
-              "n": 1
-            },
-            {
-              "v": 3727338.8046791204,
-              "n": 1
-            },
-            {
-              "v": 423019.02810073394,
-              "n": 1
-            },
-            {
-              "v": 1131857.3004578887,
-              "n": 1
-            },
-            {
-              "v": 3937758.1759938635,
-              "n": 1
-            },
-            {
-              "v": 1940079.6246092285,
-              "n": 1
-            },
-            {
-              "v": 3656928.816882231,
-              "n": 1
-            },
-            {
-              "v": 534841.8751139762,
-              "n": 1
-            },
-            {
-              "v": 4851482.322101016,
-              "n": 1
-            },
-            {
-              "v": 347804.26272029406,
               "n": 1
             },
             {
@@ -5335,7 +5269,71 @@
               "n": 1
             },
             {
+              "v": 347804.26272029406,
+              "n": 1
+            },
+            {
+              "v": 2654010.5642531104,
+              "n": 1
+            },
+            {
+              "v": 5945590.302377821,
+              "n": 1
+            },
+            {
+              "v": 1765005.5137781699,
+              "n": 1
+            },
+            {
+              "v": 3727338.8046791204,
+              "n": 1
+            },
+            {
               "v": 1049358.6037059696,
+              "n": 1
+            },
+            {
+              "v": 1940079.6246092285,
+              "n": 1
+            },
+            {
+              "v": 3656928.816882231,
+              "n": 1
+            },
+            {
+              "v": 534841.8751139762,
+              "n": 1
+            },
+            {
+              "v": 6147365.473505214,
+              "n": 1
+            },
+            {
+              "v": 6579818.404422868,
+              "n": 1
+            },
+            {
+              "v": 423019.02810073394,
+              "n": 1
+            },
+            {
+              "v": 1131857.3004578887,
+              "n": 1
+            },
+            {
+              "v": 3937758.1759938635,
+              "n": 1
+            },
+            {
+              "v": 3627756.7504065335,
+              "n": 1
+            },
+            {
+              "v": 3362506.6182253817,
+              "n": 1
+            },
+            {
+              "v": 4851482.322101016,
               "n": 1
             },
             {
@@ -5357,30 +5355,6 @@
             {
               "v": 1019102.8555496905,
               "n": 1
-            },
-            {
-              "v": 5767382.952231494,
-              "n": 1
-            },
-            {
-              "v": 6986715.763042983,
-              "n": 1
-            },
-            {
-              "v": 1445212.6114098737,
-              "n": 1
-            },
-            {
-              "v": 1305743.6492741685,
-              "n": 1
-            },
-            {
-              "v": 6147365.473505214,
-              "n": 1
-            },
-            {
-              "v": 6579818.404422868,
-              "n": 1
             }
           ]
         },
@@ -5392,42 +5366,6 @@
           "min": 31132861.649632555,
           "max": 429971589919.2261,
           "top_values": [
-            {
-              "v": 71691838243.6549,
-              "n": 1
-            },
-            {
-              "v": 1935633978.0311139,
-              "n": 1
-            },
-            {
-              "v": 102715650616.05867,
-              "n": 1
-            },
-            {
-              "v": 27649269092.73762,
-              "n": 1
-            },
-            {
-              "v": 304575234931.07745,
-              "n": 1
-            },
-            {
-              "v": 9070963317.360067,
-              "n": 1
-            },
-            {
-              "v": 206400848840.97125,
-              "n": 1
-            },
-            {
-              "v": 31132861.649632555,
-              "n": 1
-            },
-            {
-              "v": 79129960790.28015,
-              "n": 1
-            },
             {
               "v": 40460733017.44443,
               "n": 1
@@ -5441,47 +5379,19 @@
               "n": 1
             },
             {
-              "v": 98104009174.95964,
+              "v": 304575234931.07745,
               "n": 1
             },
             {
-              "v": 178289129797.5117,
+              "v": 9070963317.360067,
               "n": 1
             },
             {
-              "v": 530362564.4613942,
+              "v": 347868466414.9896,
               "n": 1
             },
             {
-              "v": 216970754025.63974,
-              "n": 1
-            },
-            {
-              "v": 8121470549.926832,
-              "n": 1
-            },
-            {
-              "v": 177047556133.7048,
-              "n": 1
-            },
-            {
-              "v": 685751115.4294983,
-              "n": 1
-            },
-            {
-              "v": 429971589919.2261,
-              "n": 1
-            },
-            {
-              "v": 77791985655.66135,
-              "n": 1
-            },
-            {
-              "v": 95626932120.56497,
-              "n": 1
-            },
-            {
-              "v": 135846782201.40788,
+              "v": 116431248518.33426,
               "n": 1
             },
             {
@@ -5494,6 +5404,14 @@
             },
             {
               "v": 12527440690.60065,
+              "n": 1
+            },
+            {
+              "v": 135846782201.40788,
+              "n": 1
+            },
+            {
+              "v": 20643998182.367287,
               "n": 1
             },
             {
@@ -5517,15 +5435,47 @@
               "n": 1
             },
             {
-              "v": 347868466414.9896,
+              "v": 177047556133.7048,
               "n": 1
             },
             {
-              "v": 116431248518.33426,
+              "v": 685751115.4294983,
               "n": 1
             },
             {
-              "v": 20643998182.367287,
+              "v": 429971589919.2261,
+              "n": 1
+            },
+            {
+              "v": 77791985655.66135,
+              "n": 1
+            },
+            {
+              "v": 95626932120.56497,
+              "n": 1
+            },
+            {
+              "v": 530362564.4613942,
+              "n": 1
+            },
+            {
+              "v": 216970754025.63974,
+              "n": 1
+            },
+            {
+              "v": 71691838243.6549,
+              "n": 1
+            },
+            {
+              "v": 1935633978.0311139,
+              "n": 1
+            },
+            {
+              "v": 102715650616.05867,
+              "n": 1
+            },
+            {
+              "v": 27649269092.73762,
               "n": 1
             },
             {
@@ -5534,6 +5484,30 @@
             },
             {
               "v": 68561182525.645645,
+              "n": 1
+            },
+            {
+              "v": 206400848840.97125,
+              "n": 1
+            },
+            {
+              "v": 8121470549.926832,
+              "n": 1
+            },
+            {
+              "v": 98104009174.95964,
+              "n": 1
+            },
+            {
+              "v": 178289129797.5117,
+              "n": 1
+            },
+            {
+              "v": 31132861.649632555,
+              "n": 1
+            },
+            {
+              "v": 79129960790.28015,
               "n": 1
             }
           ]
@@ -5558,75 +5532,23 @@
           "max": "WEST BENGAL",
           "top_values": [
             {
-              "v": "ANDHRA PRADESH",
+              "v": "D\u0100DRA & NAGAR HAVELI & DAM\u0100N & DIU",
               "n": 1
             },
             {
-              "v": "CHHAtT\u012aSGARH",
+              "v": "DELHI",
               "n": 1
             },
             {
-              "v": "GUJAR\u0100T",
+              "v": "MADHYA PRADESH",
               "n": 1
             },
             {
-              "v": "ASSAM",
+              "v": "JH\u0100RKHAND",
               "n": 1
             },
             {
-              "v": "TRIPURA",
-              "n": 1
-            },
-            {
-              "v": "HIM\u0100CHAL PRADESH",
-              "n": 1
-            },
-            {
-              "v": "SIKKIM",
-              "n": 1
-            },
-            {
-              "v": "PUNJAB",
-              "n": 1
-            },
-            {
-              "v": "LAD\u0100KH",
-              "n": 1
-            },
-            {
-              "v": "LAKSHADWEEP",
-              "n": 1
-            },
-            {
-              "v": "CHAND\u012aGARH",
-              "n": 1
-            },
-            {
-              "v": "ANDAMAN & NICOBAR",
-              "n": 1
-            },
-            {
-              "v": "KERALA",
-              "n": 1
-            },
-            {
-              "v": "N\u0100G\u0100LAND",
-              "n": 1
-            },
-            {
-              "v": "ODISHA",
-              "n": 1
-            },
-            {
-              "v": "TELANG\u0100NA",
-              "n": 1
-            },
-            {
-              "v": "HARY\u0100NA",
-              "n": 1
-            },
-            {
-              "v": "DISPUTED (MADHYA PRADESH & GUJAR\u0100T)",
+              "v": "ARUN\u0100CHAL PRADESH",
               "n": 1
             },
             {
@@ -5650,6 +5572,22 @@
               "n": 1
             },
             {
+              "v": "HIM\u0100CHAL PRADESH",
+              "n": 1
+            },
+            {
+              "v": "SIKKIM",
+              "n": 1
+            },
+            {
+              "v": "PUNJAB",
+              "n": 1
+            },
+            {
+              "v": "LAD\u0100KH",
+              "n": 1
+            },
+            {
               "v": "PUDUCHERRY",
               "n": 1
             },
@@ -5670,35 +5608,43 @@
               "n": 1
             },
             {
-              "v": "D\u0100DRA & NAGAR HAVELI & DAM\u0100N & DIU",
+              "v": "KERALA",
               "n": 1
             },
             {
-              "v": "DELHI",
+              "v": "N\u0100G\u0100LAND",
               "n": 1
             },
             {
-              "v": "MADHYA PRADESH",
+              "v": "ODISHA",
               "n": 1
             },
             {
-              "v": "JH\u0100RKHAND",
+              "v": "ANDHRA PRADESH",
               "n": 1
             },
             {
-              "v": "ARUN\u0100CHAL PRADESH",
+              "v": "CHHAtT\u012aSGARH",
               "n": 1
             },
             {
-              "v": "MAH\u0100R\u0100SHTRA",
+              "v": "GUJAR\u0100T",
               "n": 1
             },
             {
-              "v": "JAMMU AND KASHM\u012aR",
+              "v": "ASSAM",
               "n": 1
             },
             {
-              "v": "UTTAR PRADESH",
+              "v": "TRIPURA",
+              "n": 1
+            },
+            {
+              "v": "TELANG\u0100NA",
+              "n": 1
+            },
+            {
+              "v": "HARY\u0100NA",
               "n": 1
             },
             {
@@ -5716,6 +5662,34 @@
             {
               "v": "WEST BENGAL",
               "n": 1
+            },
+            {
+              "v": "LAKSHADWEEP",
+              "n": 1
+            },
+            {
+              "v": "CHAND\u012aGARH",
+              "n": 1
+            },
+            {
+              "v": "ANDAMAN & NICOBAR",
+              "n": 1
+            },
+            {
+              "v": "MAH\u0100R\u0100SHTRA",
+              "n": 1
+            },
+            {
+              "v": "JAMMU AND KASHM\u012aR",
+              "n": 1
+            },
+            {
+              "v": "UTTAR PRADESH",
+              "n": 1
+            },
+            {
+              "v": "DISPUTED (MADHYA PRADESH & GUJAR\u0100T)",
+              "n": 1
             }
           ]
         },
@@ -5732,47 +5706,23 @@
               "n": 4
             },
             {
-              "v": 11,
+              "v": 34,
               "n": 1
             },
             {
-              "v": 7,
-              "n": 1
-            },
-            {
-              "v": 15,
-              "n": 1
-            },
-            {
-              "v": 12,
-              "n": 1
-            },
-            {
-              "v": 10,
-              "n": 1
-            },
-            {
-              "v": 21,
-              "n": 1
-            },
-            {
-              "v": 37,
-              "n": 1
-            },
-            {
-              "v": 24,
-              "n": 1
-            },
-            {
-              "v": 35,
-              "n": 1
-            },
-            {
-              "v": 33,
+              "v": 4,
               "n": 1
             },
             {
               "v": 36,
+              "n": 1
+            },
+            {
+              "v": 6,
+              "n": 1
+            },
+            {
+              "v": 12,
               "n": 1
             },
             {
@@ -5808,43 +5758,15 @@
               "n": 1
             },
             {
-              "v": 29,
+              "v": 11,
               "n": 1
             },
             {
-              "v": 28,
+              "v": 33,
               "n": 1
             },
             {
-              "v": 14,
-              "n": 1
-            },
-            {
-              "v": 34,
-              "n": 1
-            },
-            {
-              "v": 6,
-              "n": 1
-            },
-            {
-              "v": 3,
-              "n": 1
-            },
-            {
-              "v": 4,
-              "n": 1
-            },
-            {
-              "v": 8,
-              "n": 1
-            },
-            {
-              "v": 17,
-              "n": 1
-            },
-            {
-              "v": 16,
+              "v": 10,
               "n": 1
             },
             {
@@ -5864,7 +5786,23 @@
               "n": 1
             },
             {
-              "v": 5,
+              "v": 24,
+              "n": 1
+            },
+            {
+              "v": 37,
+              "n": 1
+            },
+            {
+              "v": 35,
+              "n": 1
+            },
+            {
+              "v": 20,
+              "n": 1
+            },
+            {
+              "v": 21,
               "n": 1
             },
             {
@@ -5872,7 +5810,43 @@
               "n": 1
             },
             {
-              "v": 20,
+              "v": 5,
+              "n": 1
+            },
+            {
+              "v": 14,
+              "n": 1
+            },
+            {
+              "v": 7,
+              "n": 1
+            },
+            {
+              "v": 29,
+              "n": 1
+            },
+            {
+              "v": 28,
+              "n": 1
+            },
+            {
+              "v": 8,
+              "n": 1
+            },
+            {
+              "v": 17,
+              "n": 1
+            },
+            {
+              "v": 16,
+              "n": 1
+            },
+            {
+              "v": 3,
+              "n": 1
+            },
+            {
+              "v": 15,
               "n": 1
             }
           ]
@@ -5886,55 +5860,19 @@
           "max": 7367386.55486,
           "top_values": [
             {
-              "v": 3650797.43791,
+              "v": 5255584.61647,
               "n": 1
             },
             {
-              "v": 234859.24611,
+              "v": 7367386.55486,
               "n": 1
             },
             {
-              "v": 321582.368932,
+              "v": 3228020.47459,
               "n": 1
             },
             {
-              "v": 62113.0763786,
-              "n": 1
-            },
-            {
-              "v": 3051893.17033,
-              "n": 1
-            },
-            {
-              "v": 18063.0554287,
-              "n": 1
-            },
-            {
-              "v": 1294185.60295,
-              "n": 1
-            },
-            {
-              "v": 5531548.43409,
-              "n": 1
-            },
-            {
-              "v": 19515.3848779,
-              "n": 1
-            },
-            {
-              "v": 2980745.4907,
-              "n": 1
-            },
-            {
-              "v": 144322.282827,
-              "n": 1
-            },
-            {
-              "v": 4653505.04251,
-              "n": 1
-            },
-            {
-              "v": 43844.4495976,
+              "v": 1000977.86666,
               "n": 1
             },
             {
@@ -5954,7 +5892,31 @@
               "n": 1
             },
             {
-              "v": 1869642.34988,
+              "v": 321582.368932,
+              "n": 1
+            },
+            {
+              "v": 62113.0763786,
+              "n": 1
+            },
+            {
+              "v": 3051893.17033,
+              "n": 1
+            },
+            {
+              "v": 2489986.05555,
+              "n": 1
+            },
+            {
+              "v": 144322.282827,
+              "n": 1
+            },
+            {
+              "v": 4653505.04251,
+              "n": 1
+            },
+            {
+              "v": 43844.4495976,
               "n": 1
             },
             {
@@ -5978,47 +5940,23 @@
               "n": 1
             },
             {
-              "v": 2489986.05555,
+              "v": 18063.0554287,
               "n": 1
             },
             {
-              "v": 5255584.61647,
+              "v": 1294185.60295,
               "n": 1
             },
             {
-              "v": 7367386.55486,
+              "v": 3650797.43791,
               "n": 1
             },
             {
-              "v": 3228020.47459,
+              "v": 234859.24611,
               "n": 1
             },
             {
-              "v": 1000977.86666,
-              "n": 1
-            },
-            {
-              "v": 466580.959052,
-              "n": 1
-            },
-            {
-              "v": 5334646.8294,
-              "n": 1
-            },
-            {
-              "v": 3027573.76649,
-              "n": 1
-            },
-            {
-              "v": 1460877.66476,
-              "n": 1
-            },
-            {
-              "v": 5962126.07767,
-              "n": 1
-            },
-            {
-              "v": 1181275.04581,
+              "v": 1869642.34988,
               "n": 1
             },
             {
@@ -6043,6 +5981,42 @@
             },
             {
               "v": 2618521.65572,
+              "n": 1
+            },
+            {
+              "v": 1460877.66476,
+              "n": 1
+            },
+            {
+              "v": 5962126.07767,
+              "n": 1
+            },
+            {
+              "v": 1181275.04581,
+              "n": 1
+            },
+            {
+              "v": 5334646.8294,
+              "n": 1
+            },
+            {
+              "v": 3027573.76649,
+              "n": 1
+            },
+            {
+              "v": 5531548.43409,
+              "n": 1
+            },
+            {
+              "v": 19515.3848779,
+              "n": 1
+            },
+            {
+              "v": 2980745.4907,
+              "n": 1
+            },
+            {
+              "v": 466580.959052,
               "n": 1
             }
           ]
@@ -6072,23 +6046,15 @@
               "n": 1
             },
             {
-              "v": 111867387.146,
+              "v": 15253036.1617,
               "n": 1
             },
             {
-              "v": 296496286032.0,
+              "v": 82235861170.0,
               "n": 1
             },
             {
-              "v": 150149190526.0,
-              "n": 1
-            },
-            {
-              "v": 109075825908.0,
-              "n": 1
-            },
-            {
-              "v": 3634036174.96,
+              "v": 21487419275.7,
               "n": 1
             },
             {
@@ -6097,10 +6063,6 @@
             },
             {
               "v": 20275401681.5,
-              "n": 1
-            },
-            {
-              "v": 30346283.2252,
               "n": 1
             },
             {
@@ -6116,27 +6078,11 @@
               "n": 1
             },
             {
-              "v": 21487419275.7,
+              "v": 131451435845.0,
               "n": 1
             },
             {
-              "v": 168011409245.0,
-              "n": 1
-            },
-            {
-              "v": 51964492974.6,
-              "n": 1
-            },
-            {
-              "v": 232445439155.0,
-              "n": 1
-            },
-            {
-              "v": 42847010743.6,
-              "n": 1
-            },
-            {
-              "v": 6853415168.2,
+              "v": 90616372590.8,
               "n": 1
             },
             {
@@ -6184,19 +6130,47 @@
               "n": 1
             },
             {
-              "v": 15253036.1617,
+              "v": 168011409245.0,
               "n": 1
             },
             {
-              "v": 82235861170.0,
+              "v": 51964492974.6,
               "n": 1
             },
             {
-              "v": 131451435845.0,
+              "v": 232445439155.0,
               "n": 1
             },
             {
-              "v": 90616372590.8,
+              "v": 42847010743.6,
+              "n": 1
+            },
+            {
+              "v": 6853415168.2,
+              "n": 1
+            },
+            {
+              "v": 111867387.146,
+              "n": 1
+            },
+            {
+              "v": 296496286032.0,
+              "n": 1
+            },
+            {
+              "v": 150149190526.0,
+              "n": 1
+            },
+            {
+              "v": 30346283.2252,
+              "n": 1
+            },
+            {
+              "v": 109075825908.0,
+              "n": 1
+            },
+            {
+              "v": 3634036174.96,
               "n": 1
             },
             {
@@ -6226,6 +6200,54 @@
           "max": "WEST BENGAL",
           "top_values": [
             {
+              "v": "PUDUCHERRY",
+              "n": 1
+            },
+            {
+              "v": "TAMIL NADU",
+              "n": 1
+            },
+            {
+              "v": "GOA",
+              "n": 1
+            },
+            {
+              "v": "LADAKH",
+              "n": 1
+            },
+            {
+              "v": "UTTARAKHAND",
+              "n": 1
+            },
+            {
+              "v": "DISPUTED (WEST BENGAL , BIHAR & JHARKHAND)",
+              "n": 1
+            },
+            {
+              "v": "KERALA",
+              "n": 1
+            },
+            {
+              "v": "MAHARASHTRA",
+              "n": 1
+            },
+            {
+              "v": "DADRA & NAGAR HAVELI & DAMAN & DIU",
+              "n": 1
+            },
+            {
+              "v": "MIZORAM",
+              "n": 1
+            },
+            {
+              "v": "DELHI",
+              "n": 1
+            },
+            {
+              "v": "MADHYA PRADESH",
+              "n": 1
+            },
+            {
               "v": "TELANGANA",
               "n": 1
             },
@@ -6238,7 +6260,31 @@
               "n": 1
             },
             {
-              "v": "ARUNACHAL PRADESH",
+              "v": "WEST BENGAL",
+              "n": 1
+            },
+            {
+              "v": "KARNATAKA",
+              "n": 1
+            },
+            {
+              "v": "DISPUTED (RAJATHAN & GUJARAT)",
+              "n": 1
+            },
+            {
+              "v": "MANIPUR",
+              "n": 1
+            },
+            {
+              "v": "PUNJAB",
+              "n": 1
+            },
+            {
+              "v": "CHHATTISGARH",
+              "n": 1
+            },
+            {
+              "v": "HIMACHAL PRADESH",
               "n": 1
             },
             {
@@ -6266,6 +6312,14 @@
               "n": 1
             },
             {
+              "v": "DISPUTED (MADHYA PRADESH & GUJARAT)",
+              "n": 1
+            },
+            {
+              "v": "ODISHA",
+              "n": 1
+            },
+            {
               "v": "RAJASTHAN",
               "n": 1
             },
@@ -6274,19 +6328,7 @@
               "n": 1
             },
             {
-              "v": "WEST BENGAL",
-              "n": 1
-            },
-            {
-              "v": "KERALA",
-              "n": 1
-            },
-            {
-              "v": "MAHARASHTRA",
-              "n": 1
-            },
-            {
-              "v": "DADRA & NAGAR HAVELI & DAMAN & DIU",
+              "v": "ARUNACHAL PRADESH",
               "n": 1
             },
             {
@@ -6306,42 +6348,6 @@
               "n": 1
             },
             {
-              "v": "PUNJAB",
-              "n": 1
-            },
-            {
-              "v": "PUDUCHERRY",
-              "n": 1
-            },
-            {
-              "v": "TAMIL NADU",
-              "n": 1
-            },
-            {
-              "v": "GOA",
-              "n": 1
-            },
-            {
-              "v": "LADAKH",
-              "n": 1
-            },
-            {
-              "v": "UTTARAKHAND",
-              "n": 1
-            },
-            {
-              "v": "DISPUTED (WEST BENGAL , BIHAR & JHARKHAND)",
-              "n": 1
-            },
-            {
-              "v": "DELHI",
-              "n": 1
-            },
-            {
-              "v": "MADHYA PRADESH",
-              "n": 1
-            },
-            {
               "v": "JAMMU AND KASHMIR",
               "n": 1
             },
@@ -6351,38 +6357,6 @@
             },
             {
               "v": "MEGHALAYA",
-              "n": 1
-            },
-            {
-              "v": "DISPUTED (MADHYA PRADESH & GUJARAT)",
-              "n": 1
-            },
-            {
-              "v": "ODISHA",
-              "n": 1
-            },
-            {
-              "v": "KARNATAKA",
-              "n": 1
-            },
-            {
-              "v": "DISPUTED (RAJATHAN & GUJARAT)",
-              "n": 1
-            },
-            {
-              "v": "MANIPUR",
-              "n": 1
-            },
-            {
-              "v": "MIZORAM",
-              "n": 1
-            },
-            {
-              "v": "CHHATTISGARH",
-              "n": 1
-            },
-            {
-              "v": "HIMACHAL PRADESH",
               "n": 1
             }
           ]
@@ -6415,15 +6389,99 @@
               "n": 1
             },
             {
+              "v": "Dadar Nagar& Haveli",
+              "n": 1
+            },
+            {
+              "v": "Gujarat",
+              "n": 1
+            },
+            {
+              "v": "Uttar Pradesh",
+              "n": 1
+            },
+            {
+              "v": "Jharkhand",
+              "n": 1
+            },
+            {
+              "v": "Kerala",
+              "n": 1
+            },
+            {
+              "v": "Union Territory of Ladakh",
+              "n": 1
+            },
+            {
+              "v": "Madhya Pradesh",
+              "n": 1
+            },
+            {
+              "v": "Sikkim",
+              "n": 1
+            },
+            {
+              "v": "Himachal Pradesh",
+              "n": 1
+            },
+            {
+              "v": "Arunachal Pradesh",
+              "n": 1
+            },
+            {
+              "v": "Manipur",
+              "n": 1
+            },
+            {
               "v": "Maharashtra",
               "n": 1
             },
             {
-              "v": "Andaman & Nicobar",
+              "v": "Haryana",
+              "n": 1
+            },
+            {
+              "v": "West Bengal",
+              "n": 1
+            },
+            {
+              "v": "Nagaland",
+              "n": 1
+            },
+            {
+              "v": "Lakshadweep",
+              "n": 1
+            },
+            {
+              "v": "Delhi",
+              "n": 1
+            },
+            {
+              "v": "Mizoram",
+              "n": 1
+            },
+            {
+              "v": "Uttarakhand",
+              "n": 1
+            },
+            {
+              "v": "Assam",
               "n": 1
             },
             {
               "v": "Orissa",
+              "n": 1
+            },
+            {
+              "v": "Karnataka",
+              "n": 1
+            },
+            {
+              "v": "Punjab",
+              "n": 1
+            },
+            {
+              "v": "Andaman & Nicobar",
               "n": 1
             },
             {
@@ -6451,87 +6509,11 @@
               "n": 1
             },
             {
-              "v": "Karnataka",
-              "n": 1
-            },
-            {
-              "v": "Punjab",
-              "n": 1
-            },
-            {
-              "v": "Uttarakhand",
-              "n": 1
-            },
-            {
-              "v": "Assam",
-              "n": 1
-            },
-            {
-              "v": "Haryana",
-              "n": 1
-            },
-            {
-              "v": "West Bengal",
-              "n": 1
-            },
-            {
-              "v": "Nagaland",
-              "n": 1
-            },
-            {
-              "v": "Kerala",
-              "n": 1
-            },
-            {
-              "v": "Union Territory of Ladakh",
-              "n": 1
-            },
-            {
               "v": "Andhra Pradesh",
               "n": 1
             },
             {
               "v": "Union Territory of Jammu and Kashmir",
-              "n": 1
-            },
-            {
-              "v": "Dadar Nagar& Haveli",
-              "n": 1
-            },
-            {
-              "v": "Gujarat",
-              "n": 1
-            },
-            {
-              "v": "Uttar Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Jharkhand",
-              "n": 1
-            },
-            {
-              "v": "Himachal Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Arunachal Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Manipur",
-              "n": 1
-            },
-            {
-              "v": "Lakshadweep",
-              "n": 1
-            },
-            {
-              "v": "Delhi",
-              "n": 1
-            },
-            {
-              "v": "Mizoram",
               "n": 1
             },
             {
@@ -6545,14 +6527,6 @@
             {
               "v": "Bihar",
               "n": 1
-            },
-            {
-              "v": "Madhya Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Sikkim",
-              "n": 1
             }
           ]
         },
@@ -6564,10 +6538,6 @@
           "min": "1",
           "max": "9",
           "top_values": [
-            {
-              "v": "21",
-              "n": 1
-            },
             {
               "v": "5",
               "n": 1
@@ -6581,11 +6551,107 @@
               "n": 1
             },
             {
+              "v": "22",
+              "n": 1
+            },
+            {
+              "v": "1",
+              "n": 1
+            },
+            {
+              "v": "18",
+              "n": 1
+            },
+            {
+              "v": "24",
+              "n": 1
+            },
+            {
+              "v": "37",
+              "n": 1
+            },
+            {
+              "v": "35",
+              "n": 1
+            },
+            {
+              "v": "29",
+              "n": 1
+            },
+            {
+              "v": "28",
+              "n": 1
+            },
+            {
+              "v": "14",
+              "n": 1
+            },
+            {
+              "v": "8",
+              "n": 1
+            },
+            {
+              "v": "17",
+              "n": 1
+            },
+            {
+              "v": "16",
+              "n": 1
+            },
+            {
               "v": "3",
               "n": 1
             },
             {
               "v": "4",
+              "n": 1
+            },
+            {
+              "v": "33",
+              "n": 1
+            },
+            {
+              "v": "25",
+              "n": 1
+            },
+            {
+              "v": "10",
+              "n": 1
+            },
+            {
+              "v": "34",
+              "n": 1
+            },
+            {
+              "v": "21",
+              "n": 1
+            },
+            {
+              "v": "11",
+              "n": 1
+            },
+            {
+              "v": "31",
+              "n": 1
+            },
+            {
+              "v": "27",
+              "n": 1
+            },
+            {
+              "v": "30",
+              "n": 1
+            },
+            {
+              "v": "2",
+              "n": 1
+            },
+            {
+              "v": "36",
+              "n": 1
+            },
+            {
+              "v": "6",
               "n": 1
             },
             {
@@ -6617,99 +6683,7 @@
               "n": 1
             },
             {
-              "v": "36",
-              "n": 1
-            },
-            {
-              "v": "6",
-              "n": 1
-            },
-            {
-              "v": "31",
-              "n": 1
-            },
-            {
-              "v": "27",
-              "n": 1
-            },
-            {
-              "v": "30",
-              "n": 1
-            },
-            {
-              "v": "2",
-              "n": 1
-            },
-            {
-              "v": "34",
-              "n": 1
-            },
-            {
-              "v": "22",
-              "n": 1
-            },
-            {
-              "v": "1",
-              "n": 1
-            },
-            {
-              "v": "18",
-              "n": 1
-            },
-            {
-              "v": "11",
-              "n": 1
-            },
-            {
-              "v": "29",
-              "n": 1
-            },
-            {
-              "v": "28",
-              "n": 1
-            },
-            {
-              "v": "14",
-              "n": 1
-            },
-            {
               "v": "12",
-              "n": 1
-            },
-            {
-              "v": "24",
-              "n": 1
-            },
-            {
-              "v": "37",
-              "n": 1
-            },
-            {
-              "v": "35",
-              "n": 1
-            },
-            {
-              "v": "8",
-              "n": 1
-            },
-            {
-              "v": "17",
-              "n": 1
-            },
-            {
-              "v": "16",
-              "n": 1
-            },
-            {
-              "v": "33",
-              "n": 1
-            },
-            {
-              "v": "25",
-              "n": 1
-            },
-            {
-              "v": "10",
               "n": 1
             }
           ]
@@ -6762,11 +6736,11 @@
               "n": 50
             },
             {
-              "v": "TAMIL NADU",
+              "v": "BIHAR",
               "n": 38
             },
             {
-              "v": "BIHAR",
+              "v": "TAMIL NADU",
               "n": 38
             },
             {
@@ -6778,7 +6752,7 @@
               "n": 35
             },
             {
-              "v": "GUJARAT",
+              "v": "CHHATTISGARH",
               "n": 33
             },
             {
@@ -6786,7 +6760,7 @@
               "n": 33
             },
             {
-              "v": "CHHATTISGARH",
+              "v": "GUJARAT",
               "n": 33
             },
             {
@@ -6810,11 +6784,11 @@
               "n": 24
             },
             {
-              "v": "WEST BENGAL",
+              "v": "PUNJAB",
               "n": 23
             },
             {
-              "v": "PUNJAB",
+              "v": "WEST BENGAL",
               "n": 23
             },
             {
@@ -6916,11 +6890,11 @@
               "n": 50
             },
             {
-              "v": "10",
+              "v": "33",
               "n": 38
             },
             {
-              "v": "33",
+              "v": "10",
               "n": 38
             },
             {
@@ -6932,11 +6906,11 @@
               "n": 35
             },
             {
-              "v": "36",
+              "v": "24",
               "n": 33
             },
             {
-              "v": "24",
+              "v": "36",
               "n": 33
             },
             {
@@ -6980,11 +6954,11 @@
               "n": 22
             },
             {
-              "v": "13",
+              "v": "14",
               "n": 16
             },
             {
-              "v": "14",
+              "v": "13",
               "n": 16
             },
             {
@@ -7004,11 +6978,11 @@
               "n": 12
             },
             {
-              "v": "15",
+              "v": "07",
               "n": 11
             },
             {
-              "v": "07",
+              "v": "15",
               "n": 11
             },
             {
@@ -7024,27 +6998,27 @@
               "n": 4
             },
             {
-              "v": "39",
-              "n": 3
-            },
-            {
               "v": "35",
               "n": 3
             },
             {
-              "v": "38",
-              "n": 2
+              "v": "39",
+              "n": 3
             },
             {
               "v": "30",
               "n": 2
             },
             {
-              "v": "31",
-              "n": 1
+              "v": "38",
+              "n": 2
             },
             {
               "v": "04",
+              "n": 1
+            },
+            {
+              "v": "31",
               "n": 1
             }
           ]
@@ -7094,11 +7068,11 @@
               "n": 8
             },
             {
-              "v": "2015_c",
+              "v": "2018",
               "n": 6
             },
             {
-              "v": "2018",
+              "v": "2015_c",
               "n": 6
             },
             {
@@ -7152,11 +7126,11 @@
               "n": 50
             },
             {
-              "v": 33,
+              "v": 10,
               "n": 38
             },
             {
-              "v": 10,
+              "v": 33,
               "n": 38
             },
             {
@@ -7200,19 +7174,19 @@
               "n": 24
             },
             {
-              "v": 3,
-              "n": 23
-            },
-            {
               "v": 19,
               "n": 23
             },
             {
-              "v": 1,
-              "n": 22
+              "v": 3,
+              "n": 23
             },
             {
               "v": 6,
+              "n": 22
+            },
+            {
+              "v": 1,
               "n": 22
             },
             {
@@ -7268,19 +7242,19 @@
               "n": 3
             },
             {
-              "v": 30,
-              "n": 2
-            },
-            {
               "v": 37,
               "n": 2
             },
             {
-              "v": 31,
-              "n": 1
+              "v": 30,
+              "n": 2
             },
             {
               "v": 4,
+              "n": 1
+            },
+            {
+              "v": 31,
               "n": 1
             }
           ]
@@ -7417,15 +7391,7 @@
               "n": 36
             },
             {
-              "v": "ASSAM",
-              "n": 33
-            },
-            {
               "v": "GUJAR\u0100T",
-              "n": 33
-            },
-            {
-              "v": "TELANG\u0100NA",
               "n": 33
             },
             {
@@ -7433,11 +7399,19 @@
               "n": 33
             },
             {
-              "v": "KARN\u0100TAKA",
-              "n": 30
+              "v": "ASSAM",
+              "n": 33
+            },
+            {
+              "v": "TELANG\u0100NA",
+              "n": 33
             },
             {
               "v": "ODISHA",
+              "n": 30
+            },
+            {
+              "v": "KARN\u0100TAKA",
               "n": 30
             },
             {
@@ -7477,11 +7451,11 @@
               "n": 14
             },
             {
-              "v": "ANDHRA PRADESH",
+              "v": "UTTAR\u0100KHAND",
               "n": 13
             },
             {
-              "v": "UTTAR\u0100KHAND",
+              "v": "ANDHRA PRADESH",
               "n": 13
             },
             {
@@ -7489,15 +7463,15 @@
               "n": 12
             },
             {
+              "v": "DELHI",
+              "n": 11
+            },
+            {
               "v": "MEGH\u0100LAYA",
               "n": 11
             },
             {
               "v": "N\u0100G\u0100LAND",
-              "n": 11
-            },
-            {
-              "v": "DELHI",
               "n": 11
             },
             {
@@ -7509,11 +7483,11 @@
               "n": 8
             },
             {
-              "v": "DISPUTED (MADHYA PRADESH & R\u0100JASTH\u0100N)",
+              "v": "SIKKIM",
               "n": 4
             },
             {
-              "v": "SIKKIM",
+              "v": "DISPUTED (MADHYA PRADESH & R\u0100JASTH\u0100N)",
               "n": 4
             },
             {
@@ -7521,11 +7495,11 @@
               "n": 4
             },
             {
-              "v": "ANDAMAN & NICOBAR",
+              "v": "D\u0100DRA & NAGAR HAVELI & DAM\u0100N & DIU",
               "n": 3
             },
             {
-              "v": "D\u0100DRA & NAGAR HAVELI & DAM\u0100N & DIU",
+              "v": "ANDAMAN & NICOBAR",
               "n": 3
             },
             {
@@ -7533,11 +7507,11 @@
               "n": 2
             },
             {
-              "v": "GOA",
+              "v": "LAD\u0100KH",
               "n": 2
             },
             {
-              "v": "LAD\u0100KH",
+              "v": "GOA",
               "n": 2
             },
             {
@@ -7549,11 +7523,11 @@
               "n": 1
             },
             {
-              "v": "DISPUTED (MADHYA PRADESH & GUJAR\u0100T)",
+              "v": "LAKSHADWEEP",
               "n": 1
             },
             {
-              "v": "LAKSHADWEEP",
+              "v": "DISPUTED (MADHYA PRADESH & GUJAR\u0100T)",
               "n": 1
             }
           ]
@@ -7605,6 +7579,10 @@
               "n": 36
             },
             {
+              "v": 36,
+              "n": 33
+            },
+            {
               "v": 24,
               "n": 33
             },
@@ -7614,10 +7592,6 @@
             },
             {
               "v": 18,
-              "n": 33
-            },
-            {
-              "v": 36,
               "n": 33
             },
             {
@@ -7645,15 +7619,15 @@
               "n": 23
             },
             {
-              "v": 1,
-              "n": 22
-            },
-            {
               "v": 6,
               "n": 22
             },
             {
               "v": 3,
+              "n": 22
+            },
+            {
+              "v": 1,
               "n": 22
             },
             {
@@ -7665,11 +7639,11 @@
               "n": 14
             },
             {
-              "v": 5,
+              "v": 28,
               "n": 13
             },
             {
-              "v": 28,
+              "v": 5,
               "n": 13
             },
             {
@@ -7681,15 +7655,15 @@
               "n": 11
             },
             {
-              "v": 13,
-              "n": 11
-            },
-            {
               "v": 7,
               "n": 11
             },
             {
-              "v": 16,
+              "v": 13,
+              "n": 11
+            },
+            {
+              "v": 0,
               "n": 8
             },
             {
@@ -7697,7 +7671,7 @@
               "n": 8
             },
             {
-              "v": 0,
+              "v": 16,
               "n": 8
             },
             {
@@ -7725,11 +7699,11 @@
               "n": 2
             },
             {
-              "v": 31,
+              "v": 4,
               "n": 1
             },
             {
-              "v": 4,
+              "v": 31,
               "n": 1
             }
           ]
@@ -7787,7 +7761,7 @@
               "n": 36
             },
             {
-              "v": "ASSAM",
+              "v": "RAJASTHAN",
               "n": 33
             },
             {
@@ -7795,7 +7769,7 @@
               "n": 33
             },
             {
-              "v": "RAJASTHAN",
+              "v": "ASSAM",
               "n": 33
             },
             {
@@ -7827,15 +7801,15 @@
               "n": 23
             },
             {
+              "v": "PUNJAB",
+              "n": 22
+            },
+            {
               "v": "JAMMU AND KASHMIR",
               "n": 22
             },
             {
               "v": "HARYANA",
-              "n": 22
-            },
-            {
-              "v": "PUNJAB",
               "n": 22
             },
             {
@@ -7847,11 +7821,11 @@
               "n": 14
             },
             {
-              "v": "ANDHRA PRADESH",
+              "v": "UTTARAKHAND",
               "n": 13
             },
             {
-              "v": "UTTARAKHAND",
+              "v": "ANDHRA PRADESH",
               "n": 13
             },
             {
@@ -7863,11 +7837,11 @@
               "n": 11
             },
             {
-              "v": "MEGHALAYA",
+              "v": "DELHI",
               "n": 11
             },
             {
-              "v": "DELHI",
+              "v": "MEGHALAYA",
               "n": 11
             },
             {
@@ -7883,11 +7857,11 @@
               "n": 4
             },
             {
-              "v": "DISPUTED (MADHYA PRADESH & RAJASTHAN)",
+              "v": "PUDUCHERRY",
               "n": 4
             },
             {
-              "v": "PUDUCHERRY",
+              "v": "DISPUTED (MADHYA PRADESH & RAJASTHAN)",
               "n": 4
             },
             {
@@ -7899,6 +7873,10 @@
               "n": 3
             },
             {
+              "v": "LADAKH",
+              "n": 2
+            },
+            {
               "v": "GOA",
               "n": 2
             },
@@ -7907,15 +7885,11 @@
               "n": 2
             },
             {
-              "v": "LADAKH",
-              "n": 2
-            },
-            {
               "v": "LAKSHADWEEP",
               "n": 1
             },
             {
-              "v": "DISPUTED (MADHYA PRADESH & GUJARAT)",
+              "v": "CHANDIGARH",
               "n": 1
             },
             {
@@ -7923,7 +7897,7 @@
               "n": 1
             },
             {
-              "v": "CHANDIGARH",
+              "v": "DISPUTED (MADHYA PRADESH & GUJARAT)",
               "n": 1
             }
           ]
@@ -8037,11 +8011,11 @@
               "n": 14
             },
             {
-              "v": "Uttarakhand",
+              "v": "Andhra Pradesh",
               "n": 13
             },
             {
-              "v": "Andhra Pradesh",
+              "v": "Uttarakhand",
               "n": 13
             },
             {
@@ -8097,7 +8071,7 @@
               "n": 2
             },
             {
-              "v": "Chandigarh",
+              "v": "Delhi",
               "n": 1
             },
             {
@@ -8105,7 +8079,7 @@
               "n": 1
             },
             {
-              "v": "Delhi",
+              "v": "Chandigarh",
               "n": 1
             },
             {
@@ -8171,11 +8145,11 @@
               "n": 24
             },
             {
-              "v": "3",
+              "v": "6",
               "n": 22
             },
             {
-              "v": "6",
+              "v": "3",
               "n": 22
             },
             {
@@ -8207,11 +8181,11 @@
               "n": 12
             },
             {
-              "v": "17",
+              "v": "13",
               "n": 11
             },
             {
-              "v": "13",
+              "v": "17",
               "n": 11
             },
             {
@@ -8235,15 +8209,15 @@
               "n": 6
             },
             {
-              "v": "34",
-              "n": 4
-            },
-            {
               "v": "11",
               "n": 4
             },
             {
-              "v": "35",
+              "v": "34",
+              "n": 4
+            },
+            {
+              "v": "25",
               "n": 2
             },
             {
@@ -8251,7 +8225,7 @@
               "n": 2
             },
             {
-              "v": "25",
+              "v": "35",
               "n": 2
             },
             {
@@ -8259,11 +8233,11 @@
               "n": 1
             },
             {
-              "v": "4",
+              "v": "31",
               "n": 1
             },
             {
-              "v": "31",
+              "v": "4",
               "n": 1
             },
             {
@@ -8587,11 +8561,11 @@
               "n": 76
             },
             {
-              "v": "MANIPUR",
+              "v": "MEGHALAYA",
               "n": 39
             },
             {
-              "v": "MEGHALAYA",
+              "v": "MANIPUR",
               "n": 39
             },
             {
@@ -8773,11 +8747,11 @@
               "n": 76
             },
             {
-              "v": 17,
+              "v": 14,
               "n": 39
             },
             {
-              "v": 14,
+              "v": 17,
               "n": 39
             },
             {
@@ -9022,11 +8996,11 @@
               "n": 25
             },
             {
-              "v": "NAGALAND",
+              "v": "TRIPURA",
               "n": 23
             },
             {
-              "v": "TRIPURA",
+              "v": "NAGALAND",
               "n": 23
             },
             {
@@ -9038,19 +9012,19 @@
               "n": 22
             },
             {
-              "v": "MEGHALAYA",
-              "n": 11
-            },
-            {
               "v": "GOA",
               "n": 11
             },
             {
-              "v": "ANDAMAN & NICOBAR",
-              "n": 9
+              "v": "MEGHALAYA",
+              "n": 11
             },
             {
               "v": "SIKKIM",
+              "n": 9
+            },
+            {
+              "v": "ANDAMAN & NICOBAR",
               "n": 9
             },
             {
@@ -9070,11 +9044,11 @@
               "n": 2
             },
             {
-              "v": "CHANDIGARH",
+              "v": "LAKSHADWEEP",
               "n": 1
             },
             {
-              "v": "Disputed (West Bengal)",
+              "v": "CHANDIGARH",
               "n": 1
             },
             {
@@ -9082,7 +9056,7 @@
               "n": 1
             },
             {
-              "v": "LAKSHADWEEP",
+              "v": "Disputed (West Bengal)",
               "n": 1
             }
           ]
@@ -9220,11 +9194,11 @@
               "n": 23
             },
             {
-              "v": "MIZORAM",
+              "v": "JAMMU AND KASHMIR",
               "n": 22
             },
             {
-              "v": "JAMMU AND KASHMIR",
+              "v": "MIZORAM",
               "n": 22
             },
             {
@@ -9260,6 +9234,10 @@
               "n": 2
             },
             {
+              "v": "CHANDIGARH",
+              "n": 1
+            },
+            {
               "v": "DISPUTED",
               "n": 1
             },
@@ -9269,10 +9247,6 @@
             },
             {
               "v": "DISPUTED (WEST BENGAL)",
-              "n": 1
-            },
-            {
-              "v": "CHANDIGARH",
               "n": 1
             }
           ]
@@ -9434,11 +9408,11 @@
               "n": 39
             },
             {
-              "v": "MIZORAM",
+              "v": "SIKKIM",
               "n": 26
             },
             {
-              "v": "SIKKIM",
+              "v": "MIZORAM",
               "n": 26
             },
             {
@@ -9608,11 +9582,11 @@
               "n": 22
             },
             {
-              "v": "07",
+              "v": "30",
               "n": 12
             },
             {
-              "v": "30",
+              "v": "07",
               "n": 12
             },
             {
@@ -9714,11 +9688,11 @@
               "n": 56
             },
             {
-              "v": 8,
+              "v": 7,
               "n": 27
             },
             {
-              "v": 7,
+              "v": 8,
               "n": 27
             },
             {
@@ -9758,10 +9732,6 @@
               "n": 4
             },
             {
-              "v": 18,
-              "n": 3
-            },
-            {
               "v": 23,
               "n": 3
             },
@@ -9770,11 +9740,15 @@
               "n": 3
             },
             {
-              "v": 15,
-              "n": 2
+              "v": 18,
+              "n": 3
             },
             {
               "v": 22,
+              "n": 2
+            },
+            {
+              "v": 15,
               "n": 2
             },
             {
@@ -9786,23 +9760,7 @@
               "n": 2
             },
             {
-              "v": 37,
-              "n": 1
-            },
-            {
-              "v": 34,
-              "n": 1
-            },
-            {
-              "v": 44,
-              "n": 1
-            },
-            {
-              "v": 51,
-              "n": 1
-            },
-            {
-              "v": 32,
+              "v": 42,
               "n": 1
             },
             {
@@ -9814,15 +9772,31 @@
               "n": 1
             },
             {
+              "v": 44,
+              "n": 1
+            },
+            {
               "v": 43,
               "n": 1
             },
             {
-              "v": 25,
+              "v": 51,
               "n": 1
             },
             {
-              "v": 42,
+              "v": 37,
+              "n": 1
+            },
+            {
+              "v": 34,
+              "n": 1
+            },
+            {
+              "v": 32,
+              "n": 1
+            },
+            {
+              "v": 25,
               "n": 1
             }
           ]
@@ -9948,19 +9922,19 @@
               "n": 58
             },
             {
-              "v": 17,
-              "n": 39
-            },
-            {
               "v": 14,
               "n": 39
             },
             {
-              "v": 11,
-              "n": 26
+              "v": 17,
+              "n": 39
             },
             {
               "v": 15,
+              "n": 26
+            },
+            {
+              "v": 11,
               "n": 26
             },
             {
@@ -10139,11 +10113,11 @@
               "n": 38
             },
             {
-              "v": "Manipur",
+              "v": "Tripura",
               "n": 37
             },
             {
-              "v": "Tripura",
+              "v": "Manipur",
               "n": 37
             },
             {
@@ -10163,11 +10137,11 @@
               "n": 6
             },
             {
-              "v": "Andaman & Nicobar",
+              "v": "Lakshadweep",
               "n": 4
             },
             {
-              "v": "Lakshadweep",
+              "v": "Andaman & Nicobar",
               "n": 4
             },
             {
@@ -10297,11 +10271,11 @@
               "n": 38
             },
             {
-              "v": "16",
+              "v": "14",
               "n": 37
             },
             {
-              "v": "14",
+              "v": "16",
               "n": 37
             },
             {
@@ -10341,11 +10315,11 @@
               "n": 1
             },
             {
-              "v": "26",
+              "v": "7",
               "n": 1
             },
             {
-              "v": "7",
+              "v": "26",
               "n": 1
             }
           ]
@@ -12518,11 +12492,11 @@
               "n": 26
             },
             {
-              "v": "37",
+              "v": "08",
               "n": 25
             },
             {
-              "v": "08",
+              "v": "37",
               "n": 25
             },
             {
@@ -12574,11 +12548,11 @@
               "n": 4
             },
             {
-              "v": "39",
+              "v": "30",
               "n": 2
             },
             {
-              "v": "12",
+              "v": "39",
               "n": 2
             },
             {
@@ -12586,23 +12560,19 @@
               "n": 2
             },
             {
-              "v": "14",
-              "n": 2
-            },
-            {
               "v": "16",
               "n": 2
             },
             {
-              "v": "30",
+              "v": "14",
               "n": 2
             },
             {
-              "v": "04",
-              "n": 1
+              "v": "12",
+              "n": 2
             },
             {
-              "v": "15",
+              "v": "11",
               "n": 1
             },
             {
@@ -12610,19 +12580,23 @@
               "n": 1
             },
             {
-              "v": "35",
-              "n": 1
-            },
-            {
               "v": "34",
               "n": 1
             },
             {
-              "v": "11",
+              "v": "31",
               "n": 1
             },
             {
-              "v": "31",
+              "v": "04",
+              "n": 1
+            },
+            {
+              "v": "35",
+              "n": 1
+            },
+            {
+              "v": "15",
               "n": 1
             }
           ]
@@ -12668,11 +12642,11 @@
               "n": 26
             },
             {
-              "v": "RAJASTHAN",
+              "v": "ANDHRA PRADESH",
               "n": 25
             },
             {
-              "v": "ANDHRA PRADESH",
+              "v": "RAJASTHAN",
               "n": 25
             },
             {
@@ -12688,11 +12662,11 @@
               "n": 17
             },
             {
-              "v": "JHARKHAND",
+              "v": "ASSAM",
               "n": 14
             },
             {
-              "v": "ASSAM",
+              "v": "JHARKHAND",
               "n": 14
             },
             {
@@ -12724,6 +12698,10 @@
               "n": 4
             },
             {
+              "v": "ARUNACHAL PRADESH",
+              "n": 2
+            },
+            {
               "v": "MEGHALAYA",
               "n": 2
             },
@@ -12740,14 +12718,6 @@
               "n": 2
             },
             {
-              "v": "ARUNACHAL PRADESH",
-              "n": 2
-            },
-            {
-              "v": "NAGALAND",
-              "n": 1
-            },
-            {
               "v": "ANDAMAN & NICOBAR",
               "n": 1
             },
@@ -12756,19 +12726,11 @@
               "n": 1
             },
             {
-              "v": "DADRA & NAGAR HAVELI",
-              "n": 1
-            },
-            {
-              "v": "LAKSHADWEEP",
-              "n": 1
-            },
-            {
               "v": "DAMAN & DIU",
               "n": 1
             },
             {
-              "v": "PUDUCHERRY",
+              "v": "DADRA & NAGAR HAVELI",
               "n": 1
             },
             {
@@ -12776,7 +12738,19 @@
               "n": 1
             },
             {
+              "v": "LAKSHADWEEP",
+              "n": 1
+            },
+            {
               "v": "CHANDIGARH",
+              "n": 1
+            },
+            {
+              "v": "PUDUCHERRY",
+              "n": 1
+            },
+            {
+              "v": "NAGALAND",
               "n": 1
             }
           ]
@@ -12888,11 +12862,11 @@
               "n": 26
             },
             {
-              "v": 28,
+              "v": 8,
               "n": 25
             },
             {
-              "v": 8,
+              "v": 28,
               "n": 25
             },
             {
@@ -12948,7 +12922,7 @@
               "n": 2
             },
             {
-              "v": 14,
+              "v": 30,
               "n": 2
             },
             {
@@ -12956,7 +12930,7 @@
               "n": 2
             },
             {
-              "v": 30,
+              "v": 14,
               "n": 2
             },
             {
@@ -12968,23 +12942,11 @@
               "n": 2
             },
             {
-              "v": 34,
-              "n": 1
-            },
-            {
-              "v": 4,
-              "n": 1
-            },
-            {
-              "v": 31,
-              "n": 1
-            },
-            {
               "v": 15,
               "n": 1
             },
             {
-              "v": 11,
+              "v": 4,
               "n": 1
             },
             {
@@ -12993,6 +12955,18 @@
             },
             {
               "v": 13,
+              "n": 1
+            },
+            {
+              "v": 34,
+              "n": 1
+            },
+            {
+              "v": 11,
+              "n": 1
+            },
+            {
+              "v": 31,
               "n": 1
             }
           ]
@@ -13099,19 +13073,19 @@
               "n": 95
             },
             {
-              "v": "06",
-              "n": 90
-            },
-            {
               "v": "22",
               "n": 90
             },
             {
-              "v": "07",
-              "n": 70
+              "v": "06",
+              "n": 90
             },
             {
               "v": "05",
+              "n": 70
+            },
+            {
+              "v": "07",
               "n": 70
             },
             {
@@ -13127,7 +13101,7 @@
               "n": 61
             },
             {
-              "v": "13",
+              "v": "16",
               "n": 60
             },
             {
@@ -13135,7 +13109,7 @@
               "n": 60
             },
             {
-              "v": "16",
+              "v": "13",
               "n": 60
             },
             {
@@ -13233,11 +13207,11 @@
               "n": 95
             },
             {
-              "v": "HARYANA",
+              "v": "CHHATTISGARH",
               "n": 90
             },
             {
-              "v": "CHHATTISGARH",
+              "v": "HARYANA",
               "n": 90
             },
             {
@@ -13265,11 +13239,11 @@
               "n": 60
             },
             {
-              "v": "NAGALAND",
+              "v": "TRIPURA",
               "n": 60
             },
             {
-              "v": "TRIPURA",
+              "v": "NAGALAND",
               "n": 60
             },
             {
@@ -13477,27 +13451,27 @@
               "n": 96
             },
             {
-              "v": 6,
-              "n": 90
-            },
-            {
               "v": 22,
               "n": 90
             },
             {
-              "v": 5,
-              "n": 70
+              "v": 6,
+              "n": 90
             },
             {
               "v": 7,
               "n": 70
             },
             {
-              "v": 14,
-              "n": 68
+              "v": 5,
+              "n": 70
             },
             {
               "v": 2,
+              "n": 68
+            },
+            {
+              "v": 14,
               "n": 68
             },
             {
@@ -13572,6 +13546,207 @@
             "st_code",
             "st_name"
           ]
+        }
+      ]
+    },
+    "bharatviz_pincodes": {
+      "row_count": 63864,
+      "columns": [
+        {
+          "name": "OGC_FID",
+          "type": "int",
+          "distinct": 63864,
+          "null_frac": 0.0,
+          "min": 0,
+          "max": 63863
+        },
+        {
+          "name": "pincode",
+          "type": "string",
+          "distinct": 19274,
+          "null_frac": 0.0,
+          "min": "110001",
+          "max": "855117"
+        },
+        {
+          "name": "office_name",
+          "type": "string",
+          "distinct": 19237,
+          "null_frac": 0.0,
+          "min": " Jankia S.O",
+          "max": "Zunheboto S.O"
+        },
+        {
+          "name": "state_name",
+          "type": "string",
+          "distinct": 37,
+          "null_frac": 0.0016,
+          "min": "Andaman & Nicobar",
+          "max": "West Bengal",
+          "top_values": [
+            {
+              "v": "Uttar Pradesh",
+              "n": 6142
+            },
+            {
+              "v": "Tamil Nadu",
+              "n": 5948
+            },
+            {
+              "v": "Maharashtra",
+              "n": 4974
+            },
+            {
+              "v": "Karnataka",
+              "n": 4348
+            },
+            {
+              "v": "Kerala",
+              "n": 3690
+            },
+            {
+              "v": "Rajasthan",
+              "n": 3568
+            },
+            {
+              "v": "Andhra Pradesh",
+              "n": 3368
+            },
+            {
+              "v": "West Bengal",
+              "n": 3266
+            },
+            {
+              "v": "Madhya Pradesh",
+              "n": 3252
+            },
+            {
+              "v": "Orissa",
+              "n": 3206
+            },
+            {
+              "v": "Bihar",
+              "n": 3080
+            },
+            {
+              "v": "Gujarat",
+              "n": 3050
+            },
+            {
+              "v": "Telangana",
+              "n": 2100
+            },
+            {
+              "v": "Assam",
+              "n": 1974
+            },
+            {
+              "v": "Punjab",
+              "n": 1910
+            },
+            {
+              "v": "Jharkhand",
+              "n": 1530
+            },
+            {
+              "v": "Himachal Pradesh",
+              "n": 1414
+            },
+            {
+              "v": "Haryana",
+              "n": 1338
+            },
+            {
+              "v": "Chhattisgarh",
+              "n": 1274
+            },
+            {
+              "v": "Uttarakhand",
+              "n": 1092
+            },
+            {
+              "v": "Union Territory of Jammu and Kashmir",
+              "n": 818
+            },
+            {
+              "v": "Meghalaya",
+              "n": 340
+            },
+            {
+              "v": "Arunachal Pradesh",
+              "n": 326
+            },
+            {
+              "v": "Manipur",
+              "n": 300
+            },
+            {
+              "v": "Tripura",
+              "n": 276
+            },
+            {
+              "v": "Nagaland",
+              "n": 266
+            },
+            {
+              "v": "Goa",
+              "n": 224
+            },
+            {
+              "v": "Mizoram",
+              "n": 192
+            },
+            {
+              "v": "Puducherry",
+              "n": 106
+            },
+            {
+              "v": "Sikkim",
+              "n": 92
+            },
+            {
+              "v": "Union Territory of Ladakh",
+              "n": 80
+            },
+            {
+              "v": "Chandigarh",
+              "n": 66
+            },
+            {
+              "v": "Delhi",
+              "n": 54
+            },
+            {
+              "v": "Andaman & Nicobar",
+              "n": 44
+            },
+            {
+              "v": "Dadar Nagar& Haveli",
+              "n": 20
+            },
+            {
+              "v": "Lakshadweep",
+              "n": 18
+            },
+            {
+              "v": "Daman & Diu",
+              "n": 16
+            }
+          ]
+        },
+        {
+          "name": "district_name",
+          "type": "string",
+          "distinct": 657,
+          "null_frac": 0.0016,
+          "min": "Adilabad",
+          "max": "Zunheboto"
+        },
+        {
+          "name": "geom",
+          "type": "geometry",
+          "distinct": -1,
+          "null_frac": 0
         }
       ]
     },
@@ -13659,11 +13834,11 @@
               "n": 21
             },
             {
-              "v": "Andhra Pradesh",
+              "v": "Odisha",
               "n": 20
             },
             {
-              "v": "Odisha",
+              "v": "Andhra Pradesh",
               "n": 20
             },
             {
@@ -13679,23 +13854,23 @@
               "n": 14
             },
             {
-              "v": "Bihar",
-              "n": 13
-            },
-            {
               "v": "Arunachal Pradesh",
               "n": 13
             },
             {
-              "v": "Telangana",
-              "n": 12
+              "v": "Bihar",
+              "n": 13
             },
             {
               "v": "Mizoram",
               "n": 12
             },
             {
-              "v": "Haryana",
+              "v": "Telangana",
+              "n": 12
+            },
+            {
+              "v": "Jharkhand",
               "n": 11
             },
             {
@@ -13703,15 +13878,15 @@
               "n": 11
             },
             {
-              "v": "Jharkhand",
+              "v": "Haryana",
               "n": 11
             },
             {
-              "v": "Manipur",
+              "v": "Sikkim",
               "n": 8
             },
             {
-              "v": "Sikkim",
+              "v": "Manipur",
               "n": 8
             },
             {
@@ -13719,7 +13894,7 @@
               "n": 7
             },
             {
-              "v": "Meghalaya",
+              "v": "Tripura",
               "n": 6
             },
             {
@@ -13727,7 +13902,7 @@
               "n": 6
             },
             {
-              "v": "Tripura",
+              "v": "Meghalaya",
               "n": 6
             },
             {
@@ -13735,7 +13910,15 @@
               "n": 3
             },
             {
+              "v": "Delhi",
+              "n": 1
+            },
+            {
               "v": "Chandigarh",
+              "n": 1
+            },
+            {
+              "v": "Lakshadweep (UT)",
               "n": 1
             },
             {
@@ -13744,14 +13927,6 @@
             },
             {
               "v": "Puducherry",
-              "n": 1
-            },
-            {
-              "v": "Delhi",
-              "n": 1
-            },
-            {
-              "v": "Lakshadweep (UT)",
               "n": 1
             }
           ]
@@ -13809,10 +13984,6 @@
               "n": 2
             },
             {
-              "v": "Chandrapur",
-              "n": 2
-            },
-            {
               "v": "Wild Life North Circle",
               "n": 2
             },
@@ -13821,11 +13992,15 @@
               "n": 2
             },
             {
-              "v": "Northern Circle",
+              "v": "Chandrapur",
+              "n": 2
+            },
+            {
+              "v": "Kolhapur",
               "n": 1
             },
             {
-              "v": "Str Wildlife",
+              "v": "Madurai",
               "n": 1
             },
             {
@@ -13833,7 +14008,19 @@
               "n": 1
             },
             {
-              "v": "Kolhapur",
+              "v": "Aurangabad",
+              "n": 1
+            },
+            {
+              "v": "Naginimora",
+              "n": 1
+            },
+            {
+              "v": "Wildlife North",
+              "n": 1
+            },
+            {
+              "v": "2",
               "n": 1
             },
             {
@@ -13841,7 +14028,7 @@
               "n": 1
             },
             {
-              "v": "1",
+              "v": "Str Wildlife",
               "n": 1
             },
             {
@@ -13853,11 +14040,7 @@
               "n": 1
             },
             {
-              "v": "Dharmapuri",
-              "n": 1
-            },
-            {
-              "v": "2",
+              "v": "1",
               "n": 1
             },
             {
@@ -13865,19 +14048,11 @@
               "n": 1
             },
             {
-              "v": "Aurangabad",
+              "v": "Dharmapuri",
               "n": 1
             },
             {
-              "v": "Madurai",
-              "n": 1
-            },
-            {
-              "v": "Wildlife North",
-              "n": 1
-            },
-            {
-              "v": "Naginimora",
+              "v": "Northern Circle",
               "n": 1
             }
           ]
@@ -13967,55 +14142,19 @@
               "n": 3
             },
             {
-              "v": "1985/09/16",
-              "n": 2
-            },
-            {
               "v": "1986/10/10",
               "n": 2
             },
             {
-              "v": "2018/03/23",
-              "n": 1
-            },
-            {
-              "v": "2013/05/03",
-              "n": 1
-            },
-            {
-              "v": "1988/02/08",
-              "n": 1
-            },
-            {
-              "v": "16-05-1997, 17-05-1997",
-              "n": 1
-            },
-            {
-              "v": "2019/05/29",
-              "n": 1
-            },
-            {
-              "v": "1994/12/08",
-              "n": 1
+              "v": "1985/09/16",
+              "n": 2
             },
             {
               "v": "2021/03/15",
               "n": 1
             },
             {
-              "v": "2013/07/18",
-              "n": 1
-            },
-            {
-              "v": "25-02-1986, 24-02-2004",
-              "n": 1
-            },
-            {
-              "v": "07-05-1997 , 09-05-1997",
-              "n": 1
-            },
-            {
-              "v": "2003/07/23",
+              "v": "1955/03/31",
               "n": 1
             },
             {
@@ -14023,11 +14162,11 @@
               "n": 1
             },
             {
-              "v": "2000/12/21",
+              "v": "16-05-1997, 17-05-1997",
               "n": 1
             },
             {
-              "v": "2000/08/08",
+              "v": "2000/06/08",
               "n": 1
             },
             {
@@ -14039,31 +14178,15 @@
               "n": 1
             },
             {
-              "v": "1970/06/03",
+              "v": "27-11-1970",
               "n": 1
             },
             {
-              "v": "1958/12/02",
+              "v": "07-05-1997 , 09-05-1997",
               "n": 1
             },
             {
-              "v": "1997/08/19",
-              "n": 1
-            },
-            {
-              "v": "2012/06/29",
-              "n": 1
-            },
-            {
-              "v": "1975/11/22",
-              "n": 1
-            },
-            {
-              "v": "1996/01/16",
-              "n": 1
-            },
-            {
-              "v": "2010/11/02",
+              "v": "2003/07/23",
               "n": 1
             },
             {
@@ -14071,31 +14194,43 @@
               "n": 1
             },
             {
-              "v": "16-09-1985, 12-02-1970",
+              "v": "2000/12/21",
               "n": 1
             },
             {
-              "v": "1980/02/29",
+              "v": "2000/08/08",
               "n": 1
             },
             {
-              "v": "2016/03/09",
+              "v": "2018/03/23",
               "n": 1
             },
             {
-              "v": "15-02-1994, 06-11-2000",
+              "v": "2010/11/02",
               "n": 1
             },
             {
-              "v": "1955/03/31",
+              "v": "1997/04/09",
               "n": 1
             },
             {
-              "v": "2000/06/08",
+              "v": "28-07-1997, 29-07-1997",
               "n": 1
             },
             {
-              "v": "27-11-1970",
+              "v": "2019/05/29",
+              "n": 1
+            },
+            {
+              "v": "1958/12/02",
+              "n": 1
+            },
+            {
+              "v": "1970/06/03",
+              "n": 1
+            },
+            {
+              "v": "1988/02/08",
               "n": 1
             },
             {
@@ -14111,15 +14246,51 @@
               "n": 1
             },
             {
+              "v": "2012/06/29",
+              "n": 1
+            },
+            {
+              "v": "25-02-1986, 24-02-2004",
+              "n": 1
+            },
+            {
+              "v": "1994/12/08",
+              "n": 1
+            },
+            {
+              "v": "16-09-1985, 12-02-1970",
+              "n": 1
+            },
+            {
+              "v": "1996/01/16",
+              "n": 1
+            },
+            {
+              "v": "1980/02/29",
+              "n": 1
+            },
+            {
+              "v": "2016/03/09",
+              "n": 1
+            },
+            {
+              "v": "15-02-1994, 06-11-2000",
+              "n": 1
+            },
+            {
+              "v": "2013/07/18",
+              "n": 1
+            },
+            {
               "v": "2000/12/07",
               "n": 1
             },
             {
-              "v": "28-07-1997, 29-07-1997",
+              "v": "2012/02/29",
               "n": 1
             },
             {
-              "v": "1997/04/09",
+              "v": "1975/11/22",
               "n": 1
             },
             {
@@ -14131,7 +14302,11 @@
               "n": 1
             },
             {
-              "v": "2012/02/29",
+              "v": "2013/05/03",
+              "n": 1
+            },
+            {
+              "v": "1997/08/19",
               "n": 1
             }
           ]
@@ -14173,10 +14348,6 @@
               "n": 2
             },
             {
-              "v": "2013",
-              "n": 2
-            },
-            {
               "v": "2003",
               "n": 2
             },
@@ -14185,27 +14356,11 @@
               "n": 2
             },
             {
+              "v": "2013",
+              "n": 2
+            },
+            {
               "v": "2016",
-              "n": 1
-            },
-            {
-              "v": "1969",
-              "n": 1
-            },
-            {
-              "v": "1988",
-              "n": 1
-            },
-            {
-              "v": "1985, 1970",
-              "n": 1
-            },
-            {
-              "v": "1955",
-              "n": 1
-            },
-            {
-              "v": "2021",
               "n": 1
             },
             {
@@ -14213,43 +14368,7 @@
               "n": 1
             },
             {
-              "v": "1980",
-              "n": 1
-            },
-            {
-              "v": "1996",
-              "n": 1
-            },
-            {
-              "v": "1986, 2004",
-              "n": 1
-            },
-            {
-              "v": "2010",
-              "n": 1
-            },
-            {
-              "v": "1994",
-              "n": 1
-            },
-            {
-              "v": "1987",
-              "n": 1
-            },
-            {
               "v": "2019",
-              "n": 1
-            },
-            {
-              "v": "2004",
-              "n": 1
-            },
-            {
-              "v": "1958",
-              "n": 1
-            },
-            {
-              "v": "1975",
               "n": 1
             },
             {
@@ -14257,7 +14376,63 @@
               "n": 1
             },
             {
+              "v": "2004",
+              "n": 1
+            },
+            {
+              "v": "1988",
+              "n": 1
+            },
+            {
+              "v": "1969",
+              "n": 1
+            },
+            {
+              "v": "1996",
+              "n": 1
+            },
+            {
+              "v": "1987",
+              "n": 1
+            },
+            {
+              "v": "1994",
+              "n": 1
+            },
+            {
+              "v": "1980",
+              "n": 1
+            },
+            {
               "v": "1994, 2000",
+              "n": 1
+            },
+            {
+              "v": "1958",
+              "n": 1
+            },
+            {
+              "v": "2010",
+              "n": 1
+            },
+            {
+              "v": "1975",
+              "n": 1
+            },
+            {
+              "v": "2021",
+              "n": 1
+            },
+            {
+              "v": "1955",
+              "n": 1
+            },
+            {
+              "v": "1985, 1970",
+              "n": 1
+            },
+            {
+              "v": "1986, 2004",
               "n": 1
             }
           ]
@@ -14271,11 +14446,11 @@
           "max": "Core Zone",
           "top_values": [
             {
-              "v": "Core Zone",
+              "v": "Buffer Zone",
               "n": 7
             },
             {
-              "v": "Buffer Zone",
+              "v": "Core Zone",
               "n": 7
             }
           ]
@@ -14341,11 +14516,11 @@
               "n": 24
             },
             {
-              "v": "37",
+              "v": "32",
               "n": 23
             },
             {
-              "v": "32",
+              "v": "37",
               "n": 23
             },
             {
@@ -14377,11 +14552,11 @@
               "n": 12
             },
             {
-              "v": "20",
+              "v": "06",
               "n": 11
             },
             {
-              "v": "06",
+              "v": "20",
               "n": 11
             },
             {
@@ -14389,11 +14564,11 @@
               "n": 11
             },
             {
-              "v": "11",
+              "v": "14",
               "n": 8
             },
             {
-              "v": "14",
+              "v": "11",
               "n": 8
             },
             {
@@ -14401,20 +14576,16 @@
               "n": 7
             },
             {
-              "v": "16",
+              "v": "13",
               "n": 6
             },
             {
-              "v": "13",
+              "v": "16",
               "n": 6
             },
             {
               "v": "17",
               "n": 6
-            },
-            {
-              "v": "07",
-              "n": 1
             },
             {
               "v": "26",
@@ -14426,6 +14597,10 @@
             },
             {
               "v": "34",
+              "n": 1
+            },
+            {
+              "v": "07",
               "n": 1
             },
             {
@@ -14601,6 +14776,10 @@
               "n": 4
             },
             {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, as well as Port Blair.",
+              "n": 3
+            },
+            {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, Austin Strait as well as Port Blair.",
               "n": 3
             },
@@ -14609,15 +14788,19 @@
               "n": 3
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, as well as Port Blair.",
-              "n": 3
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Jarawa Protection Post, as well as Port Blair",
+              "n": 2
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur area, as well as Port Blair.",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder area, Diglipur area, as well as Port Blair",
               "n": 2
             },
             {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to South Cinque Island and West Sister Island as well as Port Blair.",
+              "n": 2
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur area, as well as Port Blair.",
               "n": 2
             },
             {
@@ -14629,19 +14812,11 @@
               "n": 2
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Gandhighat Jetty, Uttara Jetty as well as Port Blair",
-              "n": 2
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder area, Diglipur area, as well as Port Blair",
-              "n": 2
-            },
-            {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai and back. Ferry services are available to the national park.",
               "n": 2
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Jarawa Protection Post, as well as Port Blair",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Gandhighat Jetty, Uttara Jetty as well as Port Blair",
               "n": 2
             },
             {
@@ -14653,6 +14828,18 @@
               "n": 1
             },
             {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Keating Point.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur Taluk, as well as Port Blair.",
+              "n": 1
+            },
+            {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai and back. Ferry services are available to the national park",
               "n": 1
             },
@@ -14661,23 +14848,7 @@
               "n": 1
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur Taluk, as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to the nearest inhabited island, Havelock. The only two ways to arrive here are either by boat or by a seapl",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to South Cinque Island, West Sister Island, Kwate tu Kwage as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "You can take the inter-island boat service from Port Blair. The journey has been termed a trip within itself and takes about a week. Another option is to take the MV Campbell Bay, a government ship that covers the distance from Port Blair to Campbell Bay",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Nilambur Jetty, Jarawa Protection Post as well as Port Blair.",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, Austin Strait as well as Port Blair",
               "n": 1
             },
             {
@@ -14689,63 +14860,15 @@
               "n": 1
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Port Blair.",
+              "v": "You can take the inter-island boat service from Port Blair. The journey has been termed a trip within itself and takes about a week. Another option is to take the MV Campbell Bay, a government ship that covers the distance from Port Blair to Campbell Bay",
               "n": 1
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to South Cinque Island, West Sister Island, Kwate tu Kwage as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur area as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Ferrargunj, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, as well as Port Blair",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur, as well as Port Blair.",
               "n": 1
             },
             {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Austen Strait from Mayabunder, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder area, Diglipur area, as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Havelock Island as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Yerrata Jetty, Rangat, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Rangat Taluk, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Seven passenger ships-MV Kavaratti, MV Arabian Sea, MV Lakshadweep Sea, MV Lagoon, MV Corals, MV Amindivi and MV Minicoy, operate between Cochin and Lakshadweep.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Keating Point.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur area as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, Austin Strait as well as Port Blair",
               "n": 1
             },
             {
@@ -14757,7 +14880,43 @@
               "n": 1
             },
             {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Ferrargunj, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Yerrata Jetty, Rangat, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Rangat Taluk, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to South Cinque Island, West Sister Island, Kwate tu Kwage as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Port Blair.",
+              "n": 1
+            },
+            {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Malacca, Nancowry, Campbell Bay, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Rangat area as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Nilambur Jetty, Jarawa Protection Post as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Havelock Island as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Seven passenger ships-MV Kavaratti, MV Arabian Sea, MV Lakshadweep Sea, MV Lagoon, MV Corals, MV Amindivi and MV Minicoy, operate between Cochin and Lakshadweep.",
               "n": 1
             },
             {
@@ -14765,11 +14924,27 @@
               "n": 1
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur, as well as Port Blair.",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur area as well as Port Blair",
               "n": 1
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Rangat area as well as Port Blair.",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to South Cinque Island, West Sister Island, Kwate tu Kwage as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Austen Strait from Mayabunder, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder area, Diglipur area, as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur area as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to the nearest inhabited island, Havelock. The only two ways to arrive here are either by boat or by a seapl",
               "n": 1
             }
           ]
@@ -14894,7 +15069,7 @@
               "n": 2
             },
             {
-              "v": "GIS Lab Forest Department,Manipur",
+              "v": "Vishnu Jedia GIS Cell,IT,Panna Tiger Reserve,Panna",
               "n": 1
             },
             {
@@ -14902,31 +15077,7 @@
               "n": 1
             },
             {
-              "v": "Vishnu Jedia GIS Cell,IT,Panna Tiger Reserve,Panna",
-              "n": 1
-            },
-            {
-              "v": "Geomatics Centre Tamilnadu forest Department",
-              "n": 1
-            },
-            {
               "v": "GIS Cell EF & CC Dept. Mizoram",
-              "n": 1
-            },
-            {
-              "v": "Forest Department Gujrat State",
-              "n": 1
-            },
-            {
-              "v": "Sohagibarwa WildLife Division,Maharajgan(UP)",
-              "n": 1
-            },
-            {
-              "v": "Gis Cell PMU Lucknow",
-              "n": 1
-            },
-            {
-              "v": "Forest Resources & Ecology Divsion ,UP",
               "n": 1
             },
             {
@@ -14938,11 +15089,7 @@
               "n": 1
             },
             {
-              "v": "HP Forest Department",
-              "n": 1
-            },
-            {
-              "v": "Forest Department, Gujarat State",
+              "v": "GIS LAB,Tripura Forest Department",
               "n": 1
             },
             {
@@ -14950,7 +15097,15 @@
               "n": 1
             },
             {
-              "v": "Forest Department ,Gujarat State",
+              "v": "Geomatics Center Mehkar",
+              "n": 1
+            },
+            {
+              "v": "Forest Resources & Ecology Divsion ,UP",
+              "n": 1
+            },
+            {
+              "v": "Geomatics Centre Tamilnadu forest Department",
               "n": 1
             },
             {
@@ -14958,7 +15113,23 @@
               "n": 1
             },
             {
+              "v": "Forest Department ,Gujarat State",
+              "n": 1
+            },
+            {
               "v": "Forest Department Gujarat State,Bhaskarcharya Inst",
+              "n": 1
+            },
+            {
+              "v": "HP Forest Department",
+              "n": 1
+            },
+            {
+              "v": "Gis Cell PMU Lucknow",
+              "n": 1
+            },
+            {
+              "v": "Forest Department Gujrat State",
               "n": 1
             },
             {
@@ -14966,11 +15137,15 @@
               "n": 1
             },
             {
-              "v": "GIS LAB,Tripura Forest Department",
+              "v": "GIS Lab Forest Department,Manipur",
               "n": 1
             },
             {
-              "v": "Kachchh East Forest Division & Bhaskaracharya inst",
+              "v": "Sohagibarwa WildLife Division,Maharajgan(UP)",
+              "n": 1
+            },
+            {
+              "v": "Forest Department, Gujarat State",
               "n": 1
             },
             {
@@ -14978,7 +15153,7 @@
               "n": 1
             },
             {
-              "v": "Geomatics Center Mehkar",
+              "v": "Kachchh East Forest Division & Bhaskaracharya inst",
               "n": 1
             }
           ]
@@ -15012,19 +15187,19 @@
               "n": 3
             },
             {
-              "v": 215712.579133,
+              "v": 15694.7586161,
               "n": 1
             },
             {
-              "v": 226005.042427,
+              "v": 17005.4612771,
               "n": 1
             },
             {
-              "v": 85329.4250679,
+              "v": 194600.235962,
               "n": 1
             },
             {
-              "v": 1.88157886019,
+              "v": 95879.3345728,
               "n": 1
             },
             {
@@ -15036,7 +15211,11 @@
               "n": 1
             },
             {
-              "v": 0.835541360972,
+              "v": 122270.81541,
+              "n": 1
+            },
+            {
+              "v": 226005.042427,
               "n": 1
             },
             {
@@ -15044,67 +15223,7 @@
               "n": 1
             },
             {
-              "v": 112288.234579,
-              "n": 1
-            },
-            {
-              "v": 194600.235962,
-              "n": 1
-            },
-            {
-              "v": 17005.4612771,
-              "n": 1
-            },
-            {
-              "v": 1695.09928119,
-              "n": 1
-            },
-            {
-              "v": 0.406347446858,
-              "n": 1
-            },
-            {
-              "v": 1.55136588867,
-              "n": 1
-            },
-            {
-              "v": 12750.7477521,
-              "n": 1
-            },
-            {
-              "v": 3.59430842459,
-              "n": 1
-            },
-            {
-              "v": 138580.286978,
-              "n": 1
-            },
-            {
-              "v": 15694.7586161,
-              "n": 1
-            },
-            {
-              "v": 38527.8764859,
-              "n": 1
-            },
-            {
-              "v": 1.32049515181,
-              "n": 1
-            },
-            {
-              "v": 51533.546447,
-              "n": 1
-            },
-            {
               "v": 176527.351831,
-              "n": 1
-            },
-            {
-              "v": 7070.97121197,
-              "n": 1
-            },
-            {
-              "v": 122270.81541,
               "n": 1
             },
             {
@@ -15124,7 +15243,63 @@
               "n": 1
             },
             {
-              "v": 95879.3345728,
+              "v": 0.406347446858,
+              "n": 1
+            },
+            {
+              "v": 7070.97121197,
+              "n": 1
+            },
+            {
+              "v": 112288.234579,
+              "n": 1
+            },
+            {
+              "v": 1.32049515181,
+              "n": 1
+            },
+            {
+              "v": 38527.8764859,
+              "n": 1
+            },
+            {
+              "v": 3.59430842459,
+              "n": 1
+            },
+            {
+              "v": 51533.546447,
+              "n": 1
+            },
+            {
+              "v": 138580.286978,
+              "n": 1
+            },
+            {
+              "v": 1695.09928119,
+              "n": 1
+            },
+            {
+              "v": 215712.579133,
+              "n": 1
+            },
+            {
+              "v": 12750.7477521,
+              "n": 1
+            },
+            {
+              "v": 85329.4250679,
+              "n": 1
+            },
+            {
+              "v": 1.88157886019,
+              "n": 1
+            },
+            {
+              "v": 1.55136588867,
+              "n": 1
+            },
+            {
+              "v": 0.835541360972,
               "n": 1
             }
           ]
@@ -15154,7 +15329,11 @@
               "n": 21
             },
             {
-              "v": "Set_8",
+              "v": "Set_4",
+              "n": 20
+            },
+            {
+              "v": "Set_7",
               "n": 20
             },
             {
@@ -15162,11 +15341,7 @@
               "n": 20
             },
             {
-              "v": "Set_4",
-              "n": 20
-            },
-            {
-              "v": "Set_7",
+              "v": "Set_8",
               "n": 20
             },
             {
@@ -15240,11 +15415,11 @@
               "n": 11
             },
             {
-              "v": "17",
+              "v": "11",
               "n": 11
             },
             {
-              "v": "11",
+              "v": "17",
               "n": 11
             },
             {
@@ -15260,11 +15435,11 @@
               "n": 10
             },
             {
-              "v": "31",
+              "v": "16",
               "n": 9
             },
             {
-              "v": "16",
+              "v": "31",
               "n": 9
             },
             {
@@ -15276,11 +15451,11 @@
               "n": 8
             },
             {
-              "v": "28",
+              "v": "14",
               "n": 7
             },
             {
-              "v": "38",
+              "v": "28",
               "n": 7
             },
             {
@@ -15288,16 +15463,8 @@
               "n": 7
             },
             {
-              "v": "14",
+              "v": "38",
               "n": 7
-            },
-            {
-              "v": "26",
-              "n": 6
-            },
-            {
-              "v": "20",
-              "n": 6
             },
             {
               "v": "35",
@@ -15308,15 +15475,27 @@
               "n": 6
             },
             {
+              "v": "20",
+              "n": 6
+            },
+            {
+              "v": "26",
+              "n": 6
+            },
+            {
               "v": "27",
               "n": 5
             },
             {
-              "v": "36",
+              "v": "32",
               "n": 4
             },
             {
-              "v": "32",
+              "v": "30",
+              "n": 4
+            },
+            {
+              "v": "36",
               "n": 4
             },
             {
@@ -15325,10 +15504,6 @@
             },
             {
               "v": "34",
-              "n": 4
-            },
-            {
-              "v": "30",
               "n": 4
             },
             {
@@ -15344,27 +15519,7 @@
               "n": 2
             },
             {
-              "v": "45",
-              "n": 1
-            },
-            {
-              "v": "52",
-              "n": 1
-            },
-            {
-              "v": "2",
-              "n": 1
-            },
-            {
-              "v": "83",
-              "n": 1
-            },
-            {
-              "v": "62",
-              "n": 1
-            },
-            {
-              "v": "7",
+              "v": "15, 16",
               "n": 1
             },
             {
@@ -15372,11 +15527,19 @@
               "n": 1
             },
             {
-              "v": " ",
+              "v": "52",
               "n": 1
             },
             {
-              "v": "15, 16",
+              "v": "62",
+              "n": 1
+            },
+            {
+              "v": "83",
+              "n": 1
+            },
+            {
+              "v": " ",
               "n": 1
             },
             {
@@ -15384,7 +15547,19 @@
               "n": 1
             },
             {
+              "v": "45",
+              "n": 1
+            },
+            {
               "v": "42",
+              "n": 1
+            },
+            {
+              "v": "2",
+              "n": 1
+            },
+            {
+              "v": "7",
               "n": 1
             },
             {
@@ -15473,6 +15648,10 @@
     "OpenCity": {
       "name": "OpenCity / Oorvani Foundation",
       "url": "https://data.opencity.in/"
+    },
+    "bharatviz": {
+      "name": "bharatviz (Saket Choudhary)",
+      "url": "https://bharatviz.org/"
     },
     "_publisher": {
       "name": "yashveeeeeeer/india-geodata",

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated": "2026-05-23T07:36:27.334574+00:00",
+  "generated": "2026-05-23T16:16:46.486302+00:00",
   "country": "IN",
   "r2_base": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev",
   "levels": {
@@ -398,7 +398,11 @@
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/states/SOI_States.parquet",
         "bytes": 10780243
       },
-      "pmtiles": null,
+      "pmtiles": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/admin/states/SOI_States.pmtiles",
+        "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/states/SOI_States.pmtiles",
+        "bytes": 4826221
+      },
       "licence": "CC0-1.0 / CC-BY-4.0",
       "attribution": {
         "primary": {
@@ -425,7 +429,11 @@
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/states/bhuvan_states.parquet",
         "bytes": 2242493
       },
-      "pmtiles": null,
+      "pmtiles": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/admin/states/bhuvan_states.pmtiles",
+        "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/states/bhuvan_states.pmtiles",
+        "bytes": 1147038
+      },
       "licence": "CC0-1.0 / CC-BY-4.0",
       "attribution": {
         "primary": {
@@ -483,7 +491,11 @@
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/districts/SOI_Districts.parquet",
         "bytes": 28691382
       },
-      "pmtiles": null,
+      "pmtiles": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/admin/districts/SOI_Districts.pmtiles",
+        "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/districts/SOI_Districts.pmtiles",
+        "bytes": 10128284
+      },
       "licence": "CC0-1.0 / CC-BY-4.0",
       "attribution": {
         "primary": {
@@ -510,7 +522,11 @@
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/districts/bhuvan_districts.parquet",
         "bytes": 37180992
       },
-      "pmtiles": null,
+      "pmtiles": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/admin/districts/bhuvan_districts.pmtiles",
+        "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/districts/bhuvan_districts.pmtiles",
+        "bytes": 15114633
+      },
       "licence": "CC0-1.0 / CC-BY-4.0",
       "attribution": {
         "primary": {
@@ -568,7 +584,11 @@
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/subdistricts/SOI_Subdistricts.parquet",
         "bytes": 56835970
       },
-      "pmtiles": null,
+      "pmtiles": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/admin/subdistricts/SOI_Subdistricts.pmtiles",
+        "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/subdistricts/SOI_Subdistricts.pmtiles",
+        "bytes": 22449178
+      },
       "licence": "CC0-1.0",
       "attribution": {
         "primary": {
@@ -626,7 +646,11 @@
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/blocks/bhuvan_blocks.parquet",
         "bytes": 97298502
       },
-      "pmtiles": null,
+      "pmtiles": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/admin/blocks/bhuvan_blocks.pmtiles",
+        "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/blocks/bhuvan_blocks.pmtiles",
+        "bytes": 39341155
+      },
       "licence": "CC0-1.0",
       "attribution": {
         "primary": {
@@ -653,7 +677,11 @@
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/blocks/PMGSY_Blocks.parquet",
         "bytes": 182298315
       },
-      "pmtiles": null,
+      "pmtiles": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/admin/blocks/PMGSY_Blocks.pmtiles",
+        "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/blocks/PMGSY_Blocks.pmtiles",
+        "bytes": 37787333
+      },
       "licence": "CC0-1.0",
       "attribution": {
         "primary": {
@@ -736,13 +764,17 @@
       "id": "soi_village_points",
       "level": "village",
       "source": "SOI",
-      "rows": null,
+      "rows": 576430,
       "parquet": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/admin/villages/SOI_VILLAGE_POINT.parquet",
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/villages/SOI_VILLAGE_POINT.parquet",
         "bytes": 26718248
       },
-      "pmtiles": null,
+      "pmtiles": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/admin/villages/SOI_VILLAGE_POINT.pmtiles",
+        "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/admin/villages/SOI_VILLAGE_POINT.pmtiles",
+        "bytes": 60575972
+      },
       "licence": "CC0-1.0",
       "attribution": {
         "primary": {
@@ -757,7 +789,7 @@
       "category": "administrative",
       "provenance": "curated",
       "fetched_at": "2026-04-26T13:01:32.132923+00:00",
-      "notes": "SoI village centroids (point geometry)."
+      "notes": "SoI village centroids (point geometry). 5.76 lakh point features \u2014 every revenue village named by SoI."
     },
     {
       "id": "lgd_parliament",
@@ -4105,6 +4137,62 @@
           "max": 36,
           "top_values": [
             {
+              "v": 34,
+              "n": 1
+            },
+            {
+              "v": 16,
+              "n": 1
+            },
+            {
+              "v": 8,
+              "n": 1
+            },
+            {
+              "v": 17,
+              "n": 1
+            },
+            {
+              "v": 3,
+              "n": 1
+            },
+            {
+              "v": 4,
+              "n": 1
+            },
+            {
+              "v": 15,
+              "n": 1
+            },
+            {
+              "v": 20,
+              "n": 1
+            },
+            {
+              "v": 35,
+              "n": 1
+            },
+            {
+              "v": 24,
+              "n": 1
+            },
+            {
+              "v": 21,
+              "n": 1
+            },
+            {
+              "v": 25,
+              "n": 1
+            },
+            {
+              "v": 10,
+              "n": 1
+            },
+            {
+              "v": 33,
+              "n": 1
+            },
+            {
               "v": 19,
               "n": 1
             },
@@ -4125,23 +4213,19 @@
               "n": 1
             },
             {
-              "v": 15,
+              "v": 18,
               "n": 1
             },
             {
-              "v": 20,
+              "v": 22,
               "n": 1
             },
             {
-              "v": 25,
+              "v": 1,
               "n": 1
             },
             {
-              "v": 10,
-              "n": 1
-            },
-            {
-              "v": 33,
+              "v": 11,
               "n": 1
             },
             {
@@ -4161,7 +4245,11 @@
               "n": 1
             },
             {
-              "v": 34,
+              "v": 6,
+              "n": 1
+            },
+            {
+              "v": 36,
               "n": 1
             },
             {
@@ -4177,50 +4265,6 @@
               "n": 1
             },
             {
-              "v": 35,
-              "n": 1
-            },
-            {
-              "v": 24,
-              "n": 1
-            },
-            {
-              "v": 16,
-              "n": 1
-            },
-            {
-              "v": 8,
-              "n": 1
-            },
-            {
-              "v": 17,
-              "n": 1
-            },
-            {
-              "v": 6,
-              "n": 1
-            },
-            {
-              "v": 36,
-              "n": 1
-            },
-            {
-              "v": 11,
-              "n": 1
-            },
-            {
-              "v": 3,
-              "n": 1
-            },
-            {
-              "v": 4,
-              "n": 1
-            },
-            {
-              "v": 12,
-              "n": 1
-            },
-            {
               "v": 7,
               "n": 1
             },
@@ -4233,19 +4277,7 @@
               "n": 1
             },
             {
-              "v": 21,
-              "n": 1
-            },
-            {
-              "v": 18,
-              "n": 1
-            },
-            {
-              "v": 22,
-              "n": 1
-            },
-            {
-              "v": 1,
+              "v": 12,
               "n": 1
             }
           ]
@@ -4267,19 +4299,55 @@
               "n": 1
             },
             {
+              "v": "DELHI",
+              "n": 1
+            },
+            {
+              "v": "MADHYA PRADESH",
+              "n": 1
+            },
+            {
+              "v": "KERALA",
+              "n": 1
+            },
+            {
+              "v": "MAHARASHTRA",
+              "n": 1
+            },
+            {
+              "v": "DADRA,NAGAR HAVELI,DAMAN & DIU",
+              "n": 1
+            },
+            {
+              "v": "MIZORAM",
+              "n": 1
+            },
+            {
               "v": "ARUNACHAL PRADESH",
               "n": 1
             },
             {
-              "v": "TELANGANA",
+              "v": "UTTAR PRADESH",
               "n": 1
             },
             {
-              "v": "SIKKIM",
+              "v": "MEGHALAYA",
               "n": 1
             },
             {
-              "v": "BIHAR",
+              "v": "ODISHA",
+              "n": 1
+            },
+            {
+              "v": "CHHATTISGARH",
+              "n": 1
+            },
+            {
+              "v": "HIMACHAL PRADESH",
+              "n": 1
+            },
+            {
+              "v": "PUNJAB",
               "n": 1
             },
             {
@@ -4300,14 +4368,6 @@
             },
             {
               "v": "UTTARAKHAND",
-              "n": 1
-            },
-            {
-              "v": "KARNATAKA",
-              "n": 1
-            },
-            {
-              "v": "MANIPUR",
               "n": 1
             },
             {
@@ -4335,7 +4395,27 @@
               "n": 1
             },
             {
+              "v": "TELANGANA",
+              "n": 1
+            },
+            {
+              "v": "SIKKIM",
+              "n": 1
+            },
+            {
+              "v": "BIHAR",
+              "n": 1
+            },
+            {
               "v": "WEST BENGAL",
+              "n": 1
+            },
+            {
+              "v": "KARNATAKA",
+              "n": 1
+            },
+            {
+              "v": "MANIPUR",
               "n": 1
             },
             {
@@ -4353,54 +4433,6 @@
             {
               "v": "ANDAMAN & NICOBAR",
               "n": 1
-            },
-            {
-              "v": "KERALA",
-              "n": 1
-            },
-            {
-              "v": "MAHARASHTRA",
-              "n": 1
-            },
-            {
-              "v": "DELHI",
-              "n": 1
-            },
-            {
-              "v": "MADHYA PRADESH",
-              "n": 1
-            },
-            {
-              "v": "ODISHA",
-              "n": 1
-            },
-            {
-              "v": "CHHATTISGARH",
-              "n": 1
-            },
-            {
-              "v": "HIMACHAL PRADESH",
-              "n": 1
-            },
-            {
-              "v": "DADRA,NAGAR HAVELI,DAMAN & DIU",
-              "n": 1
-            },
-            {
-              "v": "MIZORAM",
-              "n": 1
-            },
-            {
-              "v": "PUNJAB",
-              "n": 1
-            },
-            {
-              "v": "UTTAR PRADESH",
-              "n": 1
-            },
-            {
-              "v": "MEGHALAYA",
-              "n": 1
             }
           ]
         },
@@ -4413,31 +4445,59 @@
           "max": "39",
           "top_values": [
             {
-              "v": "32",
+              "v": "20",
               "n": 1
             },
             {
-              "v": "38",
+              "v": "15",
               "n": 1
             },
             {
-              "v": "23",
+              "v": "29",
               "n": 1
             },
             {
-              "v": "19",
+              "v": "02",
               "n": 1
             },
             {
-              "v": "13",
+              "v": "14",
+              "n": 1
+            },
+            {
+              "v": "03",
+              "n": 1
+            },
+            {
+              "v": "17",
+              "n": 1
+            },
+            {
+              "v": "16",
+              "n": 1
+            },
+            {
+              "v": "31",
+              "n": 1
+            },
+            {
+              "v": "27",
+              "n": 1
+            },
+            {
+              "v": "30",
+              "n": 1
+            },
+            {
+              "v": "33",
+              "n": 1
+            },
+            {
+              "v": "10",
               "n": 1
             },
             {
               "v": "11",
-              "n": 1
-            },
-            {
-              "v": "21",
               "n": 1
             },
             {
@@ -4461,35 +4521,35 @@
               "n": 1
             },
             {
-              "v": "22",
+              "v": "01",
               "n": 1
             },
             {
-              "v": "18",
+              "v": "05",
               "n": 1
             },
             {
-              "v": "31",
+              "v": "32",
               "n": 1
             },
             {
-              "v": "27",
+              "v": "38",
               "n": 1
             },
             {
-              "v": "30",
+              "v": "23",
               "n": 1
             },
             {
-              "v": "03",
+              "v": "19",
               "n": 1
             },
             {
-              "v": "17",
+              "v": "13",
               "n": 1
             },
             {
-              "v": "16",
+              "v": "21",
               "n": 1
             },
             {
@@ -4505,23 +4565,15 @@
               "n": 1
             },
             {
-              "v": "33",
-              "n": 1
-            },
-            {
-              "v": "10",
-              "n": 1
-            },
-            {
               "v": "34",
               "n": 1
             },
             {
-              "v": "20",
+              "v": "22",
               "n": 1
             },
             {
-              "v": "15",
+              "v": "18",
               "n": 1
             },
             {
@@ -4535,26 +4587,6 @@
             {
               "v": "35",
               "n": 1
-            },
-            {
-              "v": "01",
-              "n": 1
-            },
-            {
-              "v": "05",
-              "n": 1
-            },
-            {
-              "v": "29",
-              "n": 1
-            },
-            {
-              "v": "02",
-              "n": 1
-            },
-            {
-              "v": "14",
-              "n": 1
             }
           ]
         },
@@ -4567,31 +4599,19 @@
           "max": 38,
           "top_values": [
             {
-              "v": 34,
+              "v": 12,
               "n": 1
             },
             {
-              "v": 20,
+              "v": 36,
               "n": 1
             },
             {
-              "v": 15,
+              "v": 6,
               "n": 1
             },
             {
               "v": 11,
-              "n": 1
-            },
-            {
-              "v": 5,
-              "n": 1
-            },
-            {
-              "v": 9,
-              "n": 1
-            },
-            {
-              "v": 7,
               "n": 1
             },
             {
@@ -4604,14 +4624,6 @@
             },
             {
               "v": 16,
-              "n": 1
-            },
-            {
-              "v": 36,
-              "n": 1
-            },
-            {
-              "v": 6,
               "n": 1
             },
             {
@@ -4631,6 +4643,38 @@
               "n": 1
             },
             {
+              "v": 5,
+              "n": 1
+            },
+            {
+              "v": 9,
+              "n": 1
+            },
+            {
+              "v": 7,
+              "n": 1
+            },
+            {
+              "v": 33,
+              "n": 1
+            },
+            {
+              "v": 10,
+              "n": 1
+            },
+            {
+              "v": 34,
+              "n": 1
+            },
+            {
+              "v": 20,
+              "n": 1
+            },
+            {
+              "v": 15,
+              "n": 1
+            },
+            {
               "v": 31,
               "n": 1
             },
@@ -4644,6 +4688,18 @@
             },
             {
               "v": 2,
+              "n": 1
+            },
+            {
+              "v": 24,
+              "n": 1
+            },
+            {
+              "v": 37,
+              "n": 1
+            },
+            {
+              "v": 35,
               "n": 1
             },
             {
@@ -4679,35 +4735,11 @@
               "n": 1
             },
             {
-              "v": 12,
-              "n": 1
-            },
-            {
-              "v": 33,
-              "n": 1
-            },
-            {
-              "v": 10,
-              "n": 1
-            },
-            {
               "v": 3,
               "n": 1
             },
             {
               "v": 4,
-              "n": 1
-            },
-            {
-              "v": 24,
-              "n": 1
-            },
-            {
-              "v": 37,
-              "n": 1
-            },
-            {
-              "v": 35,
               "n": 1
             }
           ]
@@ -4721,23 +4753,19 @@
           "max": "West Bengal",
           "top_values": [
             {
-              "v": "Maharashtra",
-              "n": 1
-            },
-            {
-              "v": "Andaman & Nicobar",
-              "n": 1
-            },
-            {
-              "v": "Dadra,Nagar Haveli,Daman & Diu",
-              "n": 1
-            },
-            {
               "v": "Tamil nadu",
               "n": 1
             },
             {
               "v": "Kerala",
+              "n": 1
+            },
+            {
+              "v": "Chhattisgarh",
+              "n": 1
+            },
+            {
+              "v": "Tripura",
               "n": 1
             },
             {
@@ -4750,6 +4778,18 @@
             },
             {
               "v": "Mizoram",
+              "n": 1
+            },
+            {
+              "v": "Karnataka",
+              "n": 1
+            },
+            {
+              "v": "Punjab",
+              "n": 1
+            },
+            {
+              "v": "Odisha",
               "n": 1
             },
             {
@@ -4769,6 +4809,34 @@
               "n": 1
             },
             {
+              "v": "Andaman & Nicobar",
+              "n": 1
+            },
+            {
+              "v": "Andhra Pradesh",
+              "n": 1
+            },
+            {
+              "v": "Maharashtra",
+              "n": 1
+            },
+            {
+              "v": "Rajasthan",
+              "n": 1
+            },
+            {
+              "v": "Bihar",
+              "n": 1
+            },
+            {
+              "v": "Uttarakhand",
+              "n": 1
+            },
+            {
+              "v": "Assam",
+              "n": 1
+            },
+            {
               "v": "Jammu & Kashmir",
               "n": 1
             },
@@ -4785,6 +4853,10 @@
               "n": 1
             },
             {
+              "v": "Dadra,Nagar Haveli,Daman & Diu",
+              "n": 1
+            },
+            {
               "v": "Haryana",
               "n": 1
             },
@@ -4797,51 +4869,11 @@
               "n": 1
             },
             {
-              "v": "Chhattisgarh",
-              "n": 1
-            },
-            {
-              "v": "Tripura",
-              "n": 1
-            },
-            {
-              "v": "Andhra Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Karnataka",
-              "n": 1
-            },
-            {
-              "v": "Punjab",
-              "n": 1
-            },
-            {
-              "v": "Odisha",
-              "n": 1
-            },
-            {
               "v": "Madhya Pradesh",
               "n": 1
             },
             {
               "v": "Sikkim",
-              "n": 1
-            },
-            {
-              "v": "Uttarakhand",
-              "n": 1
-            },
-            {
-              "v": "Assam",
-              "n": 1
-            },
-            {
-              "v": "Rajasthan",
-              "n": 1
-            },
-            {
-              "v": "Bihar",
               "n": 1
             },
             {
@@ -4875,15 +4907,31 @@
           "max": "WEST BENGAL",
           "top_values": [
             {
-              "v": "DADRA,NAGAR HAVELI,DAMAN & DIU",
+              "v": "WEST BENGAL",
               "n": 1
             },
             {
-              "v": "MIZORAM",
+              "v": "KERALA",
               "n": 1
             },
             {
-              "v": "ARUNACHAL PRADESH",
+              "v": "MAHARASHTRA",
+              "n": 1
+            },
+            {
+              "v": "RAJASTHAN",
+              "n": 1
+            },
+            {
+              "v": "CHANDIGARH",
+              "n": 1
+            },
+            {
+              "v": "KARNATAKA",
+              "n": 1
+            },
+            {
+              "v": "MANIPUR",
               "n": 1
             },
             {
@@ -4899,55 +4947,11 @@
               "n": 1
             },
             {
-              "v": "KARNATAKA",
+              "v": "DADRA,NAGAR HAVELI,DAMAN & DIU",
               "n": 1
             },
             {
-              "v": "MANIPUR",
-              "n": 1
-            },
-            {
-              "v": "PUDUCHERRY",
-              "n": 1
-            },
-            {
-              "v": "TAMIL NADU",
-              "n": 1
-            },
-            {
-              "v": "GOA",
-              "n": 1
-            },
-            {
-              "v": "LADAKH",
-              "n": 1
-            },
-            {
-              "v": "UTTARAKHAND",
-              "n": 1
-            },
-            {
-              "v": "LAKSHADWEEP",
-              "n": 1
-            },
-            {
-              "v": "GUJARAT",
-              "n": 1
-            },
-            {
-              "v": "HARYANA",
-              "n": 1
-            },
-            {
-              "v": "ANDAMAN & NICOBAR",
-              "n": 1
-            },
-            {
-              "v": "RAJASTHAN",
-              "n": 1
-            },
-            {
-              "v": "CHANDIGARH",
+              "v": "MIZORAM",
               "n": 1
             },
             {
@@ -4971,10 +4975,6 @@
               "n": 1
             },
             {
-              "v": "WEST BENGAL",
-              "n": 1
-            },
-            {
               "v": "UTTAR PRADESH",
               "n": 1
             },
@@ -4983,11 +4983,43 @@
               "n": 1
             },
             {
-              "v": "KERALA",
+              "v": "LAKSHADWEEP",
               "n": 1
             },
             {
-              "v": "MAHARASHTRA",
+              "v": "GUJARAT",
+              "n": 1
+            },
+            {
+              "v": "HARYANA",
+              "n": 1
+            },
+            {
+              "v": "ANDAMAN & NICOBAR",
+              "n": 1
+            },
+            {
+              "v": "PUDUCHERRY",
+              "n": 1
+            },
+            {
+              "v": "TAMIL NADU",
+              "n": 1
+            },
+            {
+              "v": "GOA",
+              "n": 1
+            },
+            {
+              "v": "LADAKH",
+              "n": 1
+            },
+            {
+              "v": "UTTARAKHAND",
+              "n": 1
+            },
+            {
+              "v": "ARUNACHAL PRADESH",
               "n": 1
             },
             {
@@ -5033,38 +5065,6 @@
               "n": 1
             },
             {
-              "v": 12,
-              "n": 1
-            },
-            {
-              "v": 16,
-              "n": 1
-            },
-            {
-              "v": 8,
-              "n": 1
-            },
-            {
-              "v": 17,
-              "n": 1
-            },
-            {
-              "v": 7,
-              "n": 1
-            },
-            {
-              "v": 9,
-              "n": 1
-            },
-            {
-              "v": 5,
-              "n": 1
-            },
-            {
-              "v": 34,
-              "n": 1
-            },
-            {
               "v": 15,
               "n": 1
             },
@@ -5073,19 +5073,15 @@
               "n": 1
             },
             {
+              "v": 12,
+              "n": 1
+            },
+            {
               "v": 6,
               "n": 1
             },
             {
               "v": 36,
-              "n": 1
-            },
-            {
-              "v": 3,
-              "n": 1
-            },
-            {
-              "v": 4,
               "n": 1
             },
             {
@@ -5121,7 +5117,55 @@
               "n": 1
             },
             {
+              "v": 3,
+              "n": 1
+            },
+            {
+              "v": 4,
+              "n": 1
+            },
+            {
               "v": 11,
+              "n": 1
+            },
+            {
+              "v": 34,
+              "n": 1
+            },
+            {
+              "v": 16,
+              "n": 1
+            },
+            {
+              "v": 8,
+              "n": 1
+            },
+            {
+              "v": 17,
+              "n": 1
+            },
+            {
+              "v": 7,
+              "n": 1
+            },
+            {
+              "v": 9,
+              "n": 1
+            },
+            {
+              "v": 5,
+              "n": 1
+            },
+            {
+              "v": 25,
+              "n": 1
+            },
+            {
+              "v": 10,
+              "n": 1
+            },
+            {
+              "v": 33,
               "n": 1
             },
             {
@@ -5141,26 +5185,6 @@
               "n": 1
             },
             {
-              "v": 25,
-              "n": 1
-            },
-            {
-              "v": 10,
-              "n": 1
-            },
-            {
-              "v": 33,
-              "n": 1
-            },
-            {
-              "v": 35,
-              "n": 1
-            },
-            {
-              "v": 24,
-              "n": 1
-            },
-            {
               "v": 29,
               "n": 1
             },
@@ -5170,6 +5194,14 @@
             },
             {
               "v": 28,
+              "n": 1
+            },
+            {
+              "v": 35,
+              "n": 1
+            },
+            {
+              "v": 24,
               "n": 1
             }
           ]
@@ -5207,7 +5239,51 @@
           "max": 8199150.436219864,
           "top_values": [
             {
-              "v": 534841.8751139762,
+              "v": 3691262.239632214,
+              "n": 1
+            },
+            {
+              "v": 72104.71259266634,
+              "n": 1
+            },
+            {
+              "v": 2963355.7852354585,
+              "n": 1
+            },
+            {
+              "v": 3627756.7504065335,
+              "n": 1
+            },
+            {
+              "v": 3362506.6182253817,
+              "n": 1
+            },
+            {
+              "v": 2654010.5642531104,
+              "n": 1
+            },
+            {
+              "v": 5945590.302377821,
+              "n": 1
+            },
+            {
+              "v": 1765005.5137781699,
+              "n": 1
+            },
+            {
+              "v": 3727338.8046791204,
+              "n": 1
+            },
+            {
+              "v": 423019.02810073394,
+              "n": 1
+            },
+            {
+              "v": 1131857.3004578887,
+              "n": 1
+            },
+            {
+              "v": 3937758.1759938635,
               "n": 1
             },
             {
@@ -5219,11 +5295,47 @@
               "n": 1
             },
             {
-              "v": 3627756.7504065335,
+              "v": 534841.8751139762,
               "n": 1
             },
             {
-              "v": 3362506.6182253817,
+              "v": 4851482.322101016,
+              "n": 1
+            },
+            {
+              "v": 347804.26272029406,
+              "n": 1
+            },
+            {
+              "v": 5597278.066786466,
+              "n": 1
+            },
+            {
+              "v": 2008605.4870488604,
+              "n": 1
+            },
+            {
+              "v": 3014349.351586134,
+              "n": 1
+            },
+            {
+              "v": 2228761.2629810357,
+              "n": 1
+            },
+            {
+              "v": 271575.03003122885,
+              "n": 1
+            },
+            {
+              "v": 3367509.5437867576,
+              "n": 1
+            },
+            {
+              "v": 5742877.345496983,
+              "n": 1
+            },
+            {
+              "v": 1049358.6037059696,
               "n": 1
             },
             {
@@ -5247,90 +5359,6 @@
               "n": 1
             },
             {
-              "v": 2228761.2629810357,
-              "n": 1
-            },
-            {
-              "v": 271575.03003122885,
-              "n": 1
-            },
-            {
-              "v": 3367509.5437867576,
-              "n": 1
-            },
-            {
-              "v": 5742877.345496983,
-              "n": 1
-            },
-            {
-              "v": 3691262.239632214,
-              "n": 1
-            },
-            {
-              "v": 72104.71259266634,
-              "n": 1
-            },
-            {
-              "v": 2963355.7852354585,
-              "n": 1
-            },
-            {
-              "v": 2654010.5642531104,
-              "n": 1
-            },
-            {
-              "v": 5945590.302377821,
-              "n": 1
-            },
-            {
-              "v": 1765005.5137781699,
-              "n": 1
-            },
-            {
-              "v": 3727338.8046791204,
-              "n": 1
-            },
-            {
-              "v": 6147365.473505214,
-              "n": 1
-            },
-            {
-              "v": 6579818.404422868,
-              "n": 1
-            },
-            {
-              "v": 347804.26272029406,
-              "n": 1
-            },
-            {
-              "v": 5597278.066786466,
-              "n": 1
-            },
-            {
-              "v": 2008605.4870488604,
-              "n": 1
-            },
-            {
-              "v": 3014349.351586134,
-              "n": 1
-            },
-            {
-              "v": 1049358.6037059696,
-              "n": 1
-            },
-            {
-              "v": 423019.02810073394,
-              "n": 1
-            },
-            {
-              "v": 1131857.3004578887,
-              "n": 1
-            },
-            {
-              "v": 3937758.1759938635,
-              "n": 1
-            },
-            {
               "v": 5767382.952231494,
               "n": 1
             },
@@ -5347,7 +5375,11 @@
               "n": 1
             },
             {
-              "v": 4851482.322101016,
+              "v": 6147365.473505214,
+              "n": 1
+            },
+            {
+              "v": 6579818.404422868,
               "n": 1
             }
           ]
@@ -5360,26 +5392,6 @@
           "min": 31132861.649632555,
           "max": 429971589919.2261,
           "top_values": [
-            {
-              "v": 156559060771.8496,
-              "n": 1
-            },
-            {
-              "v": 3999136843.180849,
-              "n": 1
-            },
-            {
-              "v": 155763425.45970094,
-              "n": 1
-            },
-            {
-              "v": 25115122035.990982,
-              "n": 1
-            },
-            {
-              "v": 27206322743.964745,
-              "n": 1
-            },
             {
               "v": 71691838243.6549,
               "n": 1
@@ -5397,6 +5409,38 @@
               "n": 1
             },
             {
+              "v": 304575234931.07745,
+              "n": 1
+            },
+            {
+              "v": 9070963317.360067,
+              "n": 1
+            },
+            {
+              "v": 206400848840.97125,
+              "n": 1
+            },
+            {
+              "v": 31132861.649632555,
+              "n": 1
+            },
+            {
+              "v": 79129960790.28015,
+              "n": 1
+            },
+            {
+              "v": 40460733017.44443,
+              "n": 1
+            },
+            {
+              "v": 58205292626.15533,
+              "n": 1
+            },
+            {
+              "v": 368622520063.3496,
+              "n": 1
+            },
+            {
               "v": 98104009174.95964,
               "n": 1
             },
@@ -5405,11 +5449,11 @@
               "n": 1
             },
             {
-              "v": 124398801034.53966,
+              "v": 530362564.4613942,
               "n": 1
             },
             {
-              "v": 68561182525.645645,
+              "v": 216970754025.63974,
               "n": 1
             },
             {
@@ -5437,27 +5481,7 @@
               "n": 1
             },
             {
-              "v": 20643998182.367287,
-              "n": 1
-            },
-            {
-              "v": 40460733017.44443,
-              "n": 1
-            },
-            {
-              "v": 58205292626.15533,
-              "n": 1
-            },
-            {
-              "v": 368622520063.3496,
-              "n": 1
-            },
-            {
-              "v": 304575234931.07745,
-              "n": 1
-            },
-            {
-              "v": 9070963317.360067,
+              "v": 135846782201.40788,
               "n": 1
             },
             {
@@ -5473,11 +5497,23 @@
               "n": 1
             },
             {
-              "v": 135846782201.40788,
+              "v": 156559060771.8496,
               "n": 1
             },
             {
-              "v": 206400848840.97125,
+              "v": 3999136843.180849,
+              "n": 1
+            },
+            {
+              "v": 155763425.45970094,
+              "n": 1
+            },
+            {
+              "v": 25115122035.990982,
+              "n": 1
+            },
+            {
+              "v": 27206322743.964745,
               "n": 1
             },
             {
@@ -5489,19 +5525,15 @@
               "n": 1
             },
             {
-              "v": 530362564.4613942,
+              "v": 20643998182.367287,
               "n": 1
             },
             {
-              "v": 216970754025.63974,
+              "v": 124398801034.53966,
               "n": 1
             },
             {
-              "v": 31132861.649632555,
-              "n": 1
-            },
-            {
-              "v": 79129960790.28015,
+              "v": 68561182525.645645,
               "n": 1
             }
           ]
@@ -5526,26 +5558,6 @@
           "max": "WEST BENGAL",
           "top_values": [
             {
-              "v": "PUDUCHERRY",
-              "n": 1
-            },
-            {
-              "v": "KARN\u0100TAKA",
-              "n": 1
-            },
-            {
-              "v": "GOA",
-              "n": 1
-            },
-            {
-              "v": "DISPUTED (MADHYA PRADESH & R\u0100JASTH\u0100N)",
-              "n": 1
-            },
-            {
-              "v": "MEGH\u0100LAYA",
-              "n": 1
-            },
-            {
               "v": "ANDHRA PRADESH",
               "n": 1
             },
@@ -5566,11 +5578,19 @@
               "n": 1
             },
             {
-              "v": "TELANG\u0100NA",
+              "v": "HIM\u0100CHAL PRADESH",
               "n": 1
             },
             {
-              "v": "HARY\u0100NA",
+              "v": "SIKKIM",
+              "n": 1
+            },
+            {
+              "v": "PUNJAB",
+              "n": 1
+            },
+            {
+              "v": "LAD\u0100KH",
               "n": 1
             },
             {
@@ -5586,19 +5606,39 @@
               "n": 1
             },
             {
-              "v": "DISPUTED (R\u0100JATH\u0100N & GUJAR\u0100T)",
+              "v": "KERALA",
               "n": 1
             },
             {
-              "v": "R\u0100JASTH\u0100N",
+              "v": "N\u0100G\u0100LAND",
               "n": 1
             },
             {
-              "v": "UTTAR\u0100KHAND",
+              "v": "ODISHA",
               "n": 1
             },
             {
-              "v": "WEST BENGAL",
+              "v": "TELANG\u0100NA",
+              "n": 1
+            },
+            {
+              "v": "HARY\u0100NA",
+              "n": 1
+            },
+            {
+              "v": "DISPUTED (MADHYA PRADESH & GUJAR\u0100T)",
+              "n": 1
+            },
+            {
+              "v": "DISPUTED (WEST BENGAL , BIH\u0100R & JH\u0100RKHAND)",
+              "n": 1
+            },
+            {
+              "v": "BIH\u0100R",
+              "n": 1
+            },
+            {
+              "v": "MIZORAM",
               "n": 1
             },
             {
@@ -5610,15 +5650,23 @@
               "n": 1
             },
             {
-              "v": "ODISHA",
+              "v": "PUDUCHERRY",
               "n": 1
             },
             {
-              "v": "KERALA",
+              "v": "KARN\u0100TAKA",
               "n": 1
             },
             {
-              "v": "N\u0100G\u0100LAND",
+              "v": "GOA",
+              "n": 1
+            },
+            {
+              "v": "DISPUTED (MADHYA PRADESH & R\u0100JASTH\u0100N)",
+              "n": 1
+            },
+            {
+              "v": "MEGH\u0100LAYA",
               "n": 1
             },
             {
@@ -5642,14 +5690,6 @@
               "n": 1
             },
             {
-              "v": "HIM\u0100CHAL PRADESH",
-              "n": 1
-            },
-            {
-              "v": "SIKKIM",
-              "n": 1
-            },
-            {
               "v": "MAH\u0100R\u0100SHTRA",
               "n": 1
             },
@@ -5662,27 +5702,19 @@
               "n": 1
             },
             {
-              "v": "DISPUTED (WEST BENGAL , BIH\u0100R & JH\u0100RKHAND)",
+              "v": "DISPUTED (R\u0100JATH\u0100N & GUJAR\u0100T)",
               "n": 1
             },
             {
-              "v": "BIH\u0100R",
+              "v": "R\u0100JASTH\u0100N",
               "n": 1
             },
             {
-              "v": "MIZORAM",
+              "v": "UTTAR\u0100KHAND",
               "n": 1
             },
             {
-              "v": "DISPUTED (MADHYA PRADESH & GUJAR\u0100T)",
-              "n": 1
-            },
-            {
-              "v": "PUNJAB",
-              "n": 1
-            },
-            {
-              "v": "LAD\u0100KH",
+              "v": "WEST BENGAL",
               "n": 1
             }
           ]
@@ -5700,39 +5732,15 @@
               "n": 4
             },
             {
-              "v": 5,
+              "v": 11,
               "n": 1
             },
             {
-              "v": 2,
+              "v": 7,
               "n": 1
             },
             {
-              "v": 8,
-              "n": 1
-            },
-            {
-              "v": 17,
-              "n": 1
-            },
-            {
-              "v": 16,
-              "n": 1
-            },
-            {
-              "v": 36,
-              "n": 1
-            },
-            {
-              "v": 6,
-              "n": 1
-            },
-            {
-              "v": 38,
-              "n": 1
-            },
-            {
-              "v": 21,
+              "v": 15,
               "n": 1
             },
             {
@@ -5740,23 +5748,31 @@
               "n": 1
             },
             {
-              "v": 34,
+              "v": 10,
               "n": 1
             },
             {
-              "v": 22,
+              "v": 21,
               "n": 1
             },
             {
-              "v": 1,
+              "v": 37,
               "n": 1
             },
             {
-              "v": 18,
+              "v": 24,
               "n": 1
             },
             {
-              "v": 11,
+              "v": 35,
+              "n": 1
+            },
+            {
+              "v": 33,
+              "n": 1
+            },
+            {
+              "v": 36,
               "n": 1
             },
             {
@@ -5764,7 +5780,7 @@
               "n": 1
             },
             {
-              "v": 30,
+              "v": 38,
               "n": 1
             },
             {
@@ -5780,39 +5796,15 @@
               "n": 1
             },
             {
-              "v": 33,
+              "v": 22,
               "n": 1
             },
             {
-              "v": 10,
+              "v": 1,
               "n": 1
             },
             {
-              "v": 20,
-              "n": 1
-            },
-            {
-              "v": 15,
-              "n": 1
-            },
-            {
-              "v": 24,
-              "n": 1
-            },
-            {
-              "v": 37,
-              "n": 1
-            },
-            {
-              "v": 35,
-              "n": 1
-            },
-            {
-              "v": 3,
-              "n": 1
-            },
-            {
-              "v": 4,
+              "v": 18,
               "n": 1
             },
             {
@@ -5828,6 +5820,34 @@
               "n": 1
             },
             {
+              "v": 34,
+              "n": 1
+            },
+            {
+              "v": 6,
+              "n": 1
+            },
+            {
+              "v": 3,
+              "n": 1
+            },
+            {
+              "v": 4,
+              "n": 1
+            },
+            {
+              "v": 8,
+              "n": 1
+            },
+            {
+              "v": 17,
+              "n": 1
+            },
+            {
+              "v": 16,
+              "n": 1
+            },
+            {
               "v": 31,
               "n": 1
             },
@@ -5836,11 +5856,23 @@
               "n": 1
             },
             {
+              "v": 30,
+              "n": 1
+            },
+            {
+              "v": 2,
+              "n": 1
+            },
+            {
+              "v": 5,
+              "n": 1
+            },
+            {
               "v": 9,
               "n": 1
             },
             {
-              "v": 7,
+              "v": 20,
               "n": 1
             }
           ]
@@ -5854,31 +5886,31 @@
           "max": 7367386.55486,
           "top_values": [
             {
-              "v": 5255584.61647,
+              "v": 3650797.43791,
               "n": 1
             },
             {
-              "v": 7367386.55486,
+              "v": 234859.24611,
               "n": 1
             },
             {
-              "v": 3228020.47459,
+              "v": 321582.368932,
               "n": 1
             },
             {
-              "v": 1000977.86666,
+              "v": 62113.0763786,
               "n": 1
             },
             {
-              "v": 1869642.34988,
+              "v": 3051893.17033,
               "n": 1
             },
             {
-              "v": 69953.923576,
+              "v": 18063.0554287,
               "n": 1
             },
             {
-              "v": 908482.059297,
+              "v": 1294185.60295,
               "n": 1
             },
             {
@@ -5894,14 +5926,6 @@
               "n": 1
             },
             {
-              "v": 2489986.05555,
-              "n": 1
-            },
-            {
-              "v": 466580.959052,
-              "n": 1
-            },
-            {
               "v": 144322.282827,
               "n": 1
             },
@@ -5914,11 +5938,11 @@
               "n": 1
             },
             {
-              "v": 3650797.43791,
+              "v": 69953.923576,
               "n": 1
             },
             {
-              "v": 234859.24611,
+              "v": 908482.059297,
               "n": 1
             },
             {
@@ -5930,15 +5954,7 @@
               "n": 1
             },
             {
-              "v": 321582.368932,
-              "n": 1
-            },
-            {
-              "v": 62113.0763786,
-              "n": 1
-            },
-            {
-              "v": 3051893.17033,
+              "v": 1869642.34988,
               "n": 1
             },
             {
@@ -5962,15 +5978,35 @@
               "n": 1
             },
             {
-              "v": 6169514.62592,
+              "v": 2489986.05555,
               "n": 1
             },
             {
-              "v": 18063.0554287,
+              "v": 5255584.61647,
               "n": 1
             },
             {
-              "v": 1294185.60295,
+              "v": 7367386.55486,
+              "n": 1
+            },
+            {
+              "v": 3228020.47459,
+              "n": 1
+            },
+            {
+              "v": 1000977.86666,
+              "n": 1
+            },
+            {
+              "v": 466580.959052,
+              "n": 1
+            },
+            {
+              "v": 5334646.8294,
+              "n": 1
+            },
+            {
+              "v": 3027573.76649,
               "n": 1
             },
             {
@@ -5986,11 +6022,7 @@
               "n": 1
             },
             {
-              "v": 5334646.8294,
-              "n": 1
-            },
-            {
-              "v": 3027573.76649,
+              "v": 6169514.62592,
               "n": 1
             },
             {
@@ -6040,6 +6072,90 @@
               "n": 1
             },
             {
+              "v": 111867387.146,
+              "n": 1
+            },
+            {
+              "v": 296496286032.0,
+              "n": 1
+            },
+            {
+              "v": 150149190526.0,
+              "n": 1
+            },
+            {
+              "v": 109075825908.0,
+              "n": 1
+            },
+            {
+              "v": 3634036174.96,
+              "n": 1
+            },
+            {
+              "v": 159974205730.0,
+              "n": 1
+            },
+            {
+              "v": 20275401681.5,
+              "n": 1
+            },
+            {
+              "v": 30346283.2252,
+              "n": 1
+            },
+            {
+              "v": 4222065.23,
+              "n": 1
+            },
+            {
+              "v": 1437689017.22,
+              "n": 1
+            },
+            {
+              "v": 10045832169.1,
+              "n": 1
+            },
+            {
+              "v": 21487419275.7,
+              "n": 1
+            },
+            {
+              "v": 168011409245.0,
+              "n": 1
+            },
+            {
+              "v": 51964492974.6,
+              "n": 1
+            },
+            {
+              "v": 232445439155.0,
+              "n": 1
+            },
+            {
+              "v": 42847010743.6,
+              "n": 1
+            },
+            {
+              "v": 6853415168.2,
+              "n": 1
+            },
+            {
+              "v": 506198185.942,
+              "n": 1
+            },
+            {
+              "v": 130355358425.0,
+              "n": 1
+            },
+            {
+              "v": 13982943.8545,
+              "n": 1
+            },
+            {
+              "v": 7837275699.51,
+              "n": 1
+            },
+            {
               "v": 39468387480.8,
               "n": 1
             },
@@ -6068,66 +6184,6 @@
               "n": 1
             },
             {
-              "v": 168011409245.0,
-              "n": 1
-            },
-            {
-              "v": 51964492974.6,
-              "n": 1
-            },
-            {
-              "v": 232445439155.0,
-              "n": 1
-            },
-            {
-              "v": 42847010743.6,
-              "n": 1
-            },
-            {
-              "v": 6853415168.2,
-              "n": 1
-            },
-            {
-              "v": 30346283.2252,
-              "n": 1
-            },
-            {
-              "v": 4222065.23,
-              "n": 1
-            },
-            {
-              "v": 1437689017.22,
-              "n": 1
-            },
-            {
-              "v": 10045832169.1,
-              "n": 1
-            },
-            {
-              "v": 506198185.942,
-              "n": 1
-            },
-            {
-              "v": 130355358425.0,
-              "n": 1
-            },
-            {
-              "v": 13982943.8545,
-              "n": 1
-            },
-            {
-              "v": 7837275699.51,
-              "n": 1
-            },
-            {
-              "v": 159974205730.0,
-              "n": 1
-            },
-            {
-              "v": 20275401681.5,
-              "n": 1
-            },
-            {
               "v": 15253036.1617,
               "n": 1
             },
@@ -6136,27 +6192,11 @@
               "n": 1
             },
             {
-              "v": 111867387.146,
+              "v": 131451435845.0,
               "n": 1
             },
             {
-              "v": 296496286032.0,
-              "n": 1
-            },
-            {
-              "v": 150149190526.0,
-              "n": 1
-            },
-            {
-              "v": 21487419275.7,
-              "n": 1
-            },
-            {
-              "v": 109075825908.0,
-              "n": 1
-            },
-            {
-              "v": 3634036174.96,
+              "v": 90616372590.8,
               "n": 1
             },
             {
@@ -6174,14 +6214,6 @@
             {
               "v": 15971452385.7,
               "n": 1
-            },
-            {
-              "v": 131451435845.0,
-              "n": 1
-            },
-            {
-              "v": 90616372590.8,
-              "n": 1
             }
           ]
         },
@@ -6193,70 +6225,6 @@
           "min": "ANDAMAN & NICOBAR",
           "max": "WEST BENGAL",
           "top_values": [
-            {
-              "v": "RAJASTHAN",
-              "n": 1
-            },
-            {
-              "v": "CHANDIGARH",
-              "n": 1
-            },
-            {
-              "v": "DELHI",
-              "n": 1
-            },
-            {
-              "v": "MADHYA PRADESH",
-              "n": 1
-            },
-            {
-              "v": "JAMMU AND KASHMIR",
-              "n": 1
-            },
-            {
-              "v": "UTTAR PRADESH",
-              "n": 1
-            },
-            {
-              "v": "MEGHALAYA",
-              "n": 1
-            },
-            {
-              "v": "PUDUCHERRY",
-              "n": 1
-            },
-            {
-              "v": "TAMIL NADU",
-              "n": 1
-            },
-            {
-              "v": "GOA",
-              "n": 1
-            },
-            {
-              "v": "LADAKH",
-              "n": 1
-            },
-            {
-              "v": "UTTARAKHAND",
-              "n": 1
-            },
-            {
-              "v": "DISPUTED (WEST BENGAL , BIHAR & JHARKHAND)",
-              "n": 1
-            },
-            {
-              "v": "KARNATAKA",
-              "n": 1
-            },
-            {
-              "v": "DISPUTED (RAJATHAN & GUJARAT)",
-              "n": 1
-            },
-            {
-              "v": "MANIPUR",
-              "n": 1
-            },
             {
               "v": "TELANGANA",
               "n": 1
@@ -6270,15 +6238,7 @@
               "n": 1
             },
             {
-              "v": "WEST BENGAL",
-              "n": 1
-            },
-            {
-              "v": "CHHATTISGARH",
-              "n": 1
-            },
-            {
-              "v": "HIMACHAL PRADESH",
+              "v": "ARUNACHAL PRADESH",
               "n": 1
             },
             {
@@ -6306,7 +6266,27 @@
               "n": 1
             },
             {
-              "v": "PUNJAB",
+              "v": "RAJASTHAN",
+              "n": 1
+            },
+            {
+              "v": "CHANDIGARH",
+              "n": 1
+            },
+            {
+              "v": "WEST BENGAL",
+              "n": 1
+            },
+            {
+              "v": "KERALA",
+              "n": 1
+            },
+            {
+              "v": "MAHARASHTRA",
+              "n": 1
+            },
+            {
+              "v": "DADRA & NAGAR HAVELI & DAMAN & DIU",
               "n": 1
             },
             {
@@ -6326,23 +6306,51 @@
               "n": 1
             },
             {
-              "v": "KERALA",
+              "v": "PUNJAB",
               "n": 1
             },
             {
-              "v": "MAHARASHTRA",
+              "v": "PUDUCHERRY",
               "n": 1
             },
             {
-              "v": "DADRA & NAGAR HAVELI & DAMAN & DIU",
+              "v": "TAMIL NADU",
               "n": 1
             },
             {
-              "v": "MIZORAM",
+              "v": "GOA",
               "n": 1
             },
             {
-              "v": "ARUNACHAL PRADESH",
+              "v": "LADAKH",
+              "n": 1
+            },
+            {
+              "v": "UTTARAKHAND",
+              "n": 1
+            },
+            {
+              "v": "DISPUTED (WEST BENGAL , BIHAR & JHARKHAND)",
+              "n": 1
+            },
+            {
+              "v": "DELHI",
+              "n": 1
+            },
+            {
+              "v": "MADHYA PRADESH",
+              "n": 1
+            },
+            {
+              "v": "JAMMU AND KASHMIR",
+              "n": 1
+            },
+            {
+              "v": "UTTAR PRADESH",
+              "n": 1
+            },
+            {
+              "v": "MEGHALAYA",
               "n": 1
             },
             {
@@ -6351,6 +6359,30 @@
             },
             {
               "v": "ODISHA",
+              "n": 1
+            },
+            {
+              "v": "KARNATAKA",
+              "n": 1
+            },
+            {
+              "v": "DISPUTED (RAJATHAN & GUJARAT)",
+              "n": 1
+            },
+            {
+              "v": "MANIPUR",
+              "n": 1
+            },
+            {
+              "v": "MIZORAM",
+              "n": 1
+            },
+            {
+              "v": "CHHATTISGARH",
+              "n": 1
+            },
+            {
+              "v": "HIMACHAL PRADESH",
               "n": 1
             }
           ]
@@ -6375,79 +6407,23 @@
           "max": "West Bengal",
           "top_values": [
             {
+              "v": "Chhattisgarh",
+              "n": 1
+            },
+            {
+              "v": "Tripura",
+              "n": 1
+            },
+            {
+              "v": "Maharashtra",
+              "n": 1
+            },
+            {
               "v": "Andaman & Nicobar",
               "n": 1
             },
             {
               "v": "Orissa",
-              "n": 1
-            },
-            {
-              "v": "Lakshadweep",
-              "n": 1
-            },
-            {
-              "v": "Delhi",
-              "n": 1
-            },
-            {
-              "v": "Mizoram",
-              "n": 1
-            },
-            {
-              "v": "Haryana",
-              "n": 1
-            },
-            {
-              "v": "West Bengal",
-              "n": 1
-            },
-            {
-              "v": "Nagaland",
-              "n": 1
-            },
-            {
-              "v": "Madhya Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Sikkim",
-              "n": 1
-            },
-            {
-              "v": "Andhra Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Union Territory of Jammu and Kashmir",
-              "n": 1
-            },
-            {
-              "v": "Karnataka",
-              "n": 1
-            },
-            {
-              "v": "Punjab",
-              "n": 1
-            },
-            {
-              "v": "Kerala",
-              "n": 1
-            },
-            {
-              "v": "Union Territory of Ladakh",
-              "n": 1
-            },
-            {
-              "v": "Himachal Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Arunachal Pradesh",
-              "n": 1
-            },
-            {
-              "v": "Manipur",
               "n": 1
             },
             {
@@ -6475,27 +6451,47 @@
               "n": 1
             },
             {
-              "v": "Daman & Diu",
+              "v": "Karnataka",
               "n": 1
             },
             {
-              "v": "Rajasthan",
+              "v": "Punjab",
               "n": 1
             },
             {
-              "v": "Bihar",
+              "v": "Uttarakhand",
               "n": 1
             },
             {
-              "v": "Chhattisgarh",
+              "v": "Assam",
               "n": 1
             },
             {
-              "v": "Tripura",
+              "v": "Haryana",
               "n": 1
             },
             {
-              "v": "Maharashtra",
+              "v": "West Bengal",
+              "n": 1
+            },
+            {
+              "v": "Nagaland",
+              "n": 1
+            },
+            {
+              "v": "Kerala",
+              "n": 1
+            },
+            {
+              "v": "Union Territory of Ladakh",
+              "n": 1
+            },
+            {
+              "v": "Andhra Pradesh",
+              "n": 1
+            },
+            {
+              "v": "Union Territory of Jammu and Kashmir",
               "n": 1
             },
             {
@@ -6515,11 +6511,47 @@
               "n": 1
             },
             {
-              "v": "Uttarakhand",
+              "v": "Himachal Pradesh",
               "n": 1
             },
             {
-              "v": "Assam",
+              "v": "Arunachal Pradesh",
+              "n": 1
+            },
+            {
+              "v": "Manipur",
+              "n": 1
+            },
+            {
+              "v": "Lakshadweep",
+              "n": 1
+            },
+            {
+              "v": "Delhi",
+              "n": 1
+            },
+            {
+              "v": "Mizoram",
+              "n": 1
+            },
+            {
+              "v": "Daman & Diu",
+              "n": 1
+            },
+            {
+              "v": "Rajasthan",
+              "n": 1
+            },
+            {
+              "v": "Bihar",
+              "n": 1
+            },
+            {
+              "v": "Madhya Pradesh",
+              "n": 1
+            },
+            {
+              "v": "Sikkim",
               "n": 1
             }
           ]
@@ -6537,11 +6569,15 @@
               "n": 1
             },
             {
-              "v": "36",
+              "v": "5",
               "n": 1
             },
             {
-              "v": "6",
+              "v": "9",
+              "n": 1
+            },
+            {
+              "v": "7",
               "n": 1
             },
             {
@@ -6550,6 +6586,58 @@
             },
             {
               "v": "4",
+              "n": 1
+            },
+            {
+              "v": "32",
+              "n": 1
+            },
+            {
+              "v": "26",
+              "n": 1
+            },
+            {
+              "v": "23",
+              "n": 1
+            },
+            {
+              "v": "19",
+              "n": 1
+            },
+            {
+              "v": "13",
+              "n": 1
+            },
+            {
+              "v": "20",
+              "n": 1
+            },
+            {
+              "v": "15",
+              "n": 1
+            },
+            {
+              "v": "36",
+              "n": 1
+            },
+            {
+              "v": "6",
+              "n": 1
+            },
+            {
+              "v": "31",
+              "n": 1
+            },
+            {
+              "v": "27",
+              "n": 1
+            },
+            {
+              "v": "30",
+              "n": 1
+            },
+            {
+              "v": "2",
               "n": 1
             },
             {
@@ -6585,11 +6673,7 @@
               "n": 1
             },
             {
-              "v": "20",
-              "n": 1
-            },
-            {
-              "v": "15",
+              "v": "12",
               "n": 1
             },
             {
@@ -6605,66 +6689,6 @@
               "n": 1
             },
             {
-              "v": "32",
-              "n": 1
-            },
-            {
-              "v": "26",
-              "n": 1
-            },
-            {
-              "v": "23",
-              "n": 1
-            },
-            {
-              "v": "19",
-              "n": 1
-            },
-            {
-              "v": "13",
-              "n": 1
-            },
-            {
-              "v": "5",
-              "n": 1
-            },
-            {
-              "v": "9",
-              "n": 1
-            },
-            {
-              "v": "7",
-              "n": 1
-            },
-            {
-              "v": "31",
-              "n": 1
-            },
-            {
-              "v": "27",
-              "n": 1
-            },
-            {
-              "v": "30",
-              "n": 1
-            },
-            {
-              "v": "2",
-              "n": 1
-            },
-            {
-              "v": "33",
-              "n": 1
-            },
-            {
-              "v": "25",
-              "n": 1
-            },
-            {
-              "v": "10",
-              "n": 1
-            },
-            {
               "v": "8",
               "n": 1
             },
@@ -6677,7 +6701,15 @@
               "n": 1
             },
             {
-              "v": "12",
+              "v": "33",
+              "n": 1
+            },
+            {
+              "v": "25",
+              "n": 1
+            },
+            {
+              "v": "10",
               "n": 1
             }
           ]
@@ -6730,11 +6762,11 @@
               "n": 50
             },
             {
-              "v": "BIHAR",
+              "v": "TAMIL NADU",
               "n": 38
             },
             {
-              "v": "TAMIL NADU",
+              "v": "BIHAR",
               "n": 38
             },
             {
@@ -6750,11 +6782,11 @@
               "n": 33
             },
             {
-              "v": "CHHATTISGARH",
+              "v": "TELANGANA",
               "n": 33
             },
             {
-              "v": "TELANGANA",
+              "v": "CHHATTISGARH",
               "n": 33
             },
             {
@@ -6778,11 +6810,11 @@
               "n": 24
             },
             {
-              "v": "PUNJAB",
+              "v": "WEST BENGAL",
               "n": 23
             },
             {
-              "v": "WEST BENGAL",
+              "v": "PUNJAB",
               "n": 23
             },
             {
@@ -6794,11 +6826,11 @@
               "n": 22
             },
             {
-              "v": "MANIPUR",
+              "v": "NAGALAND",
               "n": 16
             },
             {
-              "v": "NAGALAND",
+              "v": "MANIPUR",
               "n": 16
             },
             {
@@ -6838,19 +6870,19 @@
               "n": 4
             },
             {
-              "v": "DADRA,NAGAR HAVELI,DAMAN & DIU",
-              "n": 3
-            },
-            {
               "v": "ANDAMAN & NICOBAR",
               "n": 3
             },
             {
-              "v": "GOA",
-              "n": 2
+              "v": "DADRA,NAGAR HAVELI,DAMAN & DIU",
+              "n": 3
             },
             {
               "v": "LADAKH",
+              "n": 2
+            },
+            {
+              "v": "GOA",
               "n": 2
             },
             {
@@ -6900,11 +6932,11 @@
               "n": 35
             },
             {
-              "v": "24",
+              "v": "36",
               "n": 33
             },
             {
-              "v": "36",
+              "v": "24",
               "n": 33
             },
             {
@@ -6932,19 +6964,19 @@
               "n": 24
             },
             {
-              "v": "19",
-              "n": 23
-            },
-            {
               "v": "03",
               "n": 23
             },
             {
-              "v": "01",
-              "n": 22
+              "v": "19",
+              "n": 23
             },
             {
               "v": "06",
+              "n": 22
+            },
+            {
+              "v": "01",
               "n": 22
             },
             {
@@ -6964,19 +6996,19 @@
               "n": 13
             },
             {
-              "v": "02",
-              "n": 12
-            },
-            {
               "v": "17",
               "n": 12
             },
             {
-              "v": "07",
-              "n": 11
+              "v": "02",
+              "n": 12
             },
             {
               "v": "15",
+              "n": 11
+            },
+            {
+              "v": "07",
               "n": 11
             },
             {
@@ -7000,11 +7032,11 @@
               "n": 3
             },
             {
-              "v": "30",
+              "v": "38",
               "n": 2
             },
             {
-              "v": "38",
+              "v": "30",
               "n": 2
             },
             {
@@ -7062,11 +7094,11 @@
               "n": 8
             },
             {
-              "v": "2018",
+              "v": "2015_c",
               "n": 6
             },
             {
-              "v": "2015_c",
+              "v": "2018",
               "n": 6
             },
             {
@@ -7120,11 +7152,11 @@
               "n": 50
             },
             {
-              "v": 10,
+              "v": 33,
               "n": 38
             },
             {
-              "v": 33,
+              "v": 10,
               "n": 38
             },
             {
@@ -7140,11 +7172,11 @@
               "n": 33
             },
             {
-              "v": 36,
+              "v": 24,
               "n": 33
             },
             {
-              "v": 24,
+              "v": 36,
               "n": 33
             },
             {
@@ -7184,11 +7216,11 @@
               "n": 22
             },
             {
-              "v": 13,
+              "v": 14,
               "n": 16
             },
             {
-              "v": 14,
+              "v": 13,
               "n": 16
             },
             {
@@ -7228,11 +7260,11 @@
               "n": 4
             },
             {
-              "v": 38,
+              "v": 35,
               "n": 3
             },
             {
-              "v": 35,
+              "v": 38,
               "n": 3
             },
             {
@@ -7244,11 +7276,11 @@
               "n": 2
             },
             {
-              "v": 4,
+              "v": 31,
               "n": 1
             },
             {
-              "v": 31,
+              "v": 4,
               "n": 1
             }
           ]
@@ -7385,14 +7417,6 @@
               "n": 36
             },
             {
-              "v": "R\u0100JASTH\u0100N",
-              "n": 33
-            },
-            {
-              "v": "TELANG\u0100NA",
-              "n": 33
-            },
-            {
               "v": "ASSAM",
               "n": 33
             },
@@ -7401,11 +7425,19 @@
               "n": 33
             },
             {
-              "v": "ODISHA",
-              "n": 30
+              "v": "TELANG\u0100NA",
+              "n": 33
+            },
+            {
+              "v": "R\u0100JASTH\u0100N",
+              "n": 33
             },
             {
               "v": "KARN\u0100TAKA",
+              "n": 30
+            },
+            {
+              "v": "ODISHA",
               "n": 30
             },
             {
@@ -7425,11 +7457,11 @@
               "n": 23
             },
             {
-              "v": "JAMMU AND KASHM\u012aR",
+              "v": "PUNJAB",
               "n": 22
             },
             {
-              "v": "PUNJAB",
+              "v": "JAMMU AND KASHM\u012aR",
               "n": 22
             },
             {
@@ -7445,11 +7477,11 @@
               "n": 14
             },
             {
-              "v": "UTTAR\u0100KHAND",
+              "v": "ANDHRA PRADESH",
               "n": 13
             },
             {
-              "v": "ANDHRA PRADESH",
+              "v": "UTTAR\u0100KHAND",
               "n": 13
             },
             {
@@ -7457,11 +7489,11 @@
               "n": 12
             },
             {
-              "v": "N\u0100G\u0100LAND",
+              "v": "MEGH\u0100LAYA",
               "n": 11
             },
             {
-              "v": "MEGH\u0100LAYA",
+              "v": "N\u0100G\u0100LAND",
               "n": 11
             },
             {
@@ -7477,10 +7509,6 @@
               "n": 8
             },
             {
-              "v": "PUDUCHERRY",
-              "n": 4
-            },
-            {
               "v": "DISPUTED (MADHYA PRADESH & R\u0100JASTH\u0100N)",
               "n": 4
             },
@@ -7489,12 +7517,20 @@
               "n": 4
             },
             {
-              "v": "D\u0100DRA & NAGAR HAVELI & DAM\u0100N & DIU",
-              "n": 3
+              "v": "PUDUCHERRY",
+              "n": 4
             },
             {
               "v": "ANDAMAN & NICOBAR",
               "n": 3
+            },
+            {
+              "v": "D\u0100DRA & NAGAR HAVELI & DAM\u0100N & DIU",
+              "n": 3
+            },
+            {
+              "v": "DISPUTED (R\u0100JATH\u0100N & GUJAR\u0100T)",
+              "n": 2
             },
             {
               "v": "GOA",
@@ -7505,23 +7541,19 @@
               "n": 2
             },
             {
-              "v": "DISPUTED (R\u0100JATH\u0100N & GUJAR\u0100T)",
-              "n": 2
+              "v": "DISPUTED (WEST BENGAL , BIH\u0100R & JH\u0100RKHAND)",
+              "n": 1
             },
             {
               "v": "CHAND\u012aGARH",
               "n": 1
             },
             {
-              "v": "LAKSHADWEEP",
-              "n": 1
-            },
-            {
-              "v": "DISPUTED (WEST BENGAL , BIH\u0100R & JH\u0100RKHAND)",
-              "n": 1
-            },
-            {
               "v": "DISPUTED (MADHYA PRADESH & GUJAR\u0100T)",
+              "n": 1
+            },
+            {
+              "v": "LAKSHADWEEP",
               "n": 1
             }
           ]
@@ -7573,7 +7605,7 @@
               "n": 36
             },
             {
-              "v": 36,
+              "v": 24,
               "n": 33
             },
             {
@@ -7585,7 +7617,7 @@
               "n": 33
             },
             {
-              "v": 24,
+              "v": 36,
               "n": 33
             },
             {
@@ -7613,7 +7645,7 @@
               "n": 23
             },
             {
-              "v": 3,
+              "v": 1,
               "n": 22
             },
             {
@@ -7621,7 +7653,7 @@
               "n": 22
             },
             {
-              "v": 1,
+              "v": 3,
               "n": 22
             },
             {
@@ -7633,11 +7665,11 @@
               "n": 14
             },
             {
-              "v": 28,
+              "v": 5,
               "n": 13
             },
             {
-              "v": 5,
+              "v": 28,
               "n": 13
             },
             {
@@ -7649,16 +7681,12 @@
               "n": 11
             },
             {
-              "v": 7,
-              "n": 11
-            },
-            {
               "v": 13,
               "n": 11
             },
             {
-              "v": 0,
-              "n": 8
+              "v": 7,
+              "n": 11
             },
             {
               "v": 16,
@@ -7669,35 +7697,39 @@
               "n": 8
             },
             {
-              "v": 11,
-              "n": 4
+              "v": 0,
+              "n": 8
             },
             {
               "v": 34,
               "n": 4
             },
             {
-              "v": 35,
-              "n": 3
+              "v": 11,
+              "n": 4
             },
             {
               "v": 38,
               "n": 3
             },
             {
-              "v": 37,
-              "n": 2
+              "v": 35,
+              "n": 3
             },
             {
               "v": 30,
               "n": 2
             },
             {
-              "v": 4,
-              "n": 1
+              "v": 37,
+              "n": 2
             },
             {
               "v": 31,
+              "n": 1
+            },
+            {
+              "v": 4,
               "n": 1
             }
           ]
@@ -7755,11 +7787,11 @@
               "n": 36
             },
             {
-              "v": "GUJARAT",
+              "v": "ASSAM",
               "n": 33
             },
             {
-              "v": "TELANGANA",
+              "v": "GUJARAT",
               "n": 33
             },
             {
@@ -7767,15 +7799,15 @@
               "n": 33
             },
             {
-              "v": "ASSAM",
+              "v": "TELANGANA",
               "n": 33
             },
             {
-              "v": "KARNATAKA",
+              "v": "ODISHA",
               "n": 30
             },
             {
-              "v": "ODISHA",
+              "v": "KARNATAKA",
               "n": 30
             },
             {
@@ -7799,11 +7831,11 @@
               "n": 22
             },
             {
-              "v": "PUNJAB",
+              "v": "HARYANA",
               "n": 22
             },
             {
-              "v": "HARYANA",
+              "v": "PUNJAB",
               "n": 22
             },
             {
@@ -7815,11 +7847,11 @@
               "n": 14
             },
             {
-              "v": "UTTARAKHAND",
+              "v": "ANDHRA PRADESH",
               "n": 13
             },
             {
-              "v": "ANDHRA PRADESH",
+              "v": "UTTARAKHAND",
               "n": 13
             },
             {
@@ -7827,15 +7859,15 @@
               "n": 12
             },
             {
+              "v": "NAGALAND",
+              "n": 11
+            },
+            {
               "v": "MEGHALAYA",
               "n": 11
             },
             {
               "v": "DELHI",
-              "n": 11
-            },
-            {
-              "v": "NAGALAND",
               "n": 11
             },
             {
@@ -7847,11 +7879,11 @@
               "n": 8
             },
             {
-              "v": "DISPUTED (MADHYA PRADESH & RAJASTHAN)",
+              "v": "SIKKIM",
               "n": 4
             },
             {
-              "v": "SIKKIM",
+              "v": "DISPUTED (MADHYA PRADESH & RAJASTHAN)",
               "n": 4
             },
             {
@@ -7859,19 +7891,19 @@
               "n": 4
             },
             {
-              "v": "ANDAMAN & NICOBAR",
-              "n": 3
-            },
-            {
               "v": "DADRA & NAGAR HAVELI & DAMAN & DIU",
               "n": 3
             },
             {
-              "v": "DISPUTED (RAJATHAN & GUJARAT)",
-              "n": 2
+              "v": "ANDAMAN & NICOBAR",
+              "n": 3
             },
             {
               "v": "GOA",
+              "n": 2
+            },
+            {
+              "v": "DISPUTED (RAJATHAN & GUJARAT)",
               "n": 2
             },
             {
@@ -7879,19 +7911,19 @@
               "n": 2
             },
             {
-              "v": "DISPUTED (MADHYA PRADESH & GUJARAT)",
-              "n": 1
-            },
-            {
               "v": "LAKSHADWEEP",
               "n": 1
             },
             {
-              "v": "CHANDIGARH",
+              "v": "DISPUTED (MADHYA PRADESH & GUJARAT)",
               "n": 1
             },
             {
               "v": "DISPUTED (WEST BENGAL , BIHAR & JHARKHAND)",
+              "n": 1
+            },
+            {
+              "v": "CHANDIGARH",
               "n": 1
             }
           ]
@@ -7965,11 +7997,11 @@
               "n": 30
             },
             {
-              "v": "Chhattisgarh",
+              "v": "Assam",
               "n": 27
             },
             {
-              "v": "Assam",
+              "v": "Chhattisgarh",
               "n": 27
             },
             {
@@ -7981,11 +8013,11 @@
               "n": 24
             },
             {
-              "v": "Punjab",
+              "v": "Haryana",
               "n": 22
             },
             {
-              "v": "Haryana",
+              "v": "Punjab",
               "n": 22
             },
             {
@@ -8017,11 +8049,11 @@
               "n": 12
             },
             {
-              "v": "Meghalaya",
+              "v": "Nagaland",
               "n": 11
             },
             {
-              "v": "Nagaland",
+              "v": "Meghalaya",
               "n": 11
             },
             {
@@ -8045,16 +8077,12 @@
               "n": 6
             },
             {
-              "v": "Puducherry",
-              "n": 4
-            },
-            {
               "v": "Sikkim",
               "n": 4
             },
             {
-              "v": "Daman & Diu",
-              "n": 2
+              "v": "Puducherry",
+              "n": 4
             },
             {
               "v": "Goa",
@@ -8065,7 +8093,11 @@
               "n": 2
             },
             {
-              "v": "Delhi",
+              "v": "Daman & Diu",
+              "n": 2
+            },
+            {
+              "v": "Chandigarh",
               "n": 1
             },
             {
@@ -8073,11 +8105,11 @@
               "n": 1
             },
             {
-              "v": "Dadar Nagar& Haveli",
+              "v": "Delhi",
               "n": 1
             },
             {
-              "v": "Chandigarh",
+              "v": "Dadar Nagar& Haveli",
               "n": 1
             }
           ]
@@ -8163,11 +8195,11 @@
               "n": 14
             },
             {
-              "v": "28",
+              "v": "5",
               "n": 13
             },
             {
-              "v": "5",
+              "v": "28",
               "n": 13
             },
             {
@@ -8175,11 +8207,11 @@
               "n": 12
             },
             {
-              "v": "13",
+              "v": "17",
               "n": 11
             },
             {
-              "v": "17",
+              "v": "13",
               "n": 11
             },
             {
@@ -8191,11 +8223,11 @@
               "n": 9
             },
             {
-              "v": "16",
+              "v": "15",
               "n": 8
             },
             {
-              "v": "15",
+              "v": "16",
               "n": 8
             },
             {
@@ -8203,15 +8235,15 @@
               "n": 6
             },
             {
-              "v": "11",
-              "n": 4
-            },
-            {
               "v": "34",
               "n": 4
             },
             {
-              "v": "25",
+              "v": "11",
+              "n": 4
+            },
+            {
+              "v": "35",
               "n": 2
             },
             {
@@ -8219,16 +8251,8 @@
               "n": 2
             },
             {
-              "v": "35",
+              "v": "25",
               "n": 2
-            },
-            {
-              "v": "7",
-              "n": 1
-            },
-            {
-              "v": "31",
-              "n": 1
             },
             {
               "v": "26",
@@ -8236,6 +8260,14 @@
             },
             {
               "v": "4",
+              "n": 1
+            },
+            {
+              "v": "31",
+              "n": 1
+            },
+            {
+              "v": "7",
               "n": 1
             }
           ]
@@ -8413,19 +8445,19 @@
               "n": 10
             },
             {
-              "v": "35",
-              "n": 9
-            },
-            {
               "v": "11",
               "n": 9
             },
             {
-              "v": "38",
-              "n": 8
+              "v": "35",
+              "n": 9
             },
             {
               "v": "34",
+              "n": 8
+            },
+            {
+              "v": "38",
               "n": 8
             },
             {
@@ -8555,11 +8587,11 @@
               "n": 76
             },
             {
-              "v": "MEGHALAYA",
+              "v": "MANIPUR",
               "n": 39
             },
             {
-              "v": "MANIPUR",
+              "v": "MEGHALAYA",
               "n": 39
             },
             {
@@ -8583,11 +8615,11 @@
               "n": 10
             },
             {
-              "v": "SIKKIM",
+              "v": "ANDAMAN & NICOBAR",
               "n": 9
             },
             {
-              "v": "ANDAMAN & NICOBAR",
+              "v": "SIKKIM",
               "n": 9
             },
             {
@@ -8769,11 +8801,11 @@
               "n": 10
             },
             {
-              "v": 35,
+              "v": 11,
               "n": 9
             },
             {
-              "v": 11,
+              "v": 35,
               "n": 9
             },
             {
@@ -8998,19 +9030,19 @@
               "n": 23
             },
             {
-              "v": "MIZORAM",
-              "n": 22
-            },
-            {
               "v": "JAMMU AND KASHMIR",
               "n": 22
             },
             {
-              "v": "GOA",
-              "n": 11
+              "v": "MIZORAM",
+              "n": 22
             },
             {
               "v": "MEGHALAYA",
+              "n": 11
+            },
+            {
+              "v": "GOA",
               "n": 11
             },
             {
@@ -9038,6 +9070,10 @@
               "n": 2
             },
             {
+              "v": "CHANDIGARH",
+              "n": 1
+            },
+            {
               "v": "Disputed (West Bengal)",
               "n": 1
             },
@@ -9047,10 +9083,6 @@
             },
             {
               "v": "LAKSHADWEEP",
-              "n": 1
-            },
-            {
-              "v": "CHANDIGARH",
               "n": 1
             }
           ]
@@ -9180,27 +9212,27 @@
               "n": 25
             },
             {
-              "v": "TRIPURA",
-              "n": 23
-            },
-            {
               "v": "NAGALAND",
               "n": 23
             },
             {
-              "v": "JAMMU AND KASHMIR",
-              "n": 22
+              "v": "TRIPURA",
+              "n": 23
             },
             {
               "v": "MIZORAM",
               "n": 22
             },
             {
-              "v": "GOA",
-              "n": 11
+              "v": "JAMMU AND KASHMIR",
+              "n": 22
             },
             {
               "v": "MEGHALAYA",
+              "n": 11
+            },
+            {
+              "v": "GOA",
               "n": 11
             },
             {
@@ -9228,19 +9260,19 @@
               "n": 2
             },
             {
-              "v": "DISPUTED (WEST BENGAL)",
-              "n": 1
-            },
-            {
-              "v": "CHANDIGARH",
-              "n": 1
-            },
-            {
               "v": "DISPUTED",
               "n": 1
             },
             {
               "v": "LAKSHADWEEP",
+              "n": 1
+            },
+            {
+              "v": "DISPUTED (WEST BENGAL)",
+              "n": 1
+            },
+            {
+              "v": "CHANDIGARH",
               "n": 1
             }
           ]
@@ -9414,11 +9446,11 @@
               "n": 22
             },
             {
-              "v": "DELHI",
+              "v": "GOA",
               "n": 12
             },
             {
-              "v": "GOA",
+              "v": "DELHI",
               "n": 12
             },
             {
@@ -9576,11 +9608,11 @@
               "n": 22
             },
             {
-              "v": "30",
+              "v": "07",
               "n": 12
             },
             {
-              "v": "07",
+              "v": "30",
               "n": 12
             },
             {
@@ -9726,7 +9758,7 @@
               "n": 4
             },
             {
-              "v": 21,
+              "v": 18,
               "n": 3
             },
             {
@@ -9734,7 +9766,7 @@
               "n": 3
             },
             {
-              "v": 18,
+              "v": 21,
               "n": 3
             },
             {
@@ -9746,11 +9778,11 @@
               "n": 2
             },
             {
-              "v": 29,
+              "v": 19,
               "n": 2
             },
             {
-              "v": 19,
+              "v": 29,
               "n": 2
             },
             {
@@ -9758,23 +9790,11 @@
               "n": 1
             },
             {
-              "v": 42,
-              "n": 1
-            },
-            {
-              "v": 27,
-              "n": 1
-            },
-            {
-              "v": 43,
-              "n": 1
-            },
-            {
               "v": 34,
               "n": 1
             },
             {
-              "v": 25,
+              "v": 44,
               "n": 1
             },
             {
@@ -9782,15 +9802,27 @@
               "n": 1
             },
             {
-              "v": 50,
-              "n": 1
-            },
-            {
               "v": 32,
               "n": 1
             },
             {
-              "v": 44,
+              "v": 27,
+              "n": 1
+            },
+            {
+              "v": 50,
+              "n": 1
+            },
+            {
+              "v": 43,
+              "n": 1
+            },
+            {
+              "v": 25,
+              "n": 1
+            },
+            {
+              "v": 42,
               "n": 1
             }
           ]
@@ -9924,11 +9956,11 @@
               "n": 39
             },
             {
-              "v": 15,
+              "v": 11,
               "n": 26
             },
             {
-              "v": 11,
+              "v": 15,
               "n": 26
             },
             {
@@ -10131,23 +10163,23 @@
               "n": 6
             },
             {
-              "v": "Lakshadweep",
-              "n": 4
-            },
-            {
               "v": "Andaman & Nicobar",
               "n": 4
             },
             {
-              "v": "Daman & Diu",
-              "n": 2
+              "v": "Lakshadweep",
+              "n": 4
             },
             {
               "v": "Puducherry",
               "n": 2
             },
             {
-              "v": "Delhi",
+              "v": "Daman & Diu",
+              "n": 2
+            },
+            {
+              "v": "Chandigarh",
               "n": 1
             },
             {
@@ -10155,7 +10187,7 @@
               "n": 1
             },
             {
-              "v": "Chandigarh",
+              "v": "Delhi",
               "n": 1
             }
           ]
@@ -10297,16 +10329,12 @@
               "n": 4
             },
             {
-              "v": "25",
-              "n": 2
-            },
-            {
               "v": "34",
               "n": 2
             },
             {
-              "v": "7",
-              "n": 1
+              "v": "25",
+              "n": 2
             },
             {
               "v": "4",
@@ -10314,6 +10342,10 @@
             },
             {
               "v": "26",
+              "n": 1
+            },
+            {
+              "v": "7",
               "n": 1
             }
           ]
@@ -10431,11 +10463,11 @@
               "n": 248
             },
             {
-              "v": 4,
+              "v": 12,
               "n": 220
             },
             {
-              "v": 12,
+              "v": 4,
               "n": 220
             },
             {
@@ -10565,11 +10597,11 @@
               "n": 248
             },
             {
-              "v": "Assam",
+              "v": "Gujarat",
               "n": 220
             },
             {
-              "v": "Gujarat",
+              "v": "Assam",
               "n": 220
             },
             {
@@ -12542,6 +12574,14 @@
               "n": 4
             },
             {
+              "v": "39",
+              "n": 2
+            },
+            {
+              "v": "12",
+              "n": 2
+            },
+            {
               "v": "17",
               "n": 2
             },
@@ -12550,7 +12590,7 @@
               "n": 2
             },
             {
-              "v": "39",
+              "v": "16",
               "n": 2
             },
             {
@@ -12558,19 +12598,19 @@
               "n": 2
             },
             {
-              "v": "12",
-              "n": 2
-            },
-            {
-              "v": "16",
-              "n": 2
-            },
-            {
               "v": "04",
               "n": 1
             },
             {
+              "v": "15",
+              "n": 1
+            },
+            {
               "v": "13",
+              "n": 1
+            },
+            {
+              "v": "35",
               "n": 1
             },
             {
@@ -12583,14 +12623,6 @@
             },
             {
               "v": "31",
-              "n": 1
-            },
-            {
-              "v": "35",
-              "n": 1
-            },
-            {
-              "v": "15",
               "n": 1
             }
           ]
@@ -12692,6 +12724,14 @@
               "n": 4
             },
             {
+              "v": "MEGHALAYA",
+              "n": 2
+            },
+            {
+              "v": "GOA",
+              "n": 2
+            },
+            {
               "v": "MANIPUR",
               "n": 2
             },
@@ -12700,36 +12740,8 @@
               "n": 2
             },
             {
-              "v": "GOA",
-              "n": 2
-            },
-            {
-              "v": "MEGHALAYA",
-              "n": 2
-            },
-            {
               "v": "ARUNACHAL PRADESH",
               "n": 2
-            },
-            {
-              "v": "CHANDIGARH",
-              "n": 1
-            },
-            {
-              "v": "MIZORAM",
-              "n": 1
-            },
-            {
-              "v": "DAMAN & DIU",
-              "n": 1
-            },
-            {
-              "v": "SIKKIM",
-              "n": 1
-            },
-            {
-              "v": "LAKSHADWEEP",
-              "n": 1
             },
             {
               "v": "NAGALAND",
@@ -12740,11 +12752,31 @@
               "n": 1
             },
             {
+              "v": "SIKKIM",
+              "n": 1
+            },
+            {
               "v": "DADRA & NAGAR HAVELI",
               "n": 1
             },
             {
+              "v": "LAKSHADWEEP",
+              "n": 1
+            },
+            {
+              "v": "DAMAN & DIU",
+              "n": 1
+            },
+            {
               "v": "PUDUCHERRY",
+              "n": 1
+            },
+            {
+              "v": "MIZORAM",
+              "n": 1
+            },
+            {
+              "v": "CHANDIGARH",
               "n": 1
             }
           ]
@@ -12916,6 +12948,14 @@
               "n": 2
             },
             {
+              "v": 14,
+              "n": 2
+            },
+            {
+              "v": 16,
+              "n": 2
+            },
+            {
               "v": 30,
               "n": 2
             },
@@ -12928,12 +12968,16 @@
               "n": 2
             },
             {
-              "v": 14,
-              "n": 2
+              "v": 34,
+              "n": 1
             },
             {
-              "v": 16,
-              "n": 2
+              "v": 4,
+              "n": 1
+            },
+            {
+              "v": 31,
+              "n": 1
             },
             {
               "v": 15,
@@ -12948,19 +12992,7 @@
               "n": 1
             },
             {
-              "v": 4,
-              "n": 1
-            },
-            {
-              "v": 34,
-              "n": 1
-            },
-            {
               "v": 13,
-              "n": 1
-            },
-            {
-              "v": 31,
               "n": 1
             }
           ]
@@ -13067,11 +13099,11 @@
               "n": 95
             },
             {
-              "v": "22",
+              "v": "06",
               "n": 90
             },
             {
-              "v": "06",
+              "v": "22",
               "n": 90
             },
             {
@@ -13095,15 +13127,15 @@
               "n": 61
             },
             {
+              "v": "13",
+              "n": 60
+            },
+            {
               "v": "17",
               "n": 60
             },
             {
               "v": "16",
-              "n": 60
-            },
-            {
-              "v": "13",
               "n": 60
             },
             {
@@ -13209,19 +13241,19 @@
               "n": 90
             },
             {
-              "v": "UTTARKHAND",
-              "n": 70
-            },
-            {
               "v": "DELHI",
               "n": 70
             },
             {
-              "v": "MANIPUR",
-              "n": 68
+              "v": "UTTARKHAND",
+              "n": 70
             },
             {
               "v": "HIMACHAL PRADESH",
+              "n": 68
+            },
+            {
+              "v": "MANIPUR",
               "n": 68
             },
             {
@@ -13229,15 +13261,15 @@
               "n": 61
             },
             {
-              "v": "TRIPURA",
-              "n": 60
-            },
-            {
               "v": "MEGHALAYA",
               "n": 60
             },
             {
               "v": "NAGALAND",
+              "n": 60
+            },
+            {
+              "v": "TRIPURA",
               "n": 60
             },
             {
@@ -13397,11 +13429,11 @@
               "n": 235
             },
             {
-              "v": 23,
+              "v": 29,
               "n": 225
             },
             {
-              "v": 29,
+              "v": 23,
               "n": 225
             },
             {
@@ -13445,11 +13477,11 @@
               "n": 96
             },
             {
-              "v": 22,
+              "v": 6,
               "n": 90
             },
             {
-              "v": 6,
+              "v": 22,
               "n": 90
             },
             {
@@ -13461,11 +13493,11 @@
               "n": 70
             },
             {
-              "v": 2,
+              "v": 14,
               "n": 68
             },
             {
-              "v": 14,
+              "v": 2,
               "n": 68
             },
             {
@@ -13473,11 +13505,11 @@
               "n": 61
             },
             {
-              "v": 16,
+              "v": 13,
               "n": 60
             },
             {
-              "v": 13,
+              "v": 16,
               "n": 60
             },
             {
@@ -13639,27 +13671,27 @@
               "n": 19
             },
             {
-              "v": "Punjab",
-              "n": 14
-            },
-            {
               "v": "Uttarakhand",
               "n": 14
             },
             {
-              "v": "Arunachal Pradesh",
-              "n": 13
+              "v": "Punjab",
+              "n": 14
             },
             {
               "v": "Bihar",
               "n": 13
             },
             {
-              "v": "Mizoram",
-              "n": 12
+              "v": "Arunachal Pradesh",
+              "n": 13
             },
             {
               "v": "Telangana",
+              "n": 12
+            },
+            {
+              "v": "Mizoram",
               "n": 12
             },
             {
@@ -13667,11 +13699,11 @@
               "n": 11
             },
             {
-              "v": "Jharkhand",
+              "v": "Chhattisgarh",
               "n": 11
             },
             {
-              "v": "Chhattisgarh",
+              "v": "Jharkhand",
               "n": 11
             },
             {
@@ -13707,10 +13739,6 @@
               "n": 1
             },
             {
-              "v": "Lakshadweep (UT)",
-              "n": 1
-            },
-            {
               "v": "Dadra & Nagar Haveli",
               "n": 1
             },
@@ -13720,6 +13748,10 @@
             },
             {
               "v": "Delhi",
+              "n": 1
+            },
+            {
+              "v": "Lakshadweep (UT)",
               "n": 1
             }
           ]
@@ -13773,14 +13805,6 @@
               "n": 3
             },
             {
-              "v": "Pune",
-              "n": 2
-            },
-            {
-              "v": "Wild Life North Circle",
-              "n": 2
-            },
-            {
               "v": "Tirunelveli",
               "n": 2
             },
@@ -13789,31 +13813,23 @@
               "n": 2
             },
             {
-              "v": "Aurangabad",
+              "v": "Wild Life North Circle",
+              "n": 2
+            },
+            {
+              "v": "Pune",
+              "n": 2
+            },
+            {
+              "v": "Northern Circle",
               "n": 1
             },
             {
-              "v": "3",
+              "v": "Str Wildlife",
               "n": 1
             },
             {
-              "v": "Madurai",
-              "n": 1
-            },
-            {
-              "v": "Mtr Wildlife",
-              "n": 1
-            },
-            {
-              "v": "1",
-              "n": 1
-            },
-            {
-              "v": "Naginimora",
-              "n": 1
-            },
-            {
-              "v": "Wildlife North",
+              "v": "Seithekema",
               "n": 1
             },
             {
@@ -13825,7 +13841,15 @@
               "n": 1
             },
             {
-              "v": "Str Wildlife",
+              "v": "1",
+              "n": 1
+            },
+            {
+              "v": "Thane",
+              "n": 1
+            },
+            {
+              "v": "Mtr Wildlife",
               "n": 1
             },
             {
@@ -13837,15 +13861,23 @@
               "n": 1
             },
             {
-              "v": "Seithekema",
+              "v": "3",
               "n": 1
             },
             {
-              "v": "Northern Circle",
+              "v": "Aurangabad",
               "n": 1
             },
             {
-              "v": "Thane",
+              "v": "Madurai",
+              "n": 1
+            },
+            {
+              "v": "Wildlife North",
+              "n": 1
+            },
+            {
+              "v": "Naginimora",
               "n": 1
             }
           ]
@@ -13897,11 +13929,11 @@
               "n": 30
             },
             {
-              "v": "MoEF",
+              "v": "Other data",
               "n": 1
             },
             {
-              "v": "Other data",
+              "v": "MoEF",
               "n": 1
             }
           ]
@@ -13935,39 +13967,47 @@
               "n": 3
             },
             {
-              "v": "1986/10/10",
-              "n": 2
-            },
-            {
               "v": "1985/09/16",
               "n": 2
             },
             {
-              "v": "2012/02/29",
+              "v": "1986/10/10",
+              "n": 2
+            },
+            {
+              "v": "2018/03/23",
               "n": 1
             },
             {
-              "v": "1975/11/22",
+              "v": "2013/05/03",
               "n": 1
             },
             {
-              "v": "2014/05/03",
+              "v": "1988/02/08",
               "n": 1
             },
             {
-              "v": "24-01-1997, 30-04-1997",
+              "v": "16-05-1997, 17-05-1997",
               "n": 1
             },
             {
-              "v": "2000/12/21",
+              "v": "2019/05/29",
               "n": 1
             },
             {
-              "v": "2000/08/08",
+              "v": "1994/12/08",
               "n": 1
             },
             {
-              "v": "06-05-1997",
+              "v": "2021/03/15",
+              "n": 1
+            },
+            {
+              "v": "2013/07/18",
+              "n": 1
+            },
+            {
+              "v": "25-02-1986, 24-02-2004",
               "n": 1
             },
             {
@@ -13983,27 +14023,15 @@
               "n": 1
             },
             {
-              "v": "2013/07/18",
+              "v": "2000/12/21",
               "n": 1
             },
             {
-              "v": "27-11-1970",
+              "v": "2000/08/08",
               "n": 1
             },
             {
-              "v": "2012/06/29",
-              "n": 1
-            },
-            {
-              "v": "2003/10/24",
-              "n": 1
-            },
-            {
-              "v": "13/04/1987",
-              "n": 1
-            },
-            {
-              "v": "2019/05/29",
+              "v": "2014/05/03",
               "n": 1
             },
             {
@@ -14015,35 +14043,7 @@
               "n": 1
             },
             {
-              "v": "2000/06/08",
-              "n": 1
-            },
-            {
-              "v": "2018/05/10",
-              "n": 1
-            },
-            {
-              "v": "2013/05/03",
-              "n": 1
-            },
-            {
-              "v": "1955/03/31",
-              "n": 1
-            },
-            {
-              "v": "16-05-1997, 17-05-1997",
-              "n": 1
-            },
-            {
               "v": "1958/12/02",
-              "n": 1
-            },
-            {
-              "v": "2021/03/15",
-              "n": 1
-            },
-            {
-              "v": "28-07-1997, 29-07-1997",
               "n": 1
             },
             {
@@ -14051,19 +14051,19 @@
               "n": 1
             },
             {
-              "v": "25-02-1986, 24-02-2004",
+              "v": "2012/06/29",
               "n": 1
             },
             {
-              "v": "16-09-1985, 12-02-1970",
+              "v": "1975/11/22",
               "n": 1
             },
             {
-              "v": "1997/04/09",
+              "v": "1996/01/16",
               "n": 1
             },
             {
-              "v": "1988/02/08",
+              "v": "2010/11/02",
               "n": 1
             },
             {
@@ -14071,7 +14071,7 @@
               "n": 1
             },
             {
-              "v": "1996/01/16",
+              "v": "16-09-1985, 12-02-1970",
               "n": 1
             },
             {
@@ -14087,7 +14087,27 @@
               "n": 1
             },
             {
-              "v": "2018/03/23",
+              "v": "1955/03/31",
+              "n": 1
+            },
+            {
+              "v": "2000/06/08",
+              "n": 1
+            },
+            {
+              "v": "27-11-1970",
+              "n": 1
+            },
+            {
+              "v": "24-01-1997, 30-04-1997",
+              "n": 1
+            },
+            {
+              "v": "2003/10/24",
+              "n": 1
+            },
+            {
+              "v": "13/04/1987",
               "n": 1
             },
             {
@@ -14095,11 +14115,23 @@
               "n": 1
             },
             {
-              "v": "2010/11/02",
+              "v": "28-07-1997, 29-07-1997",
               "n": 1
             },
             {
-              "v": "1994/12/08",
+              "v": "1997/04/09",
+              "n": 1
+            },
+            {
+              "v": "06-05-1997",
+              "n": 1
+            },
+            {
+              "v": "2018/05/10",
+              "n": 1
+            },
+            {
+              "v": "2012/02/29",
               "n": 1
             }
           ]
@@ -14133,7 +14165,7 @@
               "n": 4
             },
             {
-              "v": "2018",
+              "v": "1970",
               "n": 2
             },
             {
@@ -14141,23 +14173,55 @@
               "n": 2
             },
             {
-              "v": "2003",
-              "n": 2
-            },
-            {
               "v": "2013",
               "n": 2
             },
             {
-              "v": "1970",
+              "v": "2003",
               "n": 2
+            },
+            {
+              "v": "2018",
+              "n": 2
+            },
+            {
+              "v": "2016",
+              "n": 1
+            },
+            {
+              "v": "1969",
+              "n": 1
+            },
+            {
+              "v": "1988",
+              "n": 1
+            },
+            {
+              "v": "1985, 1970",
+              "n": 1
+            },
+            {
+              "v": "1955",
+              "n": 1
+            },
+            {
+              "v": "2021",
+              "n": 1
             },
             {
               "v": "1997, 1997",
               "n": 1
             },
             {
+              "v": "1980",
+              "n": 1
+            },
+            {
               "v": "1996",
+              "n": 1
+            },
+            {
+              "v": "1986, 2004",
               "n": 1
             },
             {
@@ -14173,43 +14237,11 @@
               "n": 1
             },
             {
-              "v": "1995",
-              "n": 1
-            },
-            {
-              "v": "1955",
-              "n": 1
-            },
-            {
-              "v": "1969",
-              "n": 1
-            },
-            {
-              "v": "2016",
-              "n": 1
-            },
-            {
-              "v": "1994, 2000",
-              "n": 1
-            },
-            {
-              "v": "1985, 1970",
-              "n": 1
-            },
-            {
-              "v": "2021",
-              "n": 1
-            },
-            {
-              "v": "1988",
-              "n": 1
-            },
-            {
-              "v": "1986, 2004",
-              "n": 1
-            },
-            {
               "v": "2019",
+              "n": 1
+            },
+            {
+              "v": "2004",
               "n": 1
             },
             {
@@ -14221,11 +14253,11 @@
               "n": 1
             },
             {
-              "v": "1980",
+              "v": "1995",
               "n": 1
             },
             {
-              "v": "2004",
+              "v": "1994, 2000",
               "n": 1
             }
           ]
@@ -14239,11 +14271,11 @@
           "max": "Core Zone",
           "top_values": [
             {
-              "v": "Buffer Zone",
+              "v": "Core Zone",
               "n": 7
             },
             {
-              "v": "Core Zone",
+              "v": "Buffer Zone",
               "n": 7
             }
           ]
@@ -14309,11 +14341,11 @@
               "n": 24
             },
             {
-              "v": "32",
+              "v": "37",
               "n": 23
             },
             {
-              "v": "37",
+              "v": "32",
               "n": 23
             },
             {
@@ -14325,11 +14357,11 @@
               "n": 19
             },
             {
-              "v": "05",
+              "v": "03",
               "n": 14
             },
             {
-              "v": "03",
+              "v": "05",
               "n": 14
             },
             {
@@ -14337,12 +14369,16 @@
               "n": 13
             },
             {
+              "v": "15",
+              "n": 12
+            },
+            {
               "v": "36",
               "n": 12
             },
             {
-              "v": "15",
-              "n": 12
+              "v": "20",
+              "n": 11
             },
             {
               "v": "06",
@@ -14353,15 +14389,11 @@
               "n": 11
             },
             {
-              "v": "20",
-              "n": 11
-            },
-            {
-              "v": "14",
+              "v": "11",
               "n": 8
             },
             {
-              "v": "11",
+              "v": "14",
               "n": 8
             },
             {
@@ -14373,11 +14405,11 @@
               "n": 6
             },
             {
-              "v": "17",
+              "v": "13",
               "n": 6
             },
             {
-              "v": "13",
+              "v": "17",
               "n": 6
             },
             {
@@ -14385,7 +14417,7 @@
               "n": 1
             },
             {
-              "v": "34",
+              "v": "26",
               "n": 1
             },
             {
@@ -14393,11 +14425,11 @@
               "n": 1
             },
             {
-              "v": "04",
+              "v": "34",
               "n": 1
             },
             {
-              "v": "26",
+              "v": "04",
               "n": 1
             }
           ]
@@ -14549,7 +14581,7 @@
               "n": 6
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Port Blair",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, Mayabunder, as well as Port Blair",
               "n": 5
             },
             {
@@ -14557,20 +14589,16 @@
               "n": 5
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, Mayabunder, as well as Port Blair",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Port Blair",
               "n": 5
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder as well as Port Blair.",
-              "n": 4
             },
             {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Gandhighat Jetty, Uttara Jetty as well as Port Blair.",
               "n": 4
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, as well as Port Blair.",
-              "n": 3
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder as well as Port Blair.",
+              "n": 4
             },
             {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, Austin Strait as well as Port Blair.",
@@ -14581,27 +14609,11 @@
               "n": 3
             },
             {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, as well as Port Blair.",
+              "n": 3
+            },
+            {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur area, as well as Port Blair.",
-              "n": 2
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur, as well as Port Blair. Travel is only by special demand.",
-              "n": 2
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder area, Diglipur area, as well as Port Blair.",
-              "n": 2
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Jarawa Protection Post, as well as Port Blair",
-              "n": 2
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai and back. Ferry services are available to the national park.",
-              "n": 2
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Gandhighat Jetty, Uttara Jetty as well as Port Blair",
               "n": 2
             },
             {
@@ -14609,39 +14621,35 @@
               "n": 2
             },
             {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder area, Diglipur area, as well as Port Blair.",
+              "n": 2
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur, as well as Port Blair. Travel is only by special demand.",
+              "n": 2
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Gandhighat Jetty, Uttara Jetty as well as Port Blair",
+              "n": 2
+            },
+            {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder area, Diglipur area, as well as Port Blair",
               "n": 2
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur Taluk, as well as Port Blair.",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai and back. Ferry services are available to the national park.",
+              "n": 2
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Jarawa Protection Post, as well as Port Blair",
+              "n": 2
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Jarawa Protection Post, as well as Port Blair.",
               "n": 1
             },
             {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect these islands to South Cinque Island as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, Gandhighat Jetty, Uttara Jetty as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to South Cinque Island, West Sister Island, Kwate tu Kwage as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Rangat Taluk, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Yerrata Jetty, Rangat, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Port Blair.",
               "n": 1
             },
             {
@@ -14653,51 +14661,11 @@
               "n": 1
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Marine Park, Port Blair.",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur Taluk, as well as Port Blair.",
               "n": 1
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur, as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Jarawa Protection Post, as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Austen Strait from Mayabunder, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, Austin Strait as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Nilambur Jetty, Jarawa Protection Post as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "You can take the inter-island boat service from Port Blair. The journey has been termed a trip within itself and takes about a week. Another option is to take the MV Campbell Bay, a government ship that covers the distance from Port Blair to Campbell Bay",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur area as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, Mayabunder, as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Ferrargunj, as well as Port Blair",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Havelock Island as well as Port Blair.",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to the nearest inhabited island, Havelock. The only two ways to arrive here are either by boat or by a seapl",
               "n": 1
             },
             {
@@ -14705,15 +14673,63 @@
               "n": 1
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Gandhighat Jetty, Uttara Jetty, Mayabunder as well as Port Blair",
+              "v": "You can take the inter-island boat service from Port Blair. The journey has been termed a trip within itself and takes about a week. Another option is to take the MV Campbell Bay, a government ship that covers the distance from Port Blair to Campbell Bay",
               "n": 1
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Malacca, Nancowry, Campbell Bay, as well as Port Blair",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Nilambur Jetty, Jarawa Protection Post as well as Port Blair.",
               "n": 1
             },
             {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to the nearest inhabited island, Havelock. The only two ways to arrive here are either by boat or by a seapl",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur, as well as Port Blair and travel is only by special demand.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Marine Park, Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to South Cinque Island, West Sister Island, Kwate tu Kwage as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur area as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Ferrargunj, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Austen Strait from Mayabunder, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder area, Diglipur area, as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Havelock Island as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Yerrata Jetty, Rangat, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Rangat Taluk, as well as Port Blair",
               "n": 1
             },
             {
@@ -14729,15 +14745,31 @@
               "n": 1
             },
             {
-              "v": "Frequent ship services are available passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder area, Diglipur area, as well as Port Blair.",
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, Austin Strait as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Gandhighat Jetty, Uttara Jetty, Mayabunder as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Mayabunder, Gandhighat Jetty, Uttara Jetty as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Malacca, Nancowry, Campbell Bay, as well as Port Blair",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Aerial Bay, Mayabunder, as well as Port Blair.",
+              "n": 1
+            },
+            {
+              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur, as well as Port Blair.",
               "n": 1
             },
             {
               "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Rangat area as well as Port Blair.",
-              "n": 1
-            },
-            {
-              "v": "Frequent ship services are available for passengers traveling to Port Blair from Vishakhapatnam, Kolkata and Chennai. Ferries connect this island to Diglipur, as well as Port Blair and travel is only by special demand.",
               "n": 1
             }
           ]
@@ -14862,15 +14894,7 @@
               "n": 2
             },
             {
-              "v": "Forest Department Gujrat State",
-              "n": 1
-            },
-            {
-              "v": "Forest Resources & Ecology Divsion ,UP",
-              "n": 1
-            },
-            {
-              "v": "GIS Cell,EF & CC Dept. Mizoram",
+              "v": "GIS Lab Forest Department,Manipur",
               "n": 1
             },
             {
@@ -14878,11 +14902,43 @@
               "n": 1
             },
             {
-              "v": "Kachchh East Forest Division & Bhaskaracharya inst",
+              "v": "Vishnu Jedia GIS Cell,IT,Panna Tiger Reserve,Panna",
               "n": 1
             },
             {
-              "v": "Kachchh West Forest Division & Bhaskarcharya Inst",
+              "v": "Geomatics Centre Tamilnadu forest Department",
+              "n": 1
+            },
+            {
+              "v": "GIS Cell EF & CC Dept. Mizoram",
+              "n": 1
+            },
+            {
+              "v": "Forest Department Gujrat State",
+              "n": 1
+            },
+            {
+              "v": "Sohagibarwa WildLife Division,Maharajgan(UP)",
+              "n": 1
+            },
+            {
+              "v": "Gis Cell PMU Lucknow",
+              "n": 1
+            },
+            {
+              "v": "Forest Resources & Ecology Divsion ,UP",
+              "n": 1
+            },
+            {
+              "v": "GIS Cell,EFACC Dept. Mizoram",
+              "n": 1
+            },
+            {
+              "v": "GIS Cell ,EF & CC Dept., Mizoram",
+              "n": 1
+            },
+            {
+              "v": "HP Forest Department",
               "n": 1
             },
             {
@@ -14894,31 +14950,19 @@
               "n": 1
             },
             {
+              "v": "Forest Department ,Gujarat State",
+              "n": 1
+            },
+            {
+              "v": "Kachchh West Forest Division & Bhaskarcharya Inst",
+              "n": 1
+            },
+            {
               "v": "Forest Department Gujarat State,Bhaskarcharya Inst",
               "n": 1
             },
             {
-              "v": "Geomatics Centre Tamilnadu forest Department",
-              "n": 1
-            },
-            {
-              "v": "GIS Lab Forest Department,Manipur",
-              "n": 1
-            },
-            {
-              "v": "Geomatics Center Mehkar",
-              "n": 1
-            },
-            {
-              "v": "Kaimoor WildLife Division Mirzapur",
-              "n": 1
-            },
-            {
-              "v": "Sohagibarwa WildLife Division,Maharajgan(UP)",
-              "n": 1
-            },
-            {
-              "v": "Forest Department ,Gujarat State",
+              "v": "GIS Cell,EF & CC Dept. Mizoram",
               "n": 1
             },
             {
@@ -14926,27 +14970,15 @@
               "n": 1
             },
             {
-              "v": "Gis Cell PMU Lucknow",
+              "v": "Kachchh East Forest Division & Bhaskaracharya inst",
               "n": 1
             },
             {
-              "v": "HP Forest Department",
+              "v": "Kaimoor WildLife Division Mirzapur",
               "n": 1
             },
             {
-              "v": "Vishnu Jedia GIS Cell,IT,Panna Tiger Reserve,Panna",
-              "n": 1
-            },
-            {
-              "v": "GIS Cell EF & CC Dept. Mizoram",
-              "n": 1
-            },
-            {
-              "v": "GIS Cell,EFACC Dept. Mizoram",
-              "n": 1
-            },
-            {
-              "v": "GIS Cell ,EF & CC Dept., Mizoram",
+              "v": "Geomatics Center Mehkar",
               "n": 1
             }
           ]
@@ -14980,43 +15012,11 @@
               "n": 3
             },
             {
-              "v": 122270.81541,
-              "n": 1
-            },
-            {
-              "v": 0.835541360972,
-              "n": 1
-            },
-            {
-              "v": 1695.09928119,
-              "n": 1
-            },
-            {
-              "v": 7070.97121197,
-              "n": 1
-            },
-            {
-              "v": 1.55136588867,
-              "n": 1
-            },
-            {
-              "v": 138580.286978,
-              "n": 1
-            },
-            {
-              "v": 5571354.36361,
-              "n": 1
-            },
-            {
-              "v": 113956.971638,
-              "n": 1
-            },
-            {
               "v": 215712.579133,
               "n": 1
             },
             {
-              "v": 12750.7477521,
+              "v": 226005.042427,
               "n": 1
             },
             {
@@ -15028,7 +15028,7 @@
               "n": 1
             },
             {
-              "v": 17005.4612771,
+              "v": 113956.971638,
               "n": 1
             },
             {
@@ -15036,15 +15036,59 @@
               "n": 1
             },
             {
-              "v": 95879.3345728,
+              "v": 0.835541360972,
               "n": 1
             },
             {
-              "v": 226005.042427,
+              "v": 5571354.36361,
+              "n": 1
+            },
+            {
+              "v": 112288.234579,
+              "n": 1
+            },
+            {
+              "v": 194600.235962,
+              "n": 1
+            },
+            {
+              "v": 17005.4612771,
+              "n": 1
+            },
+            {
+              "v": 1695.09928119,
+              "n": 1
+            },
+            {
+              "v": 0.406347446858,
+              "n": 1
+            },
+            {
+              "v": 1.55136588867,
+              "n": 1
+            },
+            {
+              "v": 12750.7477521,
               "n": 1
             },
             {
               "v": 3.59430842459,
+              "n": 1
+            },
+            {
+              "v": 138580.286978,
+              "n": 1
+            },
+            {
+              "v": 15694.7586161,
+              "n": 1
+            },
+            {
+              "v": 38527.8764859,
+              "n": 1
+            },
+            {
+              "v": 1.32049515181,
               "n": 1
             },
             {
@@ -15053,6 +15097,14 @@
             },
             {
               "v": 176527.351831,
+              "n": 1
+            },
+            {
+              "v": 7070.97121197,
+              "n": 1
+            },
+            {
+              "v": 122270.81541,
               "n": 1
             },
             {
@@ -15072,27 +15124,7 @@
               "n": 1
             },
             {
-              "v": 0.406347446858,
-              "n": 1
-            },
-            {
-              "v": 15694.7586161,
-              "n": 1
-            },
-            {
-              "v": 38527.8764859,
-              "n": 1
-            },
-            {
-              "v": 1.32049515181,
-              "n": 1
-            },
-            {
-              "v": 112288.234579,
-              "n": 1
-            },
-            {
-              "v": 194600.235962,
+              "v": 95879.3345728,
               "n": 1
             }
           ]
@@ -15126,15 +15158,15 @@
               "n": 20
             },
             {
-              "v": "Set_7",
-              "n": 20
-            },
-            {
               "v": "Set_1",
               "n": 20
             },
             {
               "v": "Set_4",
+              "n": 20
+            },
+            {
+              "v": "Set_7",
               "n": 20
             },
             {
@@ -15208,12 +15240,16 @@
               "n": 11
             },
             {
+              "v": "17",
+              "n": 11
+            },
+            {
               "v": "11",
               "n": 11
             },
             {
-              "v": "17",
-              "n": 11
+              "v": "24",
+              "n": 10
             },
             {
               "v": "22",
@@ -15221,10 +15257,6 @@
             },
             {
               "v": "25",
-              "n": 10
-            },
-            {
-              "v": "24",
               "n": 10
             },
             {
@@ -15236,11 +15268,11 @@
               "n": 9
             },
             {
-              "v": "21",
+              "v": "23",
               "n": 8
             },
             {
-              "v": "23",
+              "v": "21",
               "n": 8
             },
             {
@@ -15252,27 +15284,27 @@
               "n": 7
             },
             {
-              "v": "14",
-              "n": 7
-            },
-            {
               "v": "18",
               "n": 7
             },
             {
-              "v": "20",
-              "n": 6
+              "v": "14",
+              "n": 7
             },
             {
               "v": "26",
               "n": 6
             },
             {
-              "v": "29",
+              "v": "20",
               "n": 6
             },
             {
               "v": "35",
+              "n": 6
+            },
+            {
+              "v": "29",
               "n": 6
             },
             {
@@ -15284,11 +15316,7 @@
               "n": 4
             },
             {
-              "v": "30",
-              "n": 4
-            },
-            {
-              "v": "34",
+              "v": "32",
               "n": 4
             },
             {
@@ -15296,7 +15324,11 @@
               "n": 4
             },
             {
-              "v": "32",
+              "v": "34",
+              "n": 4
+            },
+            {
+              "v": "30",
               "n": 4
             },
             {
@@ -15312,43 +15344,11 @@
               "n": 2
             },
             {
-              "v": "39",
-              "n": 1
-            },
-            {
-              "v": "62",
-              "n": 1
-            },
-            {
-              "v": "42",
-              "n": 1
-            },
-            {
-              "v": "47",
-              "n": 1
-            },
-            {
               "v": "45",
               "n": 1
             },
             {
-              "v": "67",
-              "n": 1
-            },
-            {
-              "v": "7",
-              "n": 1
-            },
-            {
-              "v": "83",
-              "n": 1
-            },
-            {
-              "v": "15, 16",
-              "n": 1
-            },
-            {
-              "v": " ",
+              "v": "52",
               "n": 1
             },
             {
@@ -15356,7 +15356,39 @@
               "n": 1
             },
             {
-              "v": "52",
+              "v": "83",
+              "n": 1
+            },
+            {
+              "v": "62",
+              "n": 1
+            },
+            {
+              "v": "7",
+              "n": 1
+            },
+            {
+              "v": "39",
+              "n": 1
+            },
+            {
+              "v": " ",
+              "n": 1
+            },
+            {
+              "v": "15, 16",
+              "n": 1
+            },
+            {
+              "v": "47",
+              "n": 1
+            },
+            {
+              "v": "42",
+              "n": 1
+            },
+            {
+              "v": "67",
               "n": 1
             }
           ]

--- a/scripts/bake_pmtiles.py
+++ b/scripts/bake_pmtiles.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Bake PMTiles for the 8 curated layers that currently only have parquet
+downloads (SOI / Bhuvan / PMGSY). Cross-source viewing on the home page
+("Per LGD · also: SOI, Bhuvan") only surfaces map-renderable sources;
+without pmtiles these alts stay hidden behind the <details> "compare
+sources" block. Baking them unblocks the inline alt links.
+
+Pipeline per layer:
+  1. parquet → GeoJSON via DuckDB-spatial (COPY ... FORMAT GDAL)
+  2. GeoJSON → PMTiles via tippecanoe (auto zoom)
+  3. Write output to sources/india-geodata/<NAME>.pmtiles
+  4. Print actual row count + output size for catalog update
+
+After running, update scripts/build_catalog.py LAYERS to fill in the
+5th tuple slot (pmtiles filename) for each baked layer, then run
+build_catalog.py and upload_r2.sh to publish.
+
+Run:
+    python3 scripts/bake_pmtiles.py            # all 8 layers
+    python3 scripts/bake_pmtiles.py bhuvan     # filter by substring
+"""
+from __future__ import annotations
+import os, subprocess, sys, time
+from pathlib import Path
+import duckdb
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / 'sources' / 'india-geodata'
+WORK = Path('/tmp/bake')
+WORK.mkdir(exist_ok=True)
+
+# (parquet_filename, layer_name_for_tippecanoe, pmtiles_filename)
+# layer_name matches the catalog id so map.ts can find vector_layers[0].
+LAYERS = [
+    ('SOI_States.parquet',         'soi_states',          'SOI_States.pmtiles'),
+    ('SOI_Districts.parquet',      'soi_districts',       'SOI_Districts.pmtiles'),
+    ('SOI_Subdistricts.parquet',   'soi_subdistricts',    'SOI_Subdistricts.pmtiles'),
+    ('SOI_VILLAGE_POINT.parquet',  'soi_village_points',  'SOI_VILLAGE_POINT.pmtiles'),
+    ('bhuvan_states.parquet',      'bhuvan_states',       'bhuvan_states.pmtiles'),
+    ('bhuvan_districts.parquet',   'bhuvan_districts',    'bhuvan_districts.pmtiles'),
+    ('bhuvan_blocks.parquet',      'bhuvan_blocks',       'bhuvan_blocks.pmtiles'),
+    ('PMGSY_Blocks.parquet',       'pmgsy_blocks',        'PMGSY_Blocks.pmtiles'),
+]
+
+
+def bake(parquet_name: str, layer: str, pmtiles_name: str, con: duckdb.DuckDBPyConnection):
+    src = SRC / parquet_name
+    if not src.exists():
+        print(f'  !! SKIP — source missing: {src}')
+        return None
+
+    gj = WORK / f'{layer}.geojson'
+    pmt_out = SRC / pmtiles_name
+
+    if gj.exists(): gj.unlink()
+    t0 = time.time()
+    con.execute(f"""
+        COPY (SELECT * FROM '{src}')
+        TO '{gj}'
+        WITH (FORMAT GDAL, DRIVER 'GeoJSON', LAYER_CREATION_OPTIONS ('WRITE_BBOX=YES'))
+    """)
+    (rows,) = con.execute(f"SELECT COUNT(*) FROM '{src}'").fetchone()
+    gj_mb = gj.stat().st_size / 1024 / 1024
+    print(f'    geojson: {gj_mb:.1f} MB, {rows:,} rows  ({time.time()-t0:.1f}s)')
+
+    if pmt_out.exists(): pmt_out.unlink()
+    t0 = time.time()
+    subprocess.run(
+        ['tippecanoe',
+         '-o', str(pmt_out), '-l', layer,
+         '-zg',
+         '--drop-densest-as-needed',
+         '--extend-zooms-if-still-dropping',
+         '--force',
+         '--no-progress-indicator',
+         str(gj)],
+        check=True, capture_output=True,
+    )
+    pmt_mb = pmt_out.stat().st_size / 1024 / 1024
+    print(f'    pmtiles: {pmt_mb:.1f} MB  ({time.time()-t0:.1f}s)')
+
+    gj.unlink()  # don't keep huge intermediate geojson around
+    return {'rows': rows, 'pmtiles_bytes': pmt_out.stat().st_size, 'pmtiles_name': pmtiles_name}
+
+
+def main():
+    filt = sys.argv[1].lower() if len(sys.argv) > 1 else None
+    con = duckdb.connect()
+    con.install_extension('spatial')
+    con.load_extension('spatial')
+
+    targets = [t for t in LAYERS if not filt or filt in t[0].lower() or filt in t[1]]
+    print(f'Baking {len(targets)} layer(s)...\n')
+    results = {}
+    for parquet, layer, pmt in targets:
+        print(f'• {layer}')
+        r = bake(parquet, layer, pmt, con)
+        if r:
+            results[layer] = r
+        print()
+
+    print('=== summary (paste into build_catalog.py LAYERS rows) ===')
+    for layer, r in results.items():
+        print(f"  {layer}: rows={r['rows']:,}  pmtiles='{r['pmtiles_name']}'  ({r['pmtiles_bytes']/1024/1024:.1f} MB)")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -55,11 +55,18 @@ ATTR = {
     'GatiShakti':    {'name': 'PM GatiShakti',               'url': 'https://gis.pmgatishakti.gov.in/'},
     'Bharatmaps':    {'name': 'Bharatmaps (NIC)',            'url': 'https://bharatmaps.gov.in/'},
     'OpenCity':      {'name': 'OpenCity / Oorvani Foundation', 'url': 'https://data.opencity.in/'},
+    'bharatviz':     {'name': 'bharatviz (Saket Choudhary)',  'url': 'https://bharatviz.org/'},
 }
 PUBLISHER = {
     'name': 'yashveeeeeeer/india-geodata',
     'url': 'https://github.com/yashveeeeeeer/india-geodata',
 }
+
+# Sources whose files are republished via the yashveeeeeeer/india-geodata
+# release archive (so PUBLISHER + UPSTREAM_BASE apply). Other curated sources
+# (bharatviz, etc.) are pulled direct from origin — their entries should not
+# carry the yashveer attribution or upstream_url.
+YASHVEER_HOSTED = {'LGD', 'SOI', 'Bhuvan', 'PMGSY', 'GatiShakti', 'Bharatmaps'}
 
 # Where to re-fetch each upstream file from. Path under the release base URL.
 # Kept here so the source registry travels with the catalog and a single
@@ -102,15 +109,14 @@ LAYERS = [
     ('lgd_panchayats',     'panchayat',   'LGD',    'LGD_panchayats.parquet',     'LGD_Panchayats.pmtiles',     319287,  LIC_BELOW,      'Authoritative. 319k gram-panchayat polygons. Use vector tiles to render at zoom.'),
 
     ('lgd_villages',       'village',     'LGD',    'LGD_Villages.parquet',       'LGD_Villages.pmtiles',       584615,  LIC_BELOW,      'Authoritative. 584k polygons. Use vector tiles to render.'),
-    ('soi_village_points', 'village',     'SOI',    'SOI_VILLAGE_POINT.parquet',  'SOI_VILLAGE_POINT.pmtiles',   576430,  LIC_BELOW,      'SoI village centroids (point geometry). 5.76 lakh point features — every revenue village named by SoI.'),
+    ('soi_village_points', 'village',     'SOI',    'SOI_VILLAGE_POINT.parquet',  'SOI_VILLAGE_POINT.pmtiles',   576430,  LIC_BELOW,      'SoI village centroids (point geometry). 5.76 lakh point features. Coverage is dense in southern + western states and sparse in UP, Bihar, Jharkhand and several NE states (SoI source limitation, not a rendering issue).'),
 
     # Electoral
     ('lgd_parliament',     'parliament_constituency', 'LGD', 'LGD_Parliament_Constituencies.parquet', 'LGD_Parliament_Constituencies.pmtiles', 543,  LIC_BELOW, 'Lok Sabha constituencies — 543 polygons covering the entire country. Latest delimitation.'),
     ('lgd_assembly',       'assembly_constituency',   'LGD', 'LGD_Assembly_Constituencies.parquet',   'LGD_Assembly_Constituencies.pmtiles',   None, LIC_BELOW, 'State legislative assembly constituencies. Polygons keyed by ST_CODE.'),
 
-    # Postal — pincodes deferred: data.gov.in ships only parquet, no PMTiles,
-    # so the "View map" button reads "no map" and the row looks broken on the
-    # home page. Re-add once we generate vector tiles for the 19k polygons.
+    # Postal
+    ('bharatviz_pincodes', 'pincode',     'bharatviz', 'bharatviz_pincodes.parquet', 'bharatviz_pincodes.pmtiles',  63864,   'MIT',          'India Post pincode boundary polygons (simplified). 63,864 polygons. © 2025 Saket Choudhary, MIT-licensed via bharatviz.org. Source: bharatviz.org/India_pincodes_simplified.geojson; code repo github.com/saketlab/bharatviz.'),
 
     # Environment
     ('gs_wildlife',        'wildlife',    'GatiShakti', 'GatiShakti_Wildlife_Sanctuaries_and_National_Parks.parquet', 'GatiShakti_Wildlife_Sanctuaries_and_National_Parks.pmtiles', None, LIC_BELOW, 'Wildlife sanctuaries + national parks. Source via PM GatiShakti GIS portal.'),
@@ -388,7 +394,7 @@ def build():
             'licence': licence,
             'attribution': {
                 'primary': ATTR[source],
-                'publisher': PUBLISHER,
+                'publisher': PUBLISHER if source in YASHVEER_HOSTED else None,
             },
             'category': level_meta.get('category', 'administrative'),
             'provenance': 'curated',

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -85,24 +85,24 @@ CATEGORIES = {
 # (id, level, source, parquet, pmtiles, rows, licence, notes)
 LAYERS = [
     ('lgd_states',         'state',       'LGD',    'LGD_States.parquet',         'LGD_States.pmtiles',         36,      LIC_STATE_DIST, 'Authoritative state and Union Territory boundaries from India\'s Local Government Directory (LGD). 36 polygons with the full LGD code chain, enabling joins with district, subdistrict, block and village layers.'),
-    ('soi_states',         'state',       'SOI',    'SOI_States.parquet',         None,                          40,      LIC_STATE_DIST, 'Survey of India derivative.'),
-    ('bhuvan_states',      'state',       'Bhuvan', 'bhuvan_states.parquet',      None,                          37,      LIC_STATE_DIST, 'NRSC/ISRO Bhuvan. Own codes, not LGD.'),
+    ('soi_states',         'state',       'SOI',    'SOI_States.parquet',         'SOI_States.pmtiles',          40,      LIC_STATE_DIST, 'Survey of India derivative.'),
+    ('bhuvan_states',      'state',       'Bhuvan', 'bhuvan_states.parquet',      'bhuvan_states.pmtiles',       37,      LIC_STATE_DIST, 'NRSC/ISRO Bhuvan. Own codes, not LGD.'),
 
     ('lgd_districts',      'district',    'LGD',    'LGD_Districts.parquet',      'LGD_Districts.pmtiles',      785,     LIC_STATE_DIST, 'Every district in India from the Local Government Directory (LGD). 785 polygons; joins to state boundaries via the state_lgd code, with the full LGD chain for joining to subdistricts, blocks and villages.'),
-    ('soi_districts',      'district',    'SOI',    'SOI_Districts.parquet',      None,                          742,     LIC_STATE_DIST, 'SoI derivative. Partial LGD codes.'),
-    ('bhuvan_districts',   'district',    'Bhuvan', 'bhuvan_districts.parquet',   None,                          663,     LIC_STATE_DIST, 'Bhuvan. Under-counts vs LGD in some states.'),
+    ('soi_districts',      'district',    'SOI',    'SOI_Districts.parquet',      'SOI_Districts.pmtiles',       742,     LIC_STATE_DIST, 'SoI derivative. Partial LGD codes.'),
+    ('bhuvan_districts',   'district',    'Bhuvan', 'bhuvan_districts.parquet',   'bhuvan_districts.pmtiles',    663,     LIC_STATE_DIST, 'Bhuvan. Under-counts vs LGD in some states.'),
 
     ('lgd_subdistricts',   'subdistrict', 'LGD',    'LGD_Subdistricts.parquet',   'LGD_Subdistricts.pmtiles',   6471,    LIC_BELOW,      'All subdistricts (tehsil / taluk / mandal) in India from the Local Government Directory (LGD). 6,471 polygons with the full LGD code chain for joining to districts, states, and finer admin levels (blocks, villages).'),
-    ('soi_subdistricts',   'subdistrict', 'SOI',    'SOI_Subdistricts.parquet',   None,                          4723,    LIC_BELOW,      'SoI tehsils. Partial codes.'),
+    ('soi_subdistricts',   'subdistrict', 'SOI',    'SOI_Subdistricts.parquet',   'SOI_Subdistricts.pmtiles',    4723,    LIC_BELOW,      'SoI tehsils. Partial codes.'),
 
     ('lgd_blocks',         'block',       'LGD',    'LGD_Blocks.parquet',         'LGD_Blocks.pmtiles',         7146,    LIC_BELOW,      'Community-development blocks across India from the Local Government Directory (LGD). 7,146 polygons with the full LGD code chain joining to subdistricts, districts and states.'),
-    ('bhuvan_blocks',      'block',       'Bhuvan', 'bhuvan_blocks.parquet',      None,                          6393,    LIC_BELOW,      'Bhuvan. Predates recent re-divisions in several states.'),
-    ('pmgsy_blocks',       'block',       'PMGSY',  'PMGSY_Blocks.parquet',       None,                          6637,    LIC_BELOW,      'PMGSY rural roads blocks. Block + district + state names joined from PMGSY_Masterdata (99% coverage).'),
+    ('bhuvan_blocks',      'block',       'Bhuvan', 'bhuvan_blocks.parquet',      'bhuvan_blocks.pmtiles',       6393,    LIC_BELOW,      'Bhuvan. Predates recent re-divisions in several states.'),
+    ('pmgsy_blocks',       'block',       'PMGSY',  'PMGSY_Blocks.parquet',       'PMGSY_Blocks.pmtiles',        6637,    LIC_BELOW,      'PMGSY rural roads blocks. Block + district + state names joined from PMGSY_Masterdata (99% coverage).'),
 
     ('lgd_panchayats',     'panchayat',   'LGD',    'LGD_panchayats.parquet',     'LGD_Panchayats.pmtiles',     319287,  LIC_BELOW,      'Authoritative. 319k gram-panchayat polygons. Use vector tiles to render at zoom.'),
 
     ('lgd_villages',       'village',     'LGD',    'LGD_Villages.parquet',       'LGD_Villages.pmtiles',       584615,  LIC_BELOW,      'Authoritative. 584k polygons. Use vector tiles to render.'),
-    ('soi_village_points', 'village',     'SOI',    'SOI_VILLAGE_POINT.parquet',  None,                          None,    LIC_BELOW,      'SoI village centroids (point geometry).'),
+    ('soi_village_points', 'village',     'SOI',    'SOI_VILLAGE_POINT.parquet',  'SOI_VILLAGE_POINT.pmtiles',   576430,  LIC_BELOW,      'SoI village centroids (point geometry). 5.76 lakh point features — every revenue village named by SoI.'),
 
     # Electoral
     ('lgd_parliament',     'parliament_constituency', 'LGD', 'LGD_Parliament_Constituencies.parquet', 'LGD_Parliament_Constituencies.pmtiles', 543,  LIC_BELOW, 'Lok Sabha constituencies — 543 polygons covering the entire country. Latest delimitation.'),

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -72,6 +72,7 @@ function licenseUrl(id) {
     'ODbL-1.0':      'https://opendatacommons.org/licenses/odbl/1-0/',
     'ODC-PDDL-1.0':  'https://opendatacommons.org/licenses/pddl/1-0/',
     'GODL-India':    'https://data.gov.in/government-open-data-license-india',
+    'MIT':           'https://opensource.org/licenses/MIT',
   };
   if (!id) return undefined;
   // dual e.g. "CC0-1.0 / CC-BY-4.0" — pick the most permissive.

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -177,6 +177,25 @@ function addFillLayers(sourceId: string, sourceLayer?: string) {
       'line-opacity': 0.85,
     },
   });
+  // Point geometries (e.g. soi_village_points 5.76 lakh points). Fill / line
+  // layers naturally ignore non-polygon features, so this circle layer adds
+  // point rendering without changing how polygon layers display. Radius
+  // grows with zoom so country-view shows sparse dots and city-view shows
+  // clearly readable markers.
+  map.addLayer({
+    id: 'point',
+    type: 'circle',
+    source: sourceId,
+    ...common,
+    filter: ['==', ['geometry-type'], 'Point'],
+    paint: {
+      'circle-radius': ['interpolate', ['linear'], ['zoom'], 4, 1, 10, 3, 14, 5],
+      'circle-color': '#0a58ca',
+      'circle-opacity': 0.7,
+      'circle-stroke-width': ['interpolate', ['linear'], ['zoom'], 8, 0, 12, 0.5],
+      'circle-stroke-color': '#fff',
+    },
+  });
 
   // One popup with one look — fed by hover on pointer devices and by tap on
   // touch devices. Tap-on-feature shows it, tap-elsewhere (or tap a different
@@ -202,28 +221,42 @@ function addFillLayers(sourceId: string, sourceLayer?: string) {
   const showPopup = (e: maplibregl.MapMouseEvent & { features?: maplibregl.MapGeoJSONFeature[] }) => {
     const f = e.features?.[0];
     if (!f) return;
-    const fid = (f.id as string | number | undefined) ?? f.properties?.OBJECTID ?? f.properties?.vil_lgd;
+    // Fid is used to dedup setHTML across the many mousemove events that fire
+    // while hovering one feature. Widened to cover SOI points (lowercase
+    // objectid, soi_code) and arbitrary contributed shapes that may carry
+    // none of the above — falls back to lngLat-as-fingerprint at ~1m precision.
+    const fid = (f.id as string | number | undefined)
+      ?? f.properties?.OBJECTID
+      ?? f.properties?.objectid
+      ?? f.properties?.vil_lgd
+      ?? f.properties?.soi_code
+      ?? `${e.lngLat.lng.toFixed(5)},${e.lngLat.lat.toFixed(5)}`;
     if (fid !== popupId) {
       popup.setHTML(buildRows(f.properties));
       popupId = fid;
     }
     popup.setLngLat(e.lngLat).addTo(map!);
   };
-  map.on('mousemove', 'fill', (e) => {
-    map!.getCanvas().style.cursor = 'pointer';
-    showPopup(e);
-  });
-  map.on('mouseleave', 'fill', () => {
-    map!.getCanvas().style.cursor = '';
-    popup.remove();
-    popupId = undefined;
-  });
-  // Touch / no-hover devices: tap a feature to show its details. Tapping
-  // empty map or a different feature swaps/clears it.
-  map.on('click', 'fill', showPopup);
+  // Bind hover / click on both polygon-fill and point layers so point-only
+  // layers (soi_village_points) get the same popup behavior as polygon ones.
+  const interactiveLayers = ['fill', 'point'];
+  for (const id of interactiveLayers) {
+    map.on('mousemove', id, (e) => {
+      map!.getCanvas().style.cursor = 'pointer';
+      showPopup(e);
+    });
+    map.on('mouseleave', id, () => {
+      map!.getCanvas().style.cursor = '';
+      popup.remove();
+      popupId = undefined;
+    });
+    // Touch / no-hover devices: tap a feature to show its details. Tapping
+    // empty map or a different feature swaps/clears it.
+    map.on('click', id, showPopup);
+  }
   map.on('click', (e) => {
     // Empty-map tap (no features at click point) dismisses the popup.
-    const hit = map!.queryRenderedFeatures(e.point, { layers: ['fill'] });
+    const hit = map!.queryRenderedFeatures(e.point, { layers: interactiveLayers });
     if (!hit.length) {
       popup.remove();
       popupId = undefined;


### PR DESCRIPTION
## Summary

Closes the cross-source viewing gap from #23: 8 curated layers now have PMTiles (were parquet-only), so the home-page "Per LGD · also: SOI, Bhuvan" framing surfaces real viewable alternates instead of being filtered down to just geoBoundaries. Also adds the first pincode layer (bharatviz, 63,864 polygons), fixes point-geometry rendering + tooltips, and corrects an attribution edge case.

## Commits

1. `4edbde9` **feat(catalog): bake PMTiles for SOI / Bhuvan / PMGSY (cross-source view parity)**
   - 8 layers baked via DuckDB-spatial → tippecanoe → R2 upload at `admin/<level>/<file>.pmtiles`. Total 182.5 MB pmtiles. Compute ~4 min for all 8.
   - `soi_village_points` row count fixed (catalog had `0`, actual is `576,430`).
   - New helper `scripts/bake_pmtiles.py` for ad-hoc re-baking from existing parquet (standalone from the full ingest pipeline).

2. `019c79d` **feat: bharatviz pincodes layer + point rendering + a few small fixes**
   - `bharatviz_pincodes` registered as the first pincode-level layer. License MIT (per bharatviz LICENSE file). Primary attribution `"bharatviz (Saket Choudhary)" → https://bharatviz.org/`. Notes preserve the MIT copyright notice + author + upstream URL + code repo.
   - `map.ts`: new circle layer for point geometries (soi_village_points had no rendering before), popup binding extended to point layer, widened the `fid` fallback chain so point tooltips dedup correctly (old chain only knew `OBJECTID` + `vil_lgd`; new chain handles `objectid`, `soi_code`, and a lngLat fingerprint).
   - `YASHVEER_HOSTED` set added so per-layer publisher attribution skips the `yashveeeeeeer/india-geodata` wrapper for sources we pull direct from origin (bharatviz, future).
   - `prerender.mjs` `licenseUrl()` learns about MIT (otherwise the SEO regression test fails for bharatviz, which aborts `npm run build`).
   - `soi_village_points` notes line flags the upstream SOI coverage gap for UP (7%), Bihar (17%), Jharkhand (22%), and most NE states. Blank space on the rendered map is real upstream sparseness.

## Home page after merge

| Level | Before | After |
|---|---|---|
| States | Per LGD · also: geoBoundaries | **Per LGD · also: SOI, Bhuvan, geoBoundaries** |
| Districts | Per LGD · also: geoBoundaries | **Per LGD · also: SOI, Bhuvan, geoBoundaries** |
| Subdistricts | Per LGD · also: geoBoundaries | **Per LGD · also: SOI, geoBoundaries** |
| Blocks | Per LGD · also: geoBoundaries | **Per LGD · also: Bhuvan, PMGSY, geoBoundaries** |
| Villages | (no alts) | **Per LGD · also: SOI** |
| **Pin codes** | (didn't exist) | **Per bharatviz (Saket Choudhary)** |

29 curated levels total (was 28).

## Tests + verification

- ✅ 359/359 vitest tests pass (including the SEO regression that initially broke on MIT)
- ✅ Build clean (`✓ built in 3.02s`)
- ✅ Each new R2 pmtiles spot-checked HTTP 200
- ✅ Local visual verification:
  - `/view/soi_village_points` renders points + tooltips show village name/state/district
  - `/view/bharatviz_pincodes` renders 63,864 pincode polygons + tooltips show pincode + office_name
  - `/view/lgd_states` polygon tooltips still work (not regressed)
  - Home page shows new alt links and clicking any alt opens the map and renders

## Follow-ups already logged

- **Task #64** — India-correct basemap (Bhuvan / Mappls) + always-on LGD boundary overlay. The Twitter J&K feedback is really about the basemap rendering the international view of disputed boundaries; baking PMTiles doesn't address that. Next PR.
- **Task #65** — A11y: `<summary>` wraps interactive `<a>` elements on every catalog row (~84 elements per devtools Issues panel). Pre-existing pattern; needs layout refactor to fix properly. Separate PR.

## Test plan

- [ ] Merge → auto-deploy completes (~2-3 min)
- [ ] Visit https://bharatlas.com/ → confirm new "also: SOI, Bhuvan, PMGSY" framing on admin rows + new Pin codes section
- [ ] Click each new alt (SOI, Bhuvan, PMGSY, bharatviz) → map opens and renders
- [ ] `/view/soi_village_points` on prod → hover a dot in Maharashtra → tooltip shows
- [ ] `/view/bharatviz_pincodes` on prod → 63k polygons render

🤖 Generated with [Claude Code](https://claude.com/claude-code)