### PR TITLE
docs(about): lead with use-case framing for lay readers

### DIFF
--- a/web/about.template.html
+++ b/web/about.template.html
@@ -46,21 +46,33 @@
     <p class="eyebrow" style="font-size:13px;letter-spacing:.04em;color:var(--accent);margin:8px 0 4px">bharatlas</p>
     <h1 class="hero">India's open atlas.</h1>
     <p class="lede">
-      Browse, slice, and download India's official map layers. Submit your own by dropping
-      it onto the page. No signup, no API key, no SQL.
+      Show your data on a map of India, or browse, slice and download India's official
+      map layers. No signup, no API key, no SQL.
     </p>
     <p style="margin:0 0 var(--sp-6)">
       <a href="/" class="cta" style="display:inline-block;background:var(--fg);color:var(--bg);padding:10px 18px;border-radius:var(--radius-md);font-weight:500;text-decoration:none">Browse the catalog →</a>
     </p>
 
+    <h2>Is this for you?</h2>
+    <p>Three different tools, three different jobs:</p>
+    <ul>
+      <li><strong>Google Maps</strong> is for finding a coffee shop, getting directions, seeing what's around you.</li>
+      <li><strong>OpenStreetMap</strong> is for adding a road, a building or a shop to the world's map. That's where Google and bharatlas both source the base map.</li>
+      <li><strong>bharatlas</strong> is for taking data you already have, a list of districts you cover, the forests in your project area, the rivers in your watershed, the wards your NGO works in, and showing it on a map of India. Drop a GeoJSON, KML or Parquet file, see it rendered, share the link or download in another format.</li>
+    </ul>
+    <p>Concretely, this gets used by:</p>
+    <ul>
+      <li><strong>Journalists + researchers:</strong> pull a state's districts, villages or constituencies in ten seconds; download as GeoJSON or Parquet.</li>
+      <li><strong>Civic technologists:</strong> share city-scale layers (wards, bike lanes, polling booths) with attribution baked in.</li>
+      <li><strong>App developers:</strong> direct PMTiles URLs, no rate limits, no API key.</li>
+    </ul>
+    <p>If you came looking for places to visit, you want Google. If you want to fix the base map itself, you want OSM.</p>
+
     <h2>Why bharatlas exists</h2>
     <p>
-      Maps live everywhere online, but you can't tell what they actually show, who
-      maintains them, or whether to trust them. Pulling out just the slice you need
-      means booting QGIS or wading through Google Maps menus. Viewing is its own ordeal:
-      sign in, navigate the menus, import. The format question alone (KML? KMZ?
-      GeoJSON? Parquet?) feels gatekept. And if you've made a map yourself and want to
-      share it, you have to stand up your own website to host it.
+      Maps of India live everywhere online, but you can't tell what they show, who
+      maintains them, or whether to trust them. Even just viewing one is its own
+      ordeal. And if you've made a map yourself, there's nowhere to share it.
     </p>
     <p>
       <a href="https://www.sathyasankaran.com" target="_blank" rel="noopener">Sathya</a> kept hitting the same wall, and built bharatlas (read aloud as "bharat atlas"), a portmanteau of Bharat and atlas. It flattens all of that.
@@ -69,13 +81,6 @@
       others find it. Have a map worth sharing? Drag and drop it onto the page. Every
       layer carries its source, licence and freshness on the same card.
     </p>
-
-    <h2>Who it's for</h2>
-    <ul>
-      <li><strong>Journalists + researchers:</strong> pull a state's districts, villages or constituencies in ten seconds; download as GeoJSON or Parquet.</li>
-      <li><strong>Civic technologists:</strong> share city-scale layers (wards, bike lanes, polling booths) with attribution baked in.</li>
-      <li><strong>App developers:</strong> direct PMTiles URLs, no rate limits, no API key.</li>
-    </ul>
 
     <h2>What you can do today</h2>
     <ul>

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -768,7 +768,7 @@ const ABOUT_FAQ = [
 await renderPage('about', {
   title: 'About',
   description:
-    "Bharatlas is the wiki for India's maps. View any layer, slice out what you need, download in any format, or contribute your own. Open licences, no signup.",
+    "Show your data on a map of India: districts, forests, rivers, wards. Or browse, slice and download India's official map layers. No signup, no API key.",
   url: ORIGIN + '/about',
   image: ORIGIN + '/og-about.png',
   structuredData: {
@@ -776,7 +776,7 @@ await renderPage('about', {
     '@graph': [
       {
         '@type': 'AboutPage',
-        name: 'About geodata',
+        name: 'About bharatlas',
         url: ORIGIN + '/about',
       },
       {


### PR DESCRIPTION
## Summary

Yash ([@maddyhoonmain](https://twitter.com/maddyhoonmain)) on Twitter, after landing on bharatlas: *"As an average rahul, what am I supposed to do with it? Of course I can locate my city. But what next? There are no places or anything. How do I contribute to it?"*

The /about page jumped straight from hero → founder lament, with no answer to "what is this for / is this for me". This rewrite fronts the use-case answer using your own Twitter reply almost verbatim (Google for directions, OSM for base-map points, bharatlas for showing data you have on a map of India).

- **New "Is this for you?" section** right after the hero CTA: three-way Google / OSM / bharatlas contrast, plus the audience bullets merged in from the dropped standalone "Who it's for". One redirect sentence at the end ("If you came looking for places to visit, you want Google. If you want to fix the base map itself, you want OSM.").
- **Trim first "Why bharatlas exists" paragraph**: dropped the QGIS / format-question rant that immediately re-jargons the lay reader who just got the friendly contrast. Kept the three core complaints (opaque, hard to view, nowhere to share). Sathya's second paragraph follows intact.
- **Hero lede**: leads with the use-case verb ("Show your data on a map of India") before the catalog verbs.
- **/about meta description** rewritten with the same use-case anchor (150 chars, under the 158 SEO guard).
- **JSON-LD `AboutPage.name`**: stale `"About geodata"` → `"About bharatlas"`.

## Test plan

- [x] `npm test` — 372/372 green, including the SEO description-length guard.
- [x] Prerender emits `prerendered /about` cleanly.
- [ ] Eyeball /about on the preview deploy: new section reads naturally, trimmed "Why" still has flow into the founder paragraph.
- [ ] Re-fetch meta description in browser dev tools to confirm the new copy ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)