### PR TITLE
chore(seo): tier-1 SEO/AEO audit fixes + a few tier-2 wins

### DIFF
--- a/web/functions/lib/render-view.ts
+++ b/web/functions/lib/render-view.ts
@@ -138,7 +138,7 @@ export function renderViewPage(opts: RenderOpts): string {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
-    <title>${esc(s.name)} · geodata</title>
+    <title>${esc(s.name)} · bharatlas</title>
     <meta name="description" content="${esc(description)}" />
     <link rel="canonical" href="${esc(canonical)}" />
     <meta property="og:type" content="website" />
@@ -148,6 +148,8 @@ export function renderViewPage(opts: RenderOpts): string {
     <meta property="og:image" content="${PUBLIC_ORIGIN}/og/c/${esc(s.id)}.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:site_name" content="bharatlas" />
+    <meta property="og:locale" content="en_IN" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="${esc(s.name)}" />
     <meta name="twitter:description" content="${esc(description)}" />

--- a/web/functions/lib/view-dataset.ts
+++ b/web/functions/lib/view-dataset.ts
@@ -26,6 +26,7 @@ export type ViewDataset = {
   canonical: string;
   ogImage: string;
   jsonLd: Record<string, unknown>;
+  breadcrumbJsonLd: Record<string, unknown>;
 };
 
 const META_DESC_MAX = 158;
@@ -51,10 +52,14 @@ export function buildViewDataset(
     levelMeta?.description ??
     `${title} — ${count ? count + ' ' + unit + ' · ' : ''}${layer.source}.`;
   const description = baseDescription.slice(0, META_DESC_MAX);
+  // Same padding template as prerender's homeSeo Dataset block: lifts
+  // terse base descriptions over the ≥50 floor and seeds format/provenance
+  // keywords for SERP rich snippets. Keep in sync with prerender.mjs's
+  // padDatasetDescription suffix.
   const ldDescription =
     baseDescription.length >= LD_DESC_MIN
       ? baseDescription
-      : `${baseDescription} Part of the bharatlas open atlas of India's geospatial data, sourced from ${layer.source}.`;
+      : `${baseDescription} Free to view, slice and download as Parquet, PMTiles, GeoJSON or KML. Open atlas of India by Urban Morph, sourced from ${layer.source}.`;
   const canonical = `${origin}/view/${layer.id}`;
   const ogImage = `${origin}/og/view/${layer.id}.png`;
 
@@ -73,6 +78,19 @@ export function buildViewDataset(
       license: layer.licence ? mapLicenceUrl(layer.licence) : undefined,
       creator: { '@type': 'Organization', name: layer.source },
       spatialCoverage: { '@type': 'Place', name: 'India' },
+    },
+    // Sibling JSON-LD block. Google honors multiple <script type="application/
+    // ld+json"> blocks on one page and de-dupes by @type. Surfaces breadcrumb
+    // trail under the URL in SERPs without coupling Dataset payload tests to
+    // a wrapping @graph.
+    breadcrumbJsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: `${origin}/` },
+        { '@type': 'ListItem', position: 2, name: 'Catalog', item: `${origin}/` },
+        { '@type': 'ListItem', position: 3, name: title, item: canonical },
+      ],
     },
   };
 }

--- a/web/functions/view/[id].ts
+++ b/web/functions/view/[id].ts
@@ -36,7 +36,7 @@ export const onRequestGet: PagesFunction<unknown, keyof Params> = async (ctx) =>
     return new Response(NOT_FOUND_HTML, { status: 404, headers: { 'content-type': 'text/html; charset=utf-8' } });
   }
 
