### PR TITLE
A11y: row actions out of <summary> + LGD cross-source overlay (basemap deferred)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,19 @@ A visual catalog, drag-drop verifier, and anonymous contribution flow for India'
 
 ```
 catalog               → state · district · subdistrict · block · village (LGD)
+                        + cross-source alternates (SOI · Bhuvan · geoBoundaries
+                        · PMGSY per level — click "also: ..." on any card)
                         + city wards (Bengaluru, Chennai, Hyderabad, Mumbai, …)
                         + electoral constituencies, wildlife, eco-zones
+                        + 63k pincode polygons (bharatviz)
 preview               → drop GeoJSON · KML · KMZ · GPX · TCX · Parquet →
                         render + validate → optional Publish
 filter & export       → dynamic facets / range / search per layer schema,
                         slice by what the data actually contains, export
                         as Parquet · GeoJSON · KML
 view (/view/<id>)     → curated layer with per-layer OG card
-view (/c/<id>)        → community submission, edge-rendered HTML, ▲/▼ vote,
-                        per-submission OG card
+view (/c/<id>)        → community submission, edge-rendered HTML, 👍 useful
+                        vote, per-submission OG card
 embed                 → /embed/<id> iframe + PNG export from any map
 ```
 
@@ -76,9 +79,9 @@ Commit messages: short subject, body explains *why* not *what*. Examples in `git
 
 ## Roadmap
 
-- **Now**: "Your submissions" panel · CSP re-enable · a11y to 95+ · privacy + ToS
+- **Now**: India-correct basemap (Bhuvan WMS / Mappls / forked Mapbox style) · CSP re-enable
 - **Next**: REST API + MCP server + Claude Code plugin (v5)
-- **Done**: catalog, in-browser filter & export, anonymous contribution, mixed catalog, votes, embed + PNG, per-layer OG, schema-driven filters, city ward ingest
+- **Done**: catalog, in-browser filter & export, anonymous contribution, mixed catalog, single-direction "useful" vote, embed + PNG, per-layer OG, schema-driven filters, city ward ingest, "Your submissions" panel, hourly auto-rebuild for community submissions, liability disclaimer + disputed-borders policy, cross-source viewing (SOI/Bhuvan/PMGSY PMTiles + bharatviz pincodes + LGD overlay), privacy + ToS, a11y refactor
 
 Track active work in [Issues](https://github.com/urbanmorph/geodata/issues) and [Milestones](https://github.com/urbanmorph/geodata/milestones).
 
@@ -105,6 +108,7 @@ Data sources, in approximate order of catalog footprint:
 - [PMGSY](https://omms.nic.in/) — Pradhan Mantri Gram Sadak Yojana; rural blocks + roads.
 - [PM GatiShakti](https://gis.pmgatishakti.gov.in/) — wildlife sanctuaries + national parks.
 - [Bharatmaps](https://bharatmaps.gov.in/) (NIC) — eco-sensitive zones.
+- [bharatviz](https://bharatviz.org/) (Saket Choudhary, MIT) — India Post pincode boundary polygons (simplified).
 - [geoBoundaries](https://www.geoboundaries.org/) — independent cross-check.
 - [data.gov.in](https://data.gov.in/) — additional government open data.
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -2,7 +2,7 @@
 
 Coverage report for bharatlas's curated admin layers. For implementation details (directory layout, refresh commands) see the [README](./README.md). For per-card licence + attribution see the [catalog](https://bharatlas.com/).
 
-Last verified: 2026-05-19.
+Last verified: 2026-05-23.
 
 ## TL;DR
 
@@ -30,9 +30,10 @@ A curated republication of openly-licensed Indian geospatial data. Each admin le
 | Block (CD) | Bhuvan | 6,393 | yes | own codes | ↑ state+dist |
 | Block (CD) | PMGSY | 6,637 | **no — IDs only** | yes | ↑ state+dist |
 | Village | LGD | **584,615** | yes | yes (full) | ↑ state+dist+subdt+block+GP |
-| Village (point) | SOI | ~600k | yes | partial | ↑ state+dist+subdt |
+| Village (point) | SOI | 576,430 | yes | partial | ↑ state+dist+subdt |
+| Pincode | bharatviz | 63,864 | yes (office name + pincode) | no | none — flat |
 
-LGD layers carry: `state_lgd`, `dist_lgd`, `subdt_lgd`, `block_lgd`, `vil_lgd`, plus 2011 Census codes (`stcode11`, `dtcode11`, …). Bhuvan uses its own codes only.
+LGD layers carry: `state_lgd`, `dist_lgd`, `subdt_lgd`, `block_lgd`, `vil_lgd`, plus 2011 Census codes (`stcode11`, `dtcode11`, …). Bhuvan uses its own codes only. As of 2026-05-23 every layer above has both `.parquet` (download) and `.pmtiles` (map view) on R2 — the SOI/Bhuvan/PMGSY pmtiles were baked in catch-up (PR #25).
 
 ### Secondary — geoBoundaries (CC-BY-4.0)
 
@@ -64,7 +65,9 @@ The 32-block-records-for-30-blocks reflects three different `block_lgd` codes re
 
 2. **Habitations / settlements not pulled.** Multi-GB files (Karma Shapes 900 MB, GatiShakti 2.5 GB, ESRI Sentinel-2 built-up 545 MB). Worth a dedicated decision.
 
-3. **SOI and Bhuvan village polygons not pulled.** Only LGD villages (474 MB) retained. SOI villages 602 MB; Bhuvan villages 792 MB. Useful only when cross-validating polygon disputes — LGD-by-code is the working source.
+3. **SOI and Bhuvan village *polygons* not pulled.** Only LGD villages (474 MB) retained as polygons. SOI village *points* (576k, 25 MB parquet + 58 MB pmtiles) ARE pulled and viewable since PR #25 — useful for label/centroid joins but not polygon work. SOI village polygons 602 MB; Bhuvan village polygons 792 MB — skipped because LGD-by-code is the working source for polygon work.
+
+   SOI village-point coverage is uneven across states: dense in southern + western states (Maharashtra 54k, Rajasthan 52k, Tamil Nadu 51k, Karnataka 51k) and catastrophically sparse in UP (7.5k, ~7% of actual villages), Bihar (7.7k, ~17%), Jharkhand (7.1k, ~22%), Mizoram (0.4k), Tripura (0.05k). Surfaced as the visual east-central blank space on /view/soi_village_points. Disclosed on the layer card.
 
 4. ~~PMGSY_Blocks has IDs but no names.~~ **Resolved 2026-05-21:** `scripts/enrich_pmgsy_blocks.py` joins `PMGSY_Masterdata.csv` into `PMGSY_Blocks.parquet`. 6,627 / 6,637 blocks (99%) now carry `BLOCK_NAME` + `DISTRICT_NAME` + `STATE_NAME`. The 10 unmatched are decommissioned / mis-coded blocks.
 

--- a/web/about.template.html
+++ b/web/about.template.html
@@ -79,7 +79,8 @@
 
     <h2>What you can do today</h2>
     <ul>
-      <li>View every admin level from <strong>state</strong> to <strong>village</strong> on a map, plus city wards across <strong>15 Indian cities</strong> (Bengaluru, Chennai, Hyderabad, Mumbai and more), constituencies, wildlife sanctuaries.</li>
+      <li>View every admin level from <strong>state</strong> to <strong>village</strong> on a map, plus city wards across <strong>15 Indian cities</strong> (Bengaluru, Chennai, Hyderabad, Mumbai and more), constituencies, wildlife sanctuaries, <strong>63,864 pincode polygons</strong>.</li>
+      <li>Compare what each authoritative source (LGD vs SOI vs Bhuvan vs geoBoundaries) says about the same admin level by clicking the alternate-source links on any card.</li>
       <li>Filter any layer by what its columns actually contain (state, zone, area, anything) and export the slice as <strong>Parquet</strong>, <strong>GeoJSON</strong> or <strong>KML</strong>.</li>
       <li><a href="/preview">Drop a file</a> to see it on a map and validate it. Optionally publish under an open licence. No signup; you get an admin token to keep forever.</li>
       <li>Embed any map in a blog post or report (iframe snippet + PNG export, one click each).</li>
@@ -98,7 +99,7 @@
       <dd>No. Viewing, slicing, downloading and contributing all work without an account. When you publish a layer you receive a one-time admin token (also downloadable as a <code>.txt</code> backup) that you keep forever to edit or delete that submission.</dd>
 
       <dt>What data sources does bharatlas use?</dt>
-      <dd>Curated layers come from the Local Government Directory (LGD), Survey of India (SOI), NRSC/ISRO Bhuvan, OpenCity / Oorvani Foundation, PMGSY (Rural Roads), PM GatiShakti, Bharatmaps (NIC), geoBoundaries and data.gov.in. Community submissions credit their own source on every card.</dd>
+      <dd>Curated layers come from the Local Government Directory (LGD), Survey of India (SOI), NRSC/ISRO Bhuvan, OpenCity / Oorvani Foundation, PMGSY (Rural Roads), PM GatiShakti, Bharatmaps (NIC), bharatviz (pincode polygons), geoBoundaries and data.gov.in. Most admin levels carry several source variants you can compare on the same map; the catalog card shows "Per LGD · also: SOI, Bhuvan" with clickable alternates. Community submissions credit their own source on every card.</dd>
 
       <dt>What licences apply?</dt>
       <dd>Curated layers carry CC0-1.0, CC-BY-4.0 or GODL-India depending on the upstream source. Community submissions choose from an open-licence allowlist: CC0, CC-BY, CC-BY-SA, ODbL, ODC-PDDL or GODL-India. Proprietary or "all rights reserved" content is rejected at submit.</dd>

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -142,15 +142,25 @@
       .row:last-child { border-bottom: none; }
 
       /* === Compact list layout (Option B) =========================== */
-      .row--compact .row__details { width: 100%; }
+      .row--compact .row__details { width: 100%; min-width: 0; }
+      /* row__head is the outer grid: details (title/source/count + expand) on
+         the left, actions on the right. row__actions used to live inside
+         <summary> but that violated HTML semantics (interactive descendants
+         of an interactive element). Moving actions out of <summary> fixes
+         the a11y issue without changing the visual layout. */
+      .row--compact .row__head {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        gap: 14px;
+      }
       .row--compact .row__summary {
         display: grid;
         /* Fixed title + source + count columns so source/count line up
-           vertically across rows regardless of title length. Actions
-           column absorbs the remainder. Title overflow → ellipsis with
-           tooltip; source widened to fit "GatiShakti"/"Bharatmaps";
-           actions wrap when needed (e.g. very long download lists). */
-        grid-template-columns: 280px 80px 180px 1fr;
+           vertically across rows regardless of title length. Title overflow
+           → ellipsis with tooltip; source widened to fit "GatiShakti" /
+           "Bharatmaps". Actions now sit in the row__head grid as a sibling. */
+        grid-template-columns: 280px 80px 180px;
         align-items: center;
         gap: 14px;
         padding: 10px 4px;
@@ -166,8 +176,8 @@
       .row--compact .row__summary > .row__count { color: var(--muted); font-size: 12px; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
       .row--compact .row__summary > .row__count .row__num { font-variant-numeric: tabular-nums; color: var(--fg); font-weight: 500; margin-right: 6px; }
       .row--compact .row__summary > .row__count .row__unit { color: var(--muted); }
-      .row--compact .row__summary > .row__actions { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; min-width: 0; }
-      .row--compact .row__summary > .row__actions .dl-inline { display: inline-flex; gap: 6px; align-items: baseline; flex-wrap: wrap; }
+      .row--compact .row__head > .row__actions { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; min-width: 0; padding: 10px 4px; }
+      .row--compact .row__head > .row__actions .dl-inline { display: inline-flex; gap: 6px; align-items: baseline; flex-wrap: wrap; }
       .row--compact .row__expand {
         padding: 10px 4px 14px;
         border-top: 1px dashed var(--line);
@@ -181,7 +191,7 @@
       /* Mobile: only title + actions visible; source + count fold into expand */
       @media (max-width: 640px) {
         .row--compact .row__summary {
-          grid-template-columns: minmax(0, 1fr) auto;
+          grid-template-columns: minmax(0, 1fr);
           gap: 6px 12px;
         }
         .row--compact .row__summary > .row__source { display: none; }

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -402,25 +402,32 @@ function renderRow(level, layersForLevel, opts = {}) {
   const countDisplay = primary.rows != null
     ? `<span class="row__num">${fmtRows(primary.rows)}</span><span class="row__unit">${esc(meta.unit || '')}</span>`
     : '<span class="row__num">—</span>';
+  // row__actions lives OUTSIDE <summary> so the interactive <a> links inside
+  // don't violate HTML semantics (interactive descendants of an interactive
+  // element). row__head is the visible grid: details on the left, actions on
+  // the right. Click on title → toggles details. Click on actions → navigates
+  // / downloads without toggling. See task #65 background for full rationale.
   return `<section class="row row--curated row--compact${collapsed}" id="${esc(level)}" ${dataAttrs}>
