### PR TITLE
fix(map): tab title stuck because URL was mutated before title read

### DIFF
--- a/web/src/embed-snippet.ts
+++ b/web/src/embed-snippet.ts
@@ -26,6 +26,26 @@ export function titleAfterCloseMap(pathname: string, hash: string, homeTitle: st
   return null;
 }
 
+// Combined URL + title decision for closing the map overlay. The caller
+// MUST compute this from a pre-mutation snapshot of location.* and then
+// apply both fields, never re-read location between the two applications.
+// Earlier code called urlAfterCloseMap + replaceState first, then
+// titleAfterCloseMap, which read the post-mutation '/' pathname and
+// returned null — title silently stuck on the per-layer string injected
+// by the /view/<id> edge function. One snapshot, one decision, both
+// applications: the ordering bug becomes impossible.
+export function nextStateOnClose(
+  pathname: string,
+  hash: string,
+  search: string,
+  homeTitle: string,
+): { url: string; title: string | null } {
+  return {
+    url: urlAfterCloseMap(pathname, hash, search),
+    title: titleAfterCloseMap(pathname, hash, homeTitle),
+  };
+}
+
 // What the URL should become after the user closes the map overlay. Three
 // call-sites (close button, Escape key, hash-clear) all funnel through here
 // so the URL bar always matches what the user is looking at (the catalog).

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,6 +1,6 @@
 // Tiny entry: hash-based map routing + hover-prefetch of the map chunk.
 // Map code is in a separate chunk; only loaded when the user opens a map.
-import { isEmbedPath, isViewPath, urlAfterCloseMap, titleAfterCloseMap } from './embed-snippet';
+import { isEmbedPath, isViewPath, nextStateOnClose } from './embed-snippet';
 
 const overlay = document.getElementById('map-overlay')!;
 const mapTitle = document.getElementById('map-title')!;
@@ -51,14 +51,17 @@ async function hideMap() {
   overlay.setAttribute('aria-hidden', 'true');
   document.body.style.overflow = '';
   (await loadMap()).closeLayer();
-  const next = urlAfterCloseMap(location.pathname, location.hash, location.search);
+  // Snapshot location BEFORE any mutation. The earlier two-call version
+  // (urlAfterCloseMap + replaceState, then titleAfterCloseMap) read the
+  // post-mutation '/' pathname for the title decision and stuck the tab
+  // title on the per-layer string.
+  const next = nextStateOnClose(location.pathname, location.hash, location.search, HOME_TITLE);
   const current = location.pathname + location.hash + location.search;
-  if (next !== current) {
-    history.replaceState(null, '', next);
+  if (next.url !== current) {
+    history.replaceState(null, '', next.url);
   }
-  const nextTitle = titleAfterCloseMap(location.pathname, location.hash, HOME_TITLE);
-  if (nextTitle !== null && nextTitle !== document.title) {
-    document.title = nextTitle;
+  if (next.title !== null && next.title !== document.title) {
+    document.title = next.title;
   }
 }
 

--- a/web/tests/embed-snippet.test.ts
+++ b/web/tests/embed-snippet.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { embedIframeHtml, isEmbedPath, isViewPath, urlAfterCloseMap, titleAfterCloseMap } from '../src/embed-snippet';
+import { embedIframeHtml, isEmbedPath, isViewPath, urlAfterCloseMap, titleAfterCloseMap, nextStateOnClose } from '../src/embed-snippet';
 
 describe('embed-snippet — embedIframeHtml', () => {
   it('emits a sane iframe snippet with the encoded layer id', () => {
@@ -81,6 +81,44 @@ describe('titleAfterCloseMap', () => {
     expect(titleAfterCloseMap('/', '', HOME)).toBeNull();
     expect(titleAfterCloseMap('/about', '', HOME)).toBeNull();
     expect(titleAfterCloseMap('/preview', '', HOME)).toBeNull();
+  });
+});
+
+describe('nextStateOnClose', () => {
+  // Regression: shipped a bug where main.ts called urlAfterCloseMap +
+  // history.replaceState BEFORE titleAfterCloseMap. replaceState mutated
+  // location.pathname from /view/<id> → /, so titleAfterCloseMap then
+  // saw the post-mutation '/', returned null, and the tab title stuck on
+  // the per-layer string injected by the /view/<id> edge function.
+  //
+  // Combining URL + title into one pure decision computed BEFORE any
+  // mutation makes the ordering bug structurally impossible: the caller
+  // applies both fields from the snapshot, never re-reads location.
+  const HOME = "India's open atlas · view, verify, contribute · bharatlas";
+
+  it('returns both new URL and new title when closing a /view/<id> path', () => {
+    expect(nextStateOnClose('/view/lgd_states', '', '', HOME)).toEqual({
+      url: '/',
+      title: HOME,
+    });
+  });
+  it('returns both new URL and new title when closing a #view/<id> hash', () => {
+    expect(nextStateOnClose('/', '#view/lgd_states', '', HOME)).toEqual({
+      url: '/',
+      title: HOME,
+    });
+  });
+  it('preserves query string on path-close', () => {
+    expect(nextStateOnClose('/view/lgd_states', '', '?q=1', HOME)).toEqual({
+      url: '/?q=1',
+      title: HOME,
+    });
+  });
+  it('returns null title on non-view URLs so caller leaves title alone', () => {
+    expect(nextStateOnClose('/about', '', '', HOME)).toEqual({
+      url: '/about',
+      title: null,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

You reported the tab title still wasn't restoring after the map close. PR #29's pure functions were correct, but the wiring in `main.ts` had an ordering bug:

```ts
history.replaceState(null, '', urlAfterCloseMap(...))   // mutates location synchronously
document.title = titleAfterCloseMap(location.pathname,  // now reads '/'
                                    location.hash, ...) // → returns null
```

By the time `titleAfterCloseMap` runs, `location.pathname` is already `/`, so it sees a non-view URL and returns `null` (the deliberate "no change" sentinel). Title stuck on the per-layer string injected by `/view/<id>`'s edge HTMLRewriter.

The pure-function tests passed because they fed in the correct pre-close path directly — they couldn't catch a caller that re-read `location` after mutating it.

## Fix

Combine the URL + title decisions into one `nextStateOnClose(pathname, hash, search, homeTitle) → {url, title}` computed from a single pre-mutation snapshot. The caller applies both fields and never re-reads `location`. Ordering bug is now structurally impossible.

## Test plan

- [x] Added 4 regression tests pinning `nextStateOnClose` (`/view/<id>` close, `#view/` close, query-string preservation, non-view no-op).
- [x] Full suite: 376/376 green.
- [ ] Eyeball on preview: open a /view layer → click close (and Escape) → tab title flips back to "India's open atlas · view, verify, contribute · bharatlas".

🤖 Generated with [Claude Code](https://claude.com/claude-code)