### PR TITLE
fix(map): PNG export was capturing blank canvas

### DIFF
--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -413,16 +413,37 @@ function wireDownloadButton(layer: Layer): void {
       prompt('Copy this iframe snippet:', snippet);
     }
   });
-  exportBtn?.addEventListener('click', (e) => {
+  exportBtn?.addEventListener('click', async (e) => {
     e.stopPropagation();
     if (!map) return;
-    // preserveDrawingBuffer: true on init means the canvas is always
-    // readable; no need to triggerRepaint or wait for a 'render' event.
+    // preserveDrawingBuffer:true keeps the WebGL framebuffer readable
+    // BUT only reflects the last animation-frame paint. If the user
+    // opened the map and clicked Export before the next frame ran, OR if
+    // a basemap tile arrived between paints, toDataURL captures a stale
+    // / blank buffer. Force a repaint and wait for the next 'idle' event
+    // (fired when MapLibre has finished applying all pending updates) so
+    // the captured pixels are guaranteed to be the user's current view.
+    const fmt = exportBtn.querySelector<HTMLElement>('.map-popover__fmt');
+    const original = fmt?.textContent ?? '';
+    if (fmt) fmt.textContent = 'Rendering…';
     try {
+      await new Promise<void>((resolve) => {
+        const m = map!;
+        m.once('idle', () => resolve());
+        m.triggerRepaint();
+      });
       const url = map.getCanvas().toDataURL('image/png');
       triggerDownload(dataUrlToBlob(url), imageFilename(layer.id));
+      if (fmt) {
+        fmt.textContent = '✓ Saved';
+        setTimeout(() => { if (original) fmt.textContent = original; }, 1400);
+      }
     } catch (err) {
       console.error('PNG export failed', err);
+      if (fmt) {
+        fmt.textContent = 'Export failed';
+        setTimeout(() => { if (original) fmt.textContent = original; }, 1800);
+      }
     }
   });
   bindPopover(btn, popover);


### PR DESCRIPTION
## User report

> Also it says you can download as PNG but it doesn't work. It downloaded something but the image is blank.

## Root cause

WebGL canvas readback timing. The map was initialised with `preserveDrawingBuffer: true` so the canvas could be read via `toDataURL()`. That's necessary but not sufficient — the buffer only reflects the **last animation-frame paint**. If any of the following happened, the buffer was stale or empty when capture ran:

1. User clicked Export before the next frame ran
2. A basemap tile arrived between paints
3. The GeoJSON-source basemap was still loading (Bharatlas Minimal fetches `/world-land.geojson` + `/india-boundary.geojson` async on first map open — both are ~50–135 KB, can take a beat on slow connections)

`toDataURL()` returned a base64 PNG of an under-rendered framebuffer. The PNG was technically valid, just empty/transparent. The user got a downloaded file that opened to nothing.

## Fix

Force a `triggerRepaint()` and `await` the `'idle'` event before calling `toDataURL()`. The `'idle'` event fires once MapLibre has finished applying all pending updates (tiles loaded, animations done, sources settled), so the captured pixels are guaranteed to be the user's current view.

Also added user-visible feedback on the export button: `"Rendering…"` while the repaint+capture runs, then `"✓ Saved"` or `"Export failed"` on a 1.4–1.8s timer. Without this the user clicks and gets either a blank file (the original bug) or a download with no UI confirmation that anything happened.

## Tests + verification

- ✅ 372/372 vitest pass (no new tests added — the pure helpers are already covered in `image-export.test.ts`; the canvas readback path needs a real WebGL context which can't be unit-tested without heavy jsdom + headless-gl setup)
- ✅ Build clean
- ✅ Local: open `/view/lgd_states`, click Download menu → Export image (PNG). Confirms button text flips to "Rendering…" → "✓ Saved", and the downloaded PNG contains the actual map view, not a blank canvas. Tested on Bharatlas Minimal (the basemap most likely to surface the bug because of its async GeoJSON source loading).

## Test plan

- [ ] Merge → auto-deploy completes
- [ ] https://bharatlas.com/view/lgd_states → Download menu → Export image (PNG) → confirms downloaded image isn't blank
- [ ] Repeat on `/view/bharatviz_pincodes` with Carto Light basemap (different rendering path — raster basemap tiles)
- [ ] Repeat on `/view/lgd_villages` with Bharatlas Minimal (heaviest layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)