### PR TITLE
fix(catalog): search relevance + visible row hiding + live pill counts

### DIFF
--- a/web/index.template.html
+++ b/web/index.template.html
@@ -129,11 +129,15 @@
         z-index: 9999;
       }
 
-      .row.hidden { display: none; }
       /* row--collapsed: hidden by default; section's .expanded class reveals.
-         Search/filter overrides with .row.hidden which always wins. */
+         Search/filter then hides non-matches with .row.hidden — bumped to
+         .category-section .row.hidden so it matches the expanded rule's
+         (0,3,0) specificity, and placed after it so source-order also
+         tips ties its way. Without this, collapsed rows below the cap
+         stay visible when search expands their section. */
       .row--collapsed { display: none; }
       .category-section.expanded .row--collapsed { display: block; }
+      .category-section .row.hidden { display: none; }
 
       .row {
         padding: 4px 0;

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -369,21 +369,25 @@ function renderRow(level, layersForLevel, opts = {}) {
       ? `<p class="row__source">${sourceText}${sourceText && freshnessSpan ? ' <span class="dot">·</span> ' : ''}${freshnessSpan}</p>`
       : '';
 
-  const haystackBase = [
-    meta.label,
-    meta.description,
-    primary.attribution?.primary?.name || '',
-    primary.notes || '',
-    primary.source || '',
-    primary.licence || '',
-    primary.category || '',
-    level,
-    formatTokens(primary),
-    // Source codes from alt layers — so a card surfaces when searching
-    // for any of its providers (e.g. "Bhuvan" on the States row).
-    layersForLevel.map((l) => l.source).join(' '),
-  ].join(' ');
-  const haystack = expandAliases(haystackBase).toLowerCase();
+  // Two haystacks so the client filter can do high-signal title matching
+  // first, then fall back to body. Without the split, "villages" surfaced
+  // Districts / Sub-districts / Blocks whose descriptions explain how they
+  // join to villages. See src/catalog-filter.ts for the matcher.
+  const primaryHaystack = expandAliases([meta.label, level].join(' ')).toLowerCase();
+  const bodyHaystack = expandAliases(
+    [
+      meta.description,
+      primary.attribution?.primary?.name || '',
+      primary.notes || '',
+      primary.source || '',
+      primary.licence || '',
+      primary.category || '',
+      formatTokens(primary),
+      // Source codes from alt layers — so a card surfaces when searching
+      // for any of its providers (e.g. "Bhuvan" on the States row).
+      layersForLevel.map((l) => l.source).join(' '),
+    ].join(' '),
+  ).toLowerCase();
 
   const dataAttrs = [
     `data-id="${esc(primary.id)}"`,
@@ -391,7 +395,8 @@ function renderRow(level, layersForLevel, opts = {}) {
     `data-category="${esc(primary.category || 'administrative')}"`,
     `data-provenance="${esc(primary.provenance || 'curated')}"`,
     `data-source="${esc(primary.source)}"`,
-    `data-search="${esc(haystack)}"`,
+    `data-search-primary="${esc(primaryHaystack)}"`,
+    `data-search-body="${esc(bodyHaystack)}"`,
   ].join(' ');
 
   // Compact list layout — one-line entry per layer. Description, source,
@@ -585,23 +590,20 @@ function renderCommunityCard(s, opts = {}) {
   const useful = s.up_count;
   const cat = s.category || 'other';
   const collapsed = opts.collapsed ? ' row--collapsed' : '';
-  // Build searchable haystack the same way curated cards do, so search
-  // works equally on community contributions.
-  const haystack = expandAliases([
-    s.name || '',
-    s.description || '',
-    s.attribution || '',
-    cat,
-    s.format || '',
-    'community',
-  ].join(' ')).toLowerCase();
+  // Two-tier haystack (matches curated cards). Title is the only field
+  // we trust as "this card is about X"; the rest is body.
+  const primaryHaystack = expandAliases(s.name || '').toLowerCase();
+  const bodyHaystack = expandAliases(
+    [s.description || '', s.attribution || '', cat, s.format || '', 'community'].join(' '),
+  ).toLowerCase();
   const dataAttrs = [
     `data-id="${esc(s.id)}"`,
     `data-useful="${useful}"`,
     `data-created="${esc(s.created_at)}"`,
     `data-category="${esc(cat)}"`,
     `data-provenance="community"`,
-    `data-search="${esc(haystack)}"`,
+    `data-search-primary="${esc(primaryHaystack)}"`,
+    `data-search-body="${esc(bodyHaystack)}"`,
   ].join(' ');
   const credit = s.is_original ? `original work by ${esc(s.attribution)}` : `source: ${esc(s.attribution)}`;
   return `<article class="comm-card${collapsed}" ${dataAttrs}>
@@ -636,10 +638,13 @@ for (const cat of Object.keys(communityByCategory)) {
 const totalLayers = Object.values(categoryCounts).reduce((a, b) => a + b, 0);
 const activeCats = Object.entries(catalog.categories || {})
   .filter(([id]) => categoryCounts[id]);
+// data-total stays as the raw category size; data-count is what the
+// client mutates as the user filters. The count span displays either
+// "N" (idle) or "filtered/N" (when a search/filter is active).
 const chips = [
-  `<button class="catalog-chip active" data-cat="all" data-count="${totalLayers}">All <span class="count">${totalLayers}</span></button>`,
+  `<button class="catalog-chip active" data-cat="all" data-count="${totalLayers}" data-total="${totalLayers}">All <span class="count">${totalLayers}</span></button>`,
   ...activeCats.map(
-    ([id, name]) => `<button class="catalog-chip" data-cat="${esc(id)}" data-count="${categoryCounts[id]}">${esc(name)} <span class="count">${categoryCounts[id]}</span></button>`,
+    ([id, name]) => `<button class="catalog-chip" data-cat="${esc(id)}" data-count="${categoryCounts[id]}" data-total="${categoryCounts[id]}">${esc(name)} <span class="count">${categoryCounts[id]}</span></button>`,
   ),
 ];
 // Only render chips when there's more than one category to switch between.

--- a/web/src/catalog-filter.ts
+++ b/web/src/catalog-filter.ts
@@ -1,0 +1,67 @@
+// Two-tier search filter for the catalog home page.
+//
+// Why two tiers: the single-haystack version surfaced any card whose
+// description mentioned a keyword. Typing "villages" returned Districts,
+// Sub-districts and Blocks because their descriptions explain how they
+// join to villages. Users searching for a term want layers ABOUT that
+// term, not layers that reference it.
+//
+// Each card carries:
+//   - primary: title + level + level-aliases. The high-signal "this card
+//     is about X" haystack. Title-word matches surface here.
+//   - body:    description + license + tags + provider names + formats.
+//     Lower-signal but still searchable for queries like "tehsil" (an
+//     alias-less synonym that lives in the description prose).
+//
+// Algorithm: every token must match the same tier. Prefer primary. If
+// no card has a primary match for the full token set, fall back to body
+// for every card. Mode is decided globally, not per-card, so that
+// "villages" doesn't quietly fall through to body matches on Districts
+// while Villages itself surfaces via primary.
+//
+// Active-category filtering is the caller's concern — this fn returns
+// matches regardless of pill, so the caller can also derive per-chip
+// counts (which the pill UI needs to show "filtered/total").
+
+export type CardLike = {
+  category: string;
+  primary: string;
+  body: string;
+};
+
+export type FilterResult = {
+  matches: boolean[];
+  countsByCategory: Map<string, number>;
+  totalMatches: number;
+};
+
+export function filterCards(cards: CardLike[], query: string): FilterResult {
+  const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+
+  if (!tokens.length) {
+    const counts = new Map<string, number>();
+    for (const c of cards) counts.set(c.category, (counts.get(c.category) || 0) + 1);
+    return {
+      matches: cards.map(() => true),
+      countsByCategory: counts,
+      totalMatches: cards.length,
+    };
+  }
+
+  const matchAll = (hay: string) => tokens.every((t) => hay.includes(t));
+
+  const primaryMatches = cards.map((c) => matchAll(c.primary));
+  const anyPrimary = primaryMatches.some(Boolean);
+
+  const matches = anyPrimary ? primaryMatches : cards.map((c) => matchAll(c.body));
+
+  const counts = new Map<string, number>();
+  let total = 0;
+  for (let i = 0; i < cards.length; i++) {
+    if (matches[i]) {
+      counts.set(cards[i].category, (counts.get(cards[i].category) || 0) + 1);
+      total++;
+    }
+  }
+  return { matches, countsByCategory: counts, totalMatches: total };
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,6 +1,7 @@
 // Tiny entry: hash-based map routing + hover-prefetch of the map chunk.
 // Map code is in a separate chunk; only loaded when the user opens a map.
 import { isEmbedPath, isViewPath, nextStateOnClose } from './embed-snippet';
+import { filterCards, type CardLike } from './catalog-filter';
 
 const overlay = document.getElementById('map-overlay')!;
 const mapTitle = document.getElementById('map-title')!;
@@ -95,8 +96,8 @@ for (const a of document.querySelectorAll<HTMLAnchorElement>('a.btn-primary[href
 
 // Catalog search + category filter (home page only).
 // Operates on category sections + pre-rendered cards via data-* attributes.
-// Pill click → show only that category section. Search → token-AND match
-// against the data-search haystack (already alias-expanded at build time).
+// Pill click → show only that category section. Search → two-tier matcher
+// (see catalog-filter.ts). Pill counts update live to filtered/total.
 const searchInput = document.getElementById('catalog-search') as HTMLInputElement | null;
 const grid = document.getElementById('catalog-grid');
 const emptyMsg = document.getElementById('catalog-empty');
@@ -104,35 +105,64 @@ const searchMeta = document.getElementById('search-meta');
 if (searchInput && grid) {
   const sections = Array.from(grid.querySelectorAll<HTMLElement>('.category-section'));
   const chips = Array.from(document.querySelectorAll<HTMLButtonElement>('.catalog-chip'));
+  // One-time collection: every card across every section, paired with its
+  // CardLike record for the pure filter and its DOM node for visibility
+  // toggling. Order is preserved so the matches[] mask lines up.
+  const cardEls = Array.from(grid.querySelectorAll<HTMLElement>('.row, .comm-card'));
+  const cardLikes: CardLike[] = cardEls.map((el) => ({
+    category: el.dataset.category || el.closest<HTMLElement>('.category-section')?.dataset.category || '',
+    primary: el.dataset.searchPrimary || '',
+    body: el.dataset.searchBody || '',
+  }));
   let activeCat = 'all';
   let query = '';
   const idleMeta = searchMeta?.textContent ?? '';
 
   const apply = () => {
-    let totalVisible = 0;
-    const tokens = query ? query.split(/\s+/).filter(Boolean) : [];
+    const result = filterCards(cardLikes, query);
     // When the user picks a category pill (or types a query), auto-expand
-    // every section so the row--collapsed cap doesn't hide matches. When
-    // both are off, leave sections in their default collapsed state.
+    // every section so the row--collapsed cap doesn't hide matches.
     const forceExpand = !!query || activeCat !== 'all';
-    for (const section of sections) {
-      const cat = section.dataset.category || '';
-      section.classList.toggle('expanded', forceExpand);
-      if (activeCat !== 'all' && cat !== activeCat) {
-        section.classList.add('hidden');
-        continue;
+
+    // Per-card visibility = matches query AND in active category.
+    // Track per-section + total visible for section hide + meta line.
+    const visiblePerSection = new Map<HTMLElement, number>();
+    let totalVisible = 0;
+    for (let i = 0; i < cardEls.length; i++) {
+      const el = cardEls[i];
+      const cat = cardLikes[i].category;
+      const inCat = activeCat === 'all' || cat === activeCat;
+      const visible = result.matches[i] && inCat;
+      el.classList.toggle('hidden', !visible);
+      if (visible) {
+        totalVisible++;
+        const sec = el.closest<HTMLElement>('.category-section');
+        if (sec) visiblePerSection.set(sec, (visiblePerSection.get(sec) || 0) + 1);
       }
-      const cards = Array.from(section.querySelectorAll<HTMLElement>('.row, .comm-card'));
-      let sectionVisible = 0;
-      for (const card of cards) {
-        const hay = card.dataset.search || '';
-        const qOk = !tokens.length || tokens.every((t) => hay.includes(t));
-        card.classList.toggle('hidden', !qOk);
-        if (qOk) sectionVisible++;
-      }
-      section.classList.toggle('hidden', sectionVisible === 0);
-      totalVisible += sectionVisible;
     }
+    for (const section of sections) {
+      section.classList.toggle('expanded', forceExpand);
+      const cat = section.dataset.category || '';
+      const sectionVisible = visiblePerSection.get(section) || 0;
+      const catFiltered = activeCat !== 'all' && cat !== activeCat;
+      section.classList.toggle('hidden', catFiltered || sectionVisible === 0);
+    }
+
+    // Pill counts: filtered/total when a query is active, bare total when idle.
+    // 'all' chip aggregates across categories; per-cat chips read their own.
+    const filtering = !!query;
+    for (const chip of chips) {
+      const cat = chip.dataset.cat || '';
+      const total = Number(chip.dataset.total || '0');
+      const filtered = cat === 'all'
+        ? result.totalMatches
+        : (result.countsByCategory.get(cat) || 0);
+      const span = chip.querySelector<HTMLElement>('.count');
+      if (span) span.textContent = filtering ? `${filtered}/${total}` : String(total);
+      // data-count drives the [data-count="0"] dim style + click guard.
+      chip.dataset.count = String(filtering ? filtered : total);
+    }
+
     if (emptyMsg) emptyMsg.hidden = totalVisible > 0;
     if (searchMeta) {
       if (!query && activeCat === 'all') {
@@ -142,7 +172,6 @@ if (searchInput && grid) {
         searchMeta.textContent = `${totalVisible} match${totalVisible === 1 ? '' : 'es'} for "${q}"`;
       } else {
         const chip = chips.find((c) => c.dataset.cat === activeCat);
-        // chip text node holds the label; the count span is separate.
         const label = (chip?.firstChild?.textContent || activeCat).trim().toLowerCase();
         searchMeta.textContent = `${totalVisible} ${label} layer${totalVisible === 1 ? '' : 's'}`;
       }

--- a/web/tests/catalog-filter.test.ts
+++ b/web/tests/catalog-filter.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { filterCards, type CardLike } from '../src/catalog-filter';
+
+// Fixture mirrors real prerender shape: each card carries a high-signal
+// "primary" haystack (title + level + aliases) and a low-signal "body"
+// (description + license + tags). The two-tier matcher uses primary
+// first; only when zero primary matches exist does it fall through to
+// body. This stops "villages" from surfacing Districts/Sub-districts/
+// Blocks whose descriptions merely mention villages.
+const cards: CardLike[] = [
+  { category: 'administrative', primary: 'states lgd state',          body: 'pan-india state and union territory boundaries' },
+  { category: 'administrative', primary: 'districts lgd district',    body: 'every district in india. joins to states, subdistricts, blocks and villages' },
+  { category: 'administrative', primary: 'sub-districts lgd subdistrict', body: 'tehsils, talukas and sub-divisions. the layer below a district. joins to blocks and villages' },
+  { category: 'administrative', primary: 'blocks lgd block',          body: 'community-development blocks. the administrative unit that groups villages' },
+  { category: 'administrative', primary: 'villages lgd village',      body: 'every revenue village in india. the finest admin polygon' },
+  { category: 'administrative', primary: 'greater bengaluru wards lgd ward', body: '369 final wards across 5 corporations, notified nov 2025' },
+  { category: 'people',         primary: 'pincodes bharatviz pincode', body: '63,864 pincode polygons. pin code postal code zip' },
+  { category: 'environment',    primary: 'wildlife sanctuaries gs wildlife', body: 'national park sanctuary reserve forest' },
+];
+
+describe('catalog-filter — filterCards', () => {
+  it('empty query: every card matches; counts mirror raw category totals', () => {
+    const r = filterCards(cards, '');
+    expect(r.matches.every((m) => m)).toBe(true);
+    expect(r.totalMatches).toBe(cards.length);
+    expect(r.countsByCategory.get('administrative')).toBe(6);
+    expect(r.countsByCategory.get('people')).toBe(1);
+    expect(r.countsByCategory.get('environment')).toBe(1);
+  });
+
+  it('whitespace-only query is treated as empty', () => {
+    const r = filterCards(cards, '   ');
+    expect(r.totalMatches).toBe(cards.length);
+  });
+
+  it('"villages": primary hit on Villages — Districts/Sub-districts/Blocks NOT surfaced even though body mentions villages', () => {
+    const r = filterCards(cards, 'villages');
+    const visibleIds = cards.flatMap((c, i) => r.matches[i] ? [c.primary] : []);
+    expect(visibleIds).toEqual(['villages lgd village']);
+    expect(r.totalMatches).toBe(1);
+    expect(r.countsByCategory.get('administrative')).toBe(1);
+  });
+
+  it('"tehsil": no primary match anywhere — falls back to body — Sub-districts surfaces', () => {
+    const r = filterCards(cards, 'tehsil');
+    const visible = cards.flatMap((c, i) => r.matches[i] ? [c.primary] : []);
+    expect(visible).toEqual(['sub-districts lgd subdistrict']);
+    expect(r.totalMatches).toBe(1);
+  });
+
+  it('"wards bengaluru": multi-token primary match — only Bengaluru wards', () => {
+    const r = filterCards(cards, 'wards bengaluru');
+    const visible = cards.flatMap((c, i) => r.matches[i] ? [c.primary] : []);
+    expect(visible).toEqual(['greater bengaluru wards lgd ward']);
+  });
+
+  it('multi-token: every token must hit the same tier (all-primary or all-body)', () => {
+    // "lgd village" — both tokens in primary of Villages only.
+    const r = filterCards(cards, 'lgd village');
+    const visible = cards.flatMap((c, i) => r.matches[i] ? [c.primary] : []);
+    expect(visible).toEqual(['villages lgd village']);
+  });
+
+  it('zero-match query: returns no visible cards, empty counts', () => {
+    const r = filterCards(cards, 'xyzzy_unmatchable');
+    expect(r.totalMatches).toBe(0);
+    expect(r.matches.every((m) => !m)).toBe(true);
+    expect(r.countsByCategory.size).toBe(0);
+  });
+
+  it('body-fallback case still aggregates counts by category', () => {
+    // "sanctuary" appears only in environment body.
+    const r = filterCards(cards, 'sanctuary');
+    expect(r.totalMatches).toBe(1);
+    expect(r.countsByCategory.get('environment')).toBe(1);
+    expect(r.countsByCategory.get('administrative')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Three catalog-search bugs spotted while testing on local, bundled into one PR per request.

### 1. Search couldn't hide rows below the "show all N" cap

CSS specificity was wrong. `.category-section.expanded .row--collapsed { display: block }` (0,3,0) beat `.row.hidden { display: none }` (0,2,0). When a search query auto-expanded a section, every collapsed row below the cap stayed visible regardless of the `.hidden` toggle. The comment on the `.row.hidden` rule even said "always wins" — an intent the CSS didn't honor.

Fix: bumped to `.category-section .row.hidden` (matches the expanded rule's specificity) and moved after it so source-order also tips ties its way.

### 2. "villages" surfaced Districts / Sub-districts / Blocks

Their descriptions explain how they join to villages, and the single-haystack matcher can't tell "card is ABOUT X" from "card mentions X" in a substring match. Split each card into two haystacks at prerender time:

- `data-search-primary`: title + level (+ aliases)
- `data-search-body`:    description, license, tags, formats, provider names, alt sources

The matcher (`src/catalog-filter.ts`) tries every token against primary across all cards. If any card hits, primary mode is used globally. Otherwise it falls back to body. Result:

- `villages` → primary hits Villages → only Villages shown (Districts/Sub-districts/Blocks no longer drag in)
- `tehsil` → no primary hit → body fallback → Sub-districts surfaces
- `wards bengaluru` → primary hits Bengaluru rows → only those
- `sanctuary` → body fallback → Wildlife sanctuaries

Mode is decided globally (any-primary-match → primary mode for all cards) so partial primary hits don't get diluted by body-only matches in other rows.

### 3. Pill counts stayed frozen at static prerender totals

The chips read "Administrative 23" even when only 1 card matched. `apply()` now recomputes per-category visible counts from `filterCards`'s `countsByCategory` and rewrites each chip's `.count` span to `filtered/total` while a query is active; reverts to bare total when cleared. `data-total` is stored once at prerender; `data-count` is mutated client-side (still drives `[data-count="0"]` dim style + click guard).

## Files

- `src/catalog-filter.ts` (new): pure matcher.
- `tests/catalog-filter.test.ts` (new): 8 cases — empty, single-primary, body-fallback, multi-token, zero-match, count aggregation.
- `src/main.ts`: `apply()` rewritten to read dual attributes and call the pure matcher; chip counts updated each call; visibility logic simplified (one card-collection pass instead of per-section nested loops).
- `scripts/prerender.mjs`: emits `data-search-primary` + `data-search-body` on each curated + community card. Adds `data-total` to each chip.
- `index.template.html`: 1-line CSS specificity fix.

## Test plan

- [x] 384/384 vitest green (8 new).
- [x] Verified live on local dev (`localhost:5173`): `villages`, `tehsil`, `wards bengaluru`, `sanctuary` all behave as expected; pills show `filtered/total` while active and revert on clear.
- [ ] Eyeball on preview after merge: confirm the same cases plus an edge — typing then clearing should restore original counts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)