-      <details class="row__details">
-        <summary class="row__summary">
-          <span class="row__title" title="${esc(meta.label)}">${esc(meta.label)}</span>
-          <span class="row__source" title="${esc(primary.source)}">${esc(primary.source)}</span>
-          <span class="row__count">${countDisplay}</span>
-          <span class="row__actions">
-            ${viewBtn}
-            ${dlInline}
-          </span>
-        </summary>
-        <div class="row__expand">
-          <p class="row__desc">${esc(meta.description)}</p>
-          ${sourceLine}
-          ${primary.licence ? `<p class="row__lic-line">Licence: <code>${esc(primary.licence)}</code></p>` : ''}
-          ${viewerHint}
-          ${altSection}
+      <div class="row__head">
+        <details class="row__details">
+          <summary class="row__summary">
+            <span class="row__title" title="${esc(meta.label)}">${esc(meta.label)}</span>
+            <span class="row__source" title="${esc(primary.source)}">${esc(primary.source)}</span>
+            <span class="row__count">${countDisplay}</span>
+          </summary>
+          <div class="row__expand">
+            <p class="row__desc">${esc(meta.description)}</p>
+            ${sourceLine}
+            ${primary.licence ? `<p class="row__lic-line">Licence: <code>${esc(primary.licence)}</code></p>` : ''}
+            ${viewerHint}
+            ${altSection}
+          </div>
+        </details>
+        <div class="row__actions">
+          ${viewBtn}
+          ${dlInline}
         </div>