-  const { title, description, canonical, ogImage, jsonLd } = buildViewDataset(
+  const { title, description, canonical, ogImage, jsonLd, breadcrumbJsonLd } = buildViewDataset(
     layer,
     catalog.level_meta?.[layer.level],
     origin,
@@ -60,6 +60,10 @@ export const onRequestGet: PagesFunction<unknown, keyof Params> = async (ctx) =>
     .on('script[type="application/ld+json"]', {
       element(el) {
         el.setInnerContent(JSON.stringify(jsonLd).replace(/</g, '\\u003c'), { html: true });
+        // Multiple JSON-LD blocks on a page are fine — Google ingests each
+        // independently. Append BreadcrumbList right after the Dataset.
+        const bc = JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c');
+        el.after(`\n    <script type="application/ld+json">${bc}</script>`, { html: true });
       },
     })
     .transform(new Response(indexResp.body, {

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -88,7 +88,11 @@ const DATASET_DESC_MIN = 80;
 function padDatasetDescription(desc, name, source) {
   const trimmed = (desc || '').trim();
   if (trimmed.length >= DATASET_DESC_MIN) return trimmed;
-  const suffix = ` Part of the bharatlas open atlas of India's geospatial data, sourced from ${source}.`;
+  // Padded suffix lifts terse level descriptions over Google's Dataset
+  // Search ≥50 floor with margin and adds format keywords + provenance
+  // for richer SERP snippets. Stays under the ~250-char rich-snippet cap
+  // when combined with the longest level description (~110 chars).
+  const suffix = ` Free to view, slice and download as Parquet, PMTiles, GeoJSON or KML. Open atlas of India by Urban Morph, sourced from ${source}.`;
   return (trimmed + suffix).trim();
 }
 
@@ -108,7 +112,8 @@ function seoHead(o) {
     `<meta property="og:description" content="${esc(o.description)}" />`,
     `<meta property="og:url" content="${esc(o.url)}" />`,
     `<meta property="og:image" content="${esc(image)}" />`,
-    `<meta property="og:site_name" content="geodata" />`,
+    `<meta property="og:site_name" content="bharatlas" />`,
+    `<meta property="og:locale" content="en_IN" />`,
     `<meta name="twitter:card" content="summary_large_image" />`,
     `<meta name="twitter:title" content="${esc(title)}" />`,
     `<meta name="twitter:description" content="${esc(o.description)}" />`,
@@ -482,18 +487,25 @@ const inlineCatalog = safeForHtmlScript(JSON.stringify(inlineCatalogObj));
 const homeSeo = seoHead({
   title: "India's open atlas · view, verify, contribute",
   description:
-    "India's open atlas — view, slice and download official boundary layers, or drop your own geo file and share it. Open licences, no signup, no tracking.",
+    "India's open atlas: view, slice and download official boundary layers, or drop your own geo file and share it. Open licences, no signup, no tracking.",
   url: ORIGIN + '/',
   structuredData: {
     '@context': 'https://schema.org',
     '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: ORIGIN + '/' },
+          { '@type': 'ListItem', position: 2, name: 'Catalog', item: ORIGIN + '/' },
+        ],
+      },
       {
         '@type': 'WebSite',
         name: 'bharatlas',
         alternateName: 'geodata',
         url: ORIGIN + '/',
         description:
-          "Open catalog, verifier and contribution flow for India's geo data — admin boundaries plus community layers.",
+          "Open catalog, verifier and contribution flow for India's geo data: admin boundaries plus community layers.",
         publisher: {
           '@type': 'Organization',
           name: 'Urban Morph',
@@ -783,6 +795,16 @@ await renderPage('about', {
         '@type': 'AboutPage',
         name: 'About bharatlas',
         url: ORIGIN + '/about',
+        author: { '@id': ORIGIN + '/about#sathya' },
+        publisher: { '@type': 'Organization', name: 'Urban Morph', url: 'https://urbanmorph.com' },
+      },
+      {
+        '@type': 'Person',
+        '@id': ORIGIN + '/about#sathya',
+        name: 'Sathya Sankaran',
+        url: 'https://www.sathyasankaran.com',
+        sameAs: ['https://linkedin.com/in/sathyasankaran'],
+        worksFor: { '@type': 'Organization', name: 'Urban Morph', url: 'https://urbanmorph.com' },
       },
       {
         '@type': 'FAQPage',

--- a/web/tests/render-view.test.ts
+++ b/web/tests/render-view.test.ts
@@ -29,7 +29,7 @@ const ORIGIN = 'https://example.com';
 describe('renderViewPage', () => {
   it('puts the submission name in the title', () => {
     const html = renderViewPage({ submission: row(), origin: ORIGIN, ratingsCount: 0, alreadyRated: false });
-    expect(html).toMatch(/<title>Mumbai bike lanes · geodata<\/title>/);
+    expect(html).toMatch(/<title>Mumbai bike lanes · bharatlas<\/title>/);
   });
 
   it('emits a canonical URL pinned to bharatlas.com (not the request origin)', () => {

--- a/web/tests/view-dataset.test.ts
+++ b/web/tests/view-dataset.test.ts
@@ -39,6 +39,19 @@ describe('buildViewDataset', () => {
     expect(v.jsonLd.description).toBe(v.ldDescription);
   });
 
+  it('emits a BreadcrumbList JSON-LD with Home → Catalog → <layer>', () => {
+    const v = buildViewDataset(layer, { label: 'Villages' }, ORIGIN);
+    expect(v.breadcrumbJsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://bharatlas.com/' },
+        { '@type': 'ListItem', position: 2, name: 'Catalog', item: 'https://bharatlas.com/' },
+        { '@type': 'ListItem', position: 3, name: 'Villages', item: 'https://bharatlas.com/view/lgd_villages' },
+      ],
+    });
+  });
+
   it('emits a Dataset JSON-LD with the required shape', () => {
     const v = buildViewDataset(layer, { label: 'Villages' }, ORIGIN);
     expect(v.jsonLd).toMatchObject({


### PR DESCRIPTION
## Summary

Bundled the four tier-1 items from the earlier SEO/AEO audit plus three tier-2 wins that were cheap to land alongside. No functional change to any user flow — all edits are metadata + JSON-LD + copy.

## Tier-1

| # | What | Where |
|---|---|---|
| 1 | Home meta description: em-dash → colon | `scripts/prerender.mjs` |
| 2 | `og:site_name` "geodata" → "bharatlas" | `scripts/prerender.mjs` (seoHead) + `functions/lib/render-view.ts` |
| 3 | `/view/<id>` + `/c/<id>` Dataset descriptions padded with format keywords + provenance ("Free to view, slice and download as Parquet, PMTiles, GeoJSON or KML. Open atlas of India by Urban Morph, sourced from …") | `functions/lib/view-dataset.ts` + `scripts/prerender.mjs::padDatasetDescription` |
| 4 | `BreadcrumbList` JSON-LD on home (Home → Catalog) and `/view/<id>` (Home → Catalog → Layer) | `scripts/prerender.mjs` (@graph) + `functions/lib/view-dataset.ts` (sibling `breadcrumbJsonLd`) + `functions/view/[id].ts` (injected via `el.after()`) |

For #4: emitted as a second `<script type=application/ld+json>` block (Google honors multiple). Kept the Dataset payload flat so existing `view-dataset.test.ts` assertions aren't coupled to a wrapping `@graph`.

## Tier-2

| # | What | Where |
|---|---|---|
| 5 | `og:locale="en_IN"` | seoHead + render-view |
| 6 | `Person` JSON-LD on /about (Sathya, sameAs LinkedIn, worksFor Urban Morph) + Organization publisher | `scripts/prerender.mjs` (about @graph) |

## Cleanup caught in the same scan

- Stale `<title>X · geodata</title>` on `/c/<id>` → `· bharatlas`.
- Em-dash in WebSite JSON-LD description (mirror of the home description we just fixed) → colon.

## Tests

- Updated `tests/render-view.test.ts` title assertion to `· bharatlas`.
- New `tests/view-dataset.test.ts` case pinning the BreadcrumbList shape (Home → Catalog → Layer with absolute origin URLs).
- 385/385 vitest green.

## Skipped from tier-2

`twitter:site` / `twitter:creator` — needs the project's Twitter handle (`@bharatlas`? `@urbanmorph`? `@sathyasankaran`?). Trivial follow-up once you pick.

## Test plan

- [x] Full vitest suite green.
- [x] Verified rendered output on local dev: home + about emit new metadata + JSON-LD correctly.
- [ ] After merge: curl `https://bharatlas.com/view/lgd_states` and confirm two JSON-LD blocks (Dataset + BreadcrumbList), `og:site_name="bharatlas"`, `og:locale="en_IN"`, title ends `· bharatlas`.
- [ ] Test in Google Rich Results: paste `/view/lgd_states` and `/about` URLs into https://search.google.com/test/rich-results — expect Dataset + BreadcrumbList valid on view, FAQPage + Person valid on about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)