-      </details>
+      </div>
     </section>`;
 }
 

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -111,15 +111,68 @@ export async function openLayer(layerId: string, opts: { titleEl: HTMLElement })
   map.addControl(new maplibregl.ScaleControl({ unit: 'metric' }));
   map.once('idle', () => loader.dismiss());
 
-  map.on('load', () => {
-    attachData(layer).catch((e) => {
+  map.on('load', async () => {
+    try {
+      await attachData(layer);
+      // Always-on India-correct state boundary overlay. Renders LGD state
+      // lines on top of whichever basemap + data layer is active so the
+      // canonical boundary is visible regardless of what the basemap shows.
+      // Skip when the user is already viewing lgd_states (would double-draw).
+      await addLgdOverlay(cat.layers ?? [], layer.id);
+    } catch (e) {
       console.error('attachData failed', e);
       const c = document.getElementById('map')!;
       const err = document.createElement('div');
       err.id = 'map-loading';
       err.textContent = `failed to load layer: ${(e as Error).message}`;
       c.appendChild(err);
-    });
+    }
+  });
+}
+
+// LGD state boundaries layered on top of any non-LGD layer. Useful for
+// cross-source comparison — when viewing soi_states / bhuvan_states /
+// gb_adm1 etc., the LGD lines on top show where the upstream and LGD
+// disagree at-a-glance. Drawn in a basemap-style warm taupe so it reads
+// as a boundary line, not a brand annotation.
+//
+// NOT a fix for basemap label problems. Underlying basemap tiles
+// (Carto / OSM) still label disputed regions per international conventions
+// (e.g. "AZAD KASHMIR", "GILGIT-BALTISTAN" inside Indian-claimed territory).
+// A real India-correct basemap (Bhuvan WMS, Mappls, or a forked Mapbox
+// style) is tracked in task #64.
+async function addLgdOverlay(catalogLayers: Layer[], activeLayerId: string): Promise<void> {
+  if (!map) return;
+  if (activeLayerId === 'lgd_states') return; // already the primary; don't double-draw
+  const lgd = catalogLayers.find((l) => l.id === 'lgd_states');
+  if (!lgd?.pmtiles?.url) return;
+
+  const archive = getArchive(lgd.pmtiles.url);
+  const metadata = await archive.getMetadata();
+  const vlayers = (metadata as { vector_layers?: Array<{ id: string }> }).vector_layers || [];
+  if (!vlayers.length) return;
+  const sourceLayer = vlayers[0].id;
+
+  if (map.getSource('lgd-overlay')) return; // idempotent
+  map.addSource('lgd-overlay', {
+    type: 'vector',
+    url: `pmtiles://${lgd.pmtiles.url}`,
+    attribution: 'India boundaries · LGD',
+  });
+  map.addLayer({
+    id: 'lgd-overlay-line',
+    type: 'line',
+    source: 'lgd-overlay',
+    'source-layer': sourceLayer,
+    paint: {
+      // Warm taupe-grey at low opacity — reads as a basemap admin boundary
+      // (printed-atlas convention), not a brand-coloured annotation. Sits
+      // visually next to the basemap's own state lines rather than competing
+      // with them or the active layer's polygons.
+      'line-color': '#8b7e6f',
+      'line-width': ['interpolate', ['linear'], ['zoom'], 4, 0.6, 10, 1.1],
+      'line-opacity': 0.55,
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

Two related changes triggered by the J&K basemap-labels Twitter feedback + the devtools a11y warning (~84 elements).

**Scope deliberately narrowed** based on visual testing: the LGD overlay was originally planned as part of the J&K basemap fix, but verification on /view/bm_eco_zones showed the labels users object to (e.g. "AZAD KASHMIR" inside Indian-claimed territory) live in the basemap's vector tiles, not in anything we can overlay. The overlay is still useful for cross-source boundary comparison, but it doesn't fix the labels problem. Real basemap replacement deferred to Task #64.

## Changes

### 1. A11y: row actions outside `<summary>` (closes #65)

- Wrap `<details>` + `row__actions` in a new `.row__head` grid container
- Summary now contains only static title/source/count text
- Actions (View map + downloads) sit as a sibling on the right via `1fr | auto` grid
- DevTools issues panel: **0/34** summaries contain interactive descendants (was 29/34)
- Behavioral wins: clicking View map / download links no longer toggles details (better UX)
- Visually unchanged for users

### 2. LGD overlay on non-LGD views (partial of #64)

- When viewing any non-`lgd_states` curated layer, render LGD state boundaries as a thin warm-taupe line on top
- Useful for cross-source comparison — boundary deltas between LGD and the upstream are visible at-a-glance
- Skipped when user is viewing `lgd_states` itself (avoids double-draw)
- Styled as a basemap-style admin line (color `#8b7e6f`, opacity 0.55, thin), not a brand annotation

## What this does NOT fix

The Twitter J&K feedback. The labels users object to come from the basemap's vector tiles (Carto / OSM), and a line overlay cannot remove labels in the layer below. **Task #64 has been reframed** from "Bhuvan basemap + overlay" to just "Replace basemap with India-correct labels". Candidates surveyed but require deeper investigation: Bhuvan WMS (verified reachable; needs MapLibre WMS adapter), Mappls (paid API key), forked Mapbox style (openstreetmap.in approach).

Default basemap deliberately left as Carto Light — switching to OSM was considered but its labels follow the same international convention.

## Tests + verification

- ✅ 359/359 vitest pass
- ✅ Build clean
- ✅ Local visual: catalog rows visually unchanged, View map / downloads click without toggling details, /view/soi_states shows LGD overlay on top
- ✅ A11y: scripted check confirms 0 summaries contain interactive descendants

## Test plan

- [ ] Merge → auto-deploy
- [ ] Hit https://bharatlas.com/ on prod, confirm catalog rows look + work the same
- [ ] /view/soi_states → confirm subtle taupe LGD state lines overlay the SOI polygons
- [ ] /view/lgd_states → confirm no overlay (skipped correctly)
- [ ] DevTools Issues panel on home: confirm count of "Interactive element inside <summary>" issues is 0

## Follow-ups already logged

- **Task #64 (reframed)** — Replace basemap with India-correct labels. The real fix for the J&K feedback. Candidates + scope documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)