### PR TITLE
feat(downloads): whole-layer GeoJSON / KML / Shapefile from catalog card

### DIFF
--- a/scripts/bake_whole_layer.py
+++ b/scripts/bake_whole_layer.py
@@ -1,0 +1,343 @@
+"""
+Bake whole-layer downloads (geojson, kml, shapefile.zip) for every curated
+layer whose source parquet is at or under a size cap.
+
+Motivation: the catalog card only exposed parquet + pmtiles. QGIS users
+wanted whole-layer GeoJSON/KML/Shapefile without entering the viewer and
+slicing by state. (Twitter @Kyangs_Thang: "Is there a way to download the
+whole layer as GeoJSON/Shapefile/KML without filtering? That would help
+since many people work on QGIS.")
+
+Generic size rule: bake if source parquet ≤ WHOLE_LAYER_MAX_PARQUET_MB
+(default 100). Anything bigger is gated to the viewer's per-state slices
+since the whole-layer geojson/kml would be unwieldy (lgd_villages parquet
+is 475 MB; its geojson would be ~1.4 GB, KML ~5 GB). Override via env
+var to force-bake the giants if you really want to.
+
+Idempotent: skips any output that already exists at non-zero size.
+Reuses bake_extracts.py's writers (GDAL GeoJSON, pure-Python KML).
+Shapefile uses ogr2ogr (GDAL/OGR command line); the output directory
+is zipped into <basename>.shp.zip to ship a single file per layer.
+
+Outputs:
+  data/baked/<R2-path>/<basename>.geojson
+  data/baked/<R2-path>/<basename>.kml
+  data/baked/<R2-path>/<basename>.shp.zip
+
+Run after fetch.sh; before build_catalog.py + upload_r2.sh.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+import duckdb
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+
+# Reuse the layer manifest + helpers from build_catalog so this script
+# stays in sync. build_catalog's module body only defines constants and
+# the LAYERS list at import time; its main entrypoint is gated below.
+import build_catalog as bc  # noqa: E402
+from bake_extracts import (  # noqa: E402
+    make_con,
+    gdal_geojson_available,
+    write_geojson_manual,
+    write_kml_from_geojson,
+)
+
+OUT = ROOT / "data" / "baked"
+SRC = ROOT / "sources" / "india-geodata"
+
+# Reference layers: assets not in the LAYERS tuple but worth exposing as
+# downloadables. (id, source-file path, R2 prefix, basename, label, level,
+# rows, licence, attribution-source-key, notes)
+#
+# India national boundary lives at web/public/india-boundary.geojson because
+# the Bharatlas Minimal basemap loads it client-side. Surfacing it as a
+# downloadable catalog layer means QGIS users get the same India-correct
+# outline we render.
+REFERENCE_INDIA_BOUNDARY_SRC = ROOT / "web" / "public" / "india-boundary.geojson"
+REFERENCE_INDIA_BOUNDARY_R2_PREFIX = "reference"
+REFERENCE_INDIA_BOUNDARY_BASENAME = "india_boundary"
+
+MAX_PARQUET_MB = float(os.environ.get("WHOLE_LAYER_MAX_PARQUET_MB", "100"))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def file_size(p: Path) -> int:
+    try:
+        return p.stat().st_size
+    except FileNotFoundError:
+        return 0
+
+
+def should_skip(out: Path) -> bool:
+    return file_size(out) > 0
+
+
+def have_ogr2ogr() -> bool:
+    return shutil.which("ogr2ogr") is not None
+
+
+def out_paths(r2_prefix: str, basename: str) -> dict[str, Path]:
+    """Where each output lives on disk. R2 upload mirrors this layout."""
+    base = OUT / r2_prefix
+    return {
+        "geojson": base / f"{basename}.geojson",
+        "kml": base / f"{basename}.kml",
+        "shapefile": base / f"{basename}.shp.zip",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Format writers (reuse + extend bake_extracts)
+# ---------------------------------------------------------------------------
+
+def write_geojson_whole(
+    con: duckdb.DuckDBPyConnection, parquet: Path, out: Path, gdal_ok: bool
+) -> None:
+    """Whole-layer geojson — no WHERE filter. Mirrors bake_extracts's
+    GDAL path, with the manual fallback for non-spatial builds."""
+    out.parent.mkdir(parents=True, exist_ok=True)
+    if gdal_ok:
+        con.execute(
+            f"COPY (SELECT * EXCLUDE geometry, geometry FROM '{parquet.as_posix()}') "
+            f"TO '{out.as_posix()}' "
+            f"WITH (FORMAT GDAL, DRIVER 'GeoJSON', LAYER_CREATION_OPTIONS 'RFC7946=YES')"
+        )
+    else:
+        # Reuse the manual writer's logic but without the state filter.
+        # write_geojson_manual takes (con, src, col, code, out) — we don't
+        # have a column filter here, so inline a no-WHERE variant.
+        import json
+        schema = con.execute(
+            f"DESCRIBE SELECT * FROM '{parquet.as_posix()}' LIMIT 0"
+        ).fetchall()
+        prop_cols = [r[0] for r in schema if r[0] != "geometry"]
+        select_props = ", ".join(f'"{c}"' for c in prop_cols)
+        rows = con.execute(
+            f"SELECT ST_AsGeoJSON(geometry) AS _geom, {select_props} "
+            f"FROM '{parquet.as_posix()}'"
+        ).fetchall()
+        with out.open("w", encoding="utf-8") as f:
+            f.write('{"type":"FeatureCollection","features":[')
+            first = True
+            for r in rows:
+                geom_str = r[0]
+                if geom_str is None:
+                    continue
+                props = {prop_cols[i]: r[i + 1] for i in range(len(prop_cols))}
+                props = {k: v for k, v in props.items() if v is not None}
+                feat = {"type": "Feature", "geometry": json.loads(geom_str), "properties": props}
+                if not first:
+                    f.write(",")
+                f.write(json.dumps(feat, ensure_ascii=False, default=str))
+                first = False
+            f.write("]}")
+
+
+def write_shapefile_zip(geojson_path: Path, basename: str, out: Path) -> None:
+    """Convert geojson → ESRI Shapefile (5-file set) → single .zip via
+    ogr2ogr. Shapefiles can't ship as one file (they're .shp/.shx/.dbf/
+    .prj/.cpg), so we zip the directory and present that as the download."""
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="shp_") as tmp:
+        tmp_dir = Path(tmp)
+        # ogr2ogr writes into a directory; the shapefile basename matches
+        # the geojson basename for tool-friendly filenames after unzip.
+        subprocess.run(
+            [
+                "ogr2ogr",
+                "-f", "ESRI Shapefile",
+                str(tmp_dir / f"{basename}.shp"),
+                str(geojson_path),
+                # Shapefile column names cap at 10 chars; -lco preserves
+                # what we can without truncation surprises.
+                "-lco", "ENCODING=UTF-8",
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zf:
+            for f in sorted(tmp_dir.iterdir()):
+                zf.write(f, arcname=f.name)
+
+
+# ---------------------------------------------------------------------------
+# Layer iteration
+# ---------------------------------------------------------------------------
+
+def curated_layers() -> list[tuple[str, str, str, int]]:
+    """(layer_id, source_parquet_path, r2_prefix, basename_without_ext)
+    for every curated layer that has a local parquet on disk. Reads from
+    build_catalog.LAYERS so the manifest stays single-sourced."""
+    out = []
+    for id_, level, source, parquet, pmtiles, rows, licence, notes in bc.LAYERS:
+        parquet_path = SRC / parquet
+        if not parquet_path.exists():
+            continue
+        path = bc.LEVELS[level]["path"]
+        basename = parquet_path.stem
+        out.append((id_, str(parquet_path), path, basename))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def bake_one(
+    con: duckdb.DuckDBPyConnection,
+    label: str,
+    parquet_path: Path,
+    r2_prefix: str,
+    basename: str,
+    gdal_ok: bool,
+    ogr2ogr_ok: bool,
+) -> tuple[int, int, list[str]]:
+    """Bake geojson + kml + shapefile.zip for one source parquet.
+    Returns (written, skipped, errors)."""
+    paths = out_paths(r2_prefix, basename)
+    written = 0
+    skipped = 0
+    errors: list[str] = []
+
+    # geojson
+    if should_skip(paths["geojson"]):
+        print(f"skip  {label} fmt=geojson size={file_size(paths['geojson'])}")
+        skipped += 1
+    else:
+        try:
+            write_geojson_whole(con, parquet_path, paths["geojson"], gdal_ok)
+            written += 1
+            print(f"wrote {label} fmt=geojson size={file_size(paths['geojson'])}")
+        except Exception as e:
+            errors.append(f"{label} geojson: {e}")
+            print(f"FAIL  {label} fmt=geojson err={e}")
+            return written, skipped, errors
+
+    # kml (depends on geojson)
+    if should_skip(paths["kml"]):
+        print(f"skip  {label} fmt=kml size={file_size(paths['kml'])}")
+        skipped += 1
+    else:
+        try:
+            write_kml_from_geojson(paths["geojson"], basename, paths["kml"])
+            written += 1
+            print(f"wrote {label} fmt=kml size={file_size(paths['kml'])}")
+        except Exception as e:
+            errors.append(f"{label} kml: {e}")
+            print(f"FAIL  {label} fmt=kml err={e}")
+
+    # shapefile (depends on geojson + ogr2ogr)
+    if should_skip(paths["shapefile"]):
+        print(f"skip  {label} fmt=shp.zip size={file_size(paths['shapefile'])}")
+        skipped += 1
+    elif not ogr2ogr_ok:
+        print(f"skip  {label} fmt=shp.zip (ogr2ogr not found)")
+        skipped += 1
+    else:
+        try:
+            write_shapefile_zip(paths["geojson"], basename, paths["shapefile"])
+            written += 1
+            print(f"wrote {label} fmt=shp.zip size={file_size(paths['shapefile'])}")
+        except subprocess.CalledProcessError as e:
+            stderr = (e.stderr or b"").decode("utf-8", "replace").strip()
+            errors.append(f"{label} shapefile: {stderr}")
+            print(f"FAIL  {label} fmt=shp.zip err={stderr}")
+        except Exception as e:
+            errors.append(f"{label} shapefile: {e}")
+            print(f"FAIL  {label} fmt=shp.zip err={e}")
+
+    return written, skipped, errors
+
+
+def main() -> int:
+    OUT.mkdir(parents=True, exist_ok=True)
+    con = make_con()
+    gdal_ok = gdal_geojson_available(con)
+    ogr2ogr_ok = have_ogr2ogr()
+    print(f"GDAL GeoJSON writer: {gdal_ok}")
+    print(f"ogr2ogr available:   {ogr2ogr_ok}")
+    print(f"Size cap:            {MAX_PARQUET_MB} MB")
+    print()
+
+    total_w, total_s, errors = 0, 0, []
+    started = time.time()
+
+    # Curated parquet-backed layers
+    cap_bytes = int(MAX_PARQUET_MB * 1024 * 1024)
+    for layer_id, parquet_str, r2_prefix, basename in curated_layers():
+        parquet_path = Path(parquet_str)
+        size = file_size(parquet_path)
+        if size > cap_bytes:
+            mb = size / (1024 * 1024)
+            print(
+                f"GATE  {layer_id} parquet={mb:.0f}MB > {MAX_PARQUET_MB}MB cap — skipping bake "
+                f"(use the viewer's per-state slices, or set WHOLE_LAYER_MAX_PARQUET_MB)"
+            )
+            continue
+        w, s, e = bake_one(con, layer_id, parquet_path, r2_prefix, basename, gdal_ok, ogr2ogr_ok)
+        total_w += w
+        total_s += s
+        errors.extend(e)
+
+    # Reference: India national boundary (osm-in). Source is geojson, not
+    # parquet — we run KML + shapefile only. (geojson is the source; copy
+    # it into the baked tree so upload_r2.sh ships it from the same place.)
+    if REFERENCE_INDIA_BOUNDARY_SRC.exists():
+        paths = out_paths(REFERENCE_INDIA_BOUNDARY_R2_PREFIX, REFERENCE_INDIA_BOUNDARY_BASENAME)
+        if not should_skip(paths["geojson"]):
+            paths["geojson"].parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(REFERENCE_INDIA_BOUNDARY_SRC, paths["geojson"])
+            print(f"wrote india_boundary fmt=geojson size={file_size(paths['geojson'])}")
+            total_w += 1
+        else:
+            print(f"skip  india_boundary fmt=geojson size={file_size(paths['geojson'])}")
+            total_s += 1
+
+        if not should_skip(paths["kml"]):
+            try:
+                write_kml_from_geojson(paths["geojson"], "India boundary", paths["kml"])
+                total_w += 1
+                print(f"wrote india_boundary fmt=kml size={file_size(paths['kml'])}")
+            except Exception as e:
+                errors.append(f"india_boundary kml: {e}")
+
+        if not should_skip(paths["shapefile"]) and ogr2ogr_ok:
+            try:
+                write_shapefile_zip(paths["geojson"], REFERENCE_INDIA_BOUNDARY_BASENAME, paths["shapefile"])
+                total_w += 1
+                print(f"wrote india_boundary fmt=shp.zip size={file_size(paths['shapefile'])}")
+            except Exception as e:
+                errors.append(f"india_boundary shapefile: {e}")
+        elif not ogr2ogr_ok:
+            print("skip  india_boundary fmt=shp.zip (ogr2ogr not found)")
+            total_s += 1
+    else:
+        print(f"WARN  india boundary source not found at {REFERENCE_INDIA_BOUNDARY_SRC}")
+
+    elapsed = time.time() - started
+    print()
+    print(f"=== bake summary: wrote={total_w} skipped={total_s} errors={len(errors)} elapsed={elapsed:.1f}s ===")
+    for e in errors:
+        print(f"  - {e}")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -11,6 +11,11 @@ ROOT = Path(__file__).resolve().parent.parent
 SRC = ROOT / 'sources' / 'india-geodata'
 GB = ROOT / 'sources' / 'geoboundaries'
 DATA = ROOT / 'data' / 'boundaries'
+# Whole-layer baked downloads (geojson / kml / shp.zip). Produced by
+# scripts/bake_whole_layer.py. URLs are wired into each layer only when
+# the corresponding file actually exists on disk — so this script is a
+# safe no-op until the bake has run.
+BAKED = ROOT / 'data' / 'baked'
 
 # Public base URL of the R2 bucket
 R2 = 'https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev'
@@ -35,6 +40,10 @@ LEVELS = {
     # Environment
     'wildlife':               {'order': 30, 'plural': 'wildlife sanctuaries + national parks',  'path': 'environment/forests',   'category': 'environment'},
     'eco_zone':               {'order': 31, 'plural': 'eco-sensitive zones',                    'path': 'environment/forests',   'category': 'environment'},
+
+    # Reference layers — base assets used across the platform AND useful
+    # standalone (national outline, etc.).
+    'country':                {'order': 0,  'plural': 'national boundary',                      'path': 'reference',             'category': 'administrative'},
 }
 
 # Licences per upstream (yashveeeeeeer/india-geodata): states/districts are
@@ -56,6 +65,7 @@ ATTR = {
     'Bharatmaps':    {'name': 'Bharatmaps (NIC)',            'url': 'https://bharatmaps.gov.in/'},
     'OpenCity':      {'name': 'OpenCity / Oorvani Foundation', 'url': 'https://data.opencity.in/'},
     'bharatviz':     {'name': 'bharatviz (Saket Choudhary)',  'url': 'https://bharatviz.org/'},
+    'osm-in':        {'name': 'osm-in (community)',           'url': 'https://github.com/osm-in/mapbox-gl-styles'},
 }
 PUBLISHER = {
     'name': 'yashveeeeeeer/india-geodata',
@@ -191,6 +201,30 @@ def size_of(p: Path) -> int | None:
         return p.stat().st_size
     except FileNotFoundError:
         return None
+
+
+# Whole-layer baked download formats. Catalog only advertises a format
+# when the file actually exists in BAKED — keeps the catalog honest if
+# bake_whole_layer.py hasn't run yet or gated a layer above the size cap.
+_BAKED_FORMATS = (
+    ('geojson',   '.geojson',  'application/geo+json'),
+    ('kml',       '.kml',      'application/vnd.google-earth.kml+xml'),
+    ('shapefile', '.shp.zip',  'application/zip'),
+)
+
+
+def baked_downloads(r2_prefix: str, basename: str) -> dict:
+    """Return {fmt: {url, bytes}} for each baked file that exists. Empty
+    dict if none have been baked yet."""
+    out = {}
+    for fmt, ext, _mime in _BAKED_FORMATS:
+        p = BAKED / r2_prefix / f'{basename}{ext}'
+        if p.exists() and p.stat().st_size > 0:
+            out[fmt] = {
+                'url': f'{R2}/{r2_prefix}/{basename}{ext}',
+                'bytes': p.stat().st_size,
+            }
+    return out
 
 
 def mtime_of(p: Path) -> str | None:
@@ -376,6 +410,7 @@ def build():
         fetched_at = mtime_of(parquet_path) or (mtime_of(pmtiles_path) if pmtiles_path else None)
         level_meta = LEVELS[level]
         path = level_meta['path']
+        baked = baked_downloads(path, parquet_path.stem)
         layers.append({
             'id': id_,
             'level': level,
@@ -391,6 +426,12 @@ def build():
                 'upstream_url': f'{UPSTREAM_BASE}/{path}/{pmtiles}',
                 'bytes': size_of(pmtiles_path) or EXTERNAL_BYTES.get(id_, {}).get('pmtiles'),
             } if pmtiles_path else None,
+            # Whole-layer baked downloads. Each is None when not baked
+            # (size-cap gated, or bake hasn't run). Frontend only renders
+            # buttons for non-null formats.
+            'geojson': baked.get('geojson'),
+            'kml': baked.get('kml'),
+            'shapefile': baked.get('shapefile'),
             'licence': licence,
             'attribution': {
                 'primary': ATTR[source],
@@ -400,6 +441,34 @@ def build():
             'provenance': 'curated',
             'fetched_at': fetched_at,
             'notes': notes,
+        })
+
+    # India national boundary (osm-in). The same India-correct line that
+    # the Bharatlas Minimal basemap renders, exposed as a downloadable
+    # layer so QGIS users get a clean outline.
+    ib_path = 'reference'
+    ib_basename = 'india_boundary'
+    ib_baked = baked_downloads(ib_path, ib_basename)
+    if ib_baked.get('geojson'):
+        layers.append({
+            'id': 'india_boundary',
+            'level': 'country',
+            'source': 'osm-in',
+            'rows': None,
+            'parquet': None,
+            'pmtiles': None,
+            'geojson': ib_baked.get('geojson'),
+            'kml': ib_baked.get('kml'),
+            'shapefile': ib_baked.get('shapefile'),
+            'licence': 'ODbL-1.0',
+            'attribution': {
+                'primary': ATTR['osm-in'],
+                'publisher': None,
+            },
+            'category': 'administrative',
+            'provenance': 'curated',
+            'fetched_at': mtime_of(BAKED / ib_path / f'{ib_basename}.geojson'),
+            'notes': "Hand-curated by the osm-in community from OpenStreetMap data. India's claim — disputed-by-IN lines filtered out.",
         })
 
     for id_, level, name, rows, notes in GEOBOUNDARIES:

--- a/scripts/upload_r2.sh
+++ b/scripts/upload_r2.sh
@@ -60,6 +60,7 @@ content_type_for() {
     *.kmz)     echo 'application/vnd.google-earth.kmz' ;;
     *.pmtiles) echo 'application/vnd.pmtiles' ;;
     *.json)    echo 'application/json' ;;
+    *.zip)     echo 'application/zip' ;;
     *)         echo 'application/octet-stream' ;;
   esac
 }
@@ -134,6 +135,17 @@ for f in "$ROOT"/data/extracts/*/*/*.*; do
   rel="${f#$ROOT/data/}"
   put "$f" "$rel"
 done
+
+echo "→ uploading whole-layer baked downloads (geojson/kml/shp.zip from bake_whole_layer.py)"
+if [ -d "$ROOT/data/baked" ]; then
+  # Mirrors the directory tree: data/baked/<r2-prefix>/<file> → <r2-prefix>/<file>
+  find "$ROOT/data/baked" -type f | while read -r f; do
+    rel="${f#$ROOT/data/baked/}"
+    put "$f" "$rel"
+  done
+else
+  echo "  (no data/baked tree yet — run scripts/bake_whole_layer.py first)"
+fi
 
 echo "✓ done"
 echo "public base: https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev"

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -259,12 +259,20 @@ function expandAliases(text) {
 }
 
 // Available download formats as a space-joined haystack token list.
+// Reflects what the catalog card actually advertises so search ("kml",
+// "shapefile") surfaces cards that ship those formats directly.
 function formatTokens(layer) {
   const t = [];
   if (layer.parquet?.url) t.push('parquet');
   if (layer.pmtiles?.url) t.push('pmtiles', 'vector tiles');
   if (layer.geojson?.url) t.push('geojson');
-  if (layer.parquet?.url) t.push('kml', 'geojson'); // derived in-browser
+  if (layer.kml?.url) t.push('kml', 'google earth');
+  if (layer.shapefile?.url) t.push('shapefile', 'shp', 'qgis');
+  // Viewer offers in-browser conversion for any parquet layer too —
+  // surface 'kml'/'geojson' even when not baked, so search-by-format
+  // doesn't hide layers whose downloads route through the viewer.
+  if (layer.parquet?.url && !layer.kml?.url) t.push('kml');
+  if (layer.parquet?.url && !layer.geojson?.url) t.push('geojson');
   return t.join(' ');
 }
 
@@ -292,6 +300,8 @@ function downloadLinks(layer) {
   if (layer.parquet?.url) items.push({ fmt: 'parquet', url: dlUrl(layer.parquet.url, 'parquet'), size: layer.parquet.bytes, count: countFor(layer, 'parquet') });
   if (layer.pmtiles?.url) items.push({ fmt: 'pmtiles', url: dlUrl(layer.pmtiles.url, 'pmtiles'), size: layer.pmtiles.bytes, count: countFor(layer, 'pmtiles') });
   if (layer.geojson?.url) items.push({ fmt: 'geojson', url: dlUrl(layer.geojson.url, 'geojson'), size: layer.geojson.bytes, count: countFor(layer, 'geojson') });
+  if (layer.kml?.url) items.push({ fmt: 'kml', url: dlUrl(layer.kml.url, 'kml'), size: layer.kml.bytes, count: countFor(layer, 'kml') });
+  if (layer.shapefile?.url) items.push({ fmt: 'shp', url: dlUrl(layer.shapefile.url, 'shapefile'), size: layer.shapefile.bytes, count: countFor(layer, 'shapefile') });
   return items;
 }
 
@@ -347,8 +357,14 @@ function renderRow(level, layersForLevel, opts = {}) {
 
   const lic = primary.licence ? `<span class="lic"><code>${esc(primary.licence)}</code></span>` : '';
 
+  // Viewer-hint message adapts to what's already on the card:
+  // - If geojson/kml/shp are baked whole-layer, the hint is just about state slicing.
+  // - Otherwise it still advertises the in-viewer instant-convert path.
+  const hasBakedDerivative = !!(primary.geojson?.url || primary.kml?.url || primary.shapefile?.url);
   const viewerHint = filterable
-    ? `<p class="row__viewer-hint">↳ Inside the viewer: slice by state · instant download as <strong>GeoJSON</strong> (QGIS, web) or <strong>KML</strong> (Google Earth & Maps)</p>`
+    ? (hasBakedDerivative
+      ? `<p class="row__viewer-hint">↳ Inside the viewer: slice by state for a single-state subset (full-layer downloads above are India-wide)</p>`
+      : `<p class="row__viewer-hint">↳ Inside the viewer: slice by state · instant download as <strong>GeoJSON</strong> (QGIS, web) or <strong>KML</strong> (Google Earth & Maps)</p>`)
     : '';
 
   const freshnessSpan = primary.fetched_at

--- a/web/src/format-hints.ts
+++ b/web/src/format-hints.ts
@@ -1,7 +1,7 @@
 // Per-format download metadata for the map-view download menu.
 // Pure: no DOM, no DuckDB. Consumed by map.ts to build the popover.
 
-export type DownloadFormat = 'parquet' | 'pmtiles' | 'geojson' | 'kml';
+export type DownloadFormat = 'parquet' | 'pmtiles' | 'geojson' | 'kml' | 'shapefile';
 
 export type DownloadEntry = {
   fmt: DownloadFormat;
@@ -15,13 +15,16 @@ type LayerLike = {
   parquet?: { url: string; bytes: number | null } | null;
   pmtiles?: { url: string; bytes: number | null } | null;
   geojson?: { url: string; bytes: number | null } | null;
+  kml?: { url: string; bytes: number | null } | null;
+  shapefile?: { url: string; bytes: number | null } | null;
 };
 
 const HINTS: Record<DownloadFormat, { label: string; hint: string }> = {
-  parquet: { label: 'Parquet', hint: 'analytics · DuckDB, pandas, R' },
-  pmtiles: { label: 'PMTiles', hint: 'vector tiles · MapLibre, web maps' },
-  geojson: { label: 'GeoJSON', hint: 'web maps, QGIS, Earth' },
-  kml:     { label: 'KML',     hint: 'Google Earth, Google My Maps' },
+  parquet:   { label: 'Parquet',   hint: 'analytics · DuckDB, pandas, R' },
+  pmtiles:   { label: 'PMTiles',   hint: 'vector tiles · MapLibre, web maps' },
+  geojson:   { label: 'GeoJSON',   hint: 'web maps, QGIS, Earth' },
+  kml:       { label: 'KML',       hint: 'Google Earth, Google My Maps' },
+  shapefile: { label: 'Shapefile', hint: 'QGIS, ArcGIS · .shp + .dbf + .shx zipped' },
 };
 
 export function formatLabel(fmt: DownloadFormat): string {
@@ -42,6 +45,12 @@ export function availableDownloads(layer: LayerLike): DownloadEntry[] {
   }
   if (layer.geojson?.url) {
     out.push({ fmt: 'geojson', ...HINTS.geojson, url: layer.geojson.url, bytes: layer.geojson.bytes });
+  }
+  if (layer.kml?.url) {
+    out.push({ fmt: 'kml', ...HINTS.kml, url: layer.kml.url, bytes: layer.kml.bytes });
+  }
+  if (layer.shapefile?.url) {
+    out.push({ fmt: 'shapefile', ...HINTS.shapefile, url: layer.shapefile.url, bytes: layer.shapefile.bytes });
   }
   return out;
 }

--- a/web/tests/format-hints.test.ts
+++ b/web/tests/format-hints.test.ts
@@ -16,6 +16,29 @@ describe('format-hints — availableDownloads', () => {
     expect(out.map((d) => d.fmt)).toEqual(['parquet', 'pmtiles', 'geojson']);
   });
 
+  it('surfaces baked kml + shapefile when present, in stable order after geojson', () => {
+    const layer = {
+      shapefile: { url: 's.shp.zip', bytes: 4 },
+      kml: { url: 'k.kml', bytes: 5 },
+      parquet: { url: 'p.parquet', bytes: 1 },
+      pmtiles: { url: 't.pmtiles', bytes: 2 },
+      geojson: { url: 'g.json', bytes: 3 },
+    };
+    const out = availableDownloads(layer);
+    expect(out.map((d) => d.fmt)).toEqual(['parquet', 'pmtiles', 'geojson', 'kml', 'shapefile']);
+  });
+
+  it('omits kml + shapefile when not baked (null) — bake-not-yet-run is graceful', () => {
+    const layer = {
+      parquet: { url: 'p', bytes: 1 },
+      pmtiles: { url: 't', bytes: 2 },
+      kml: null,
+      shapefile: null,
+    };
+    const out = availableDownloads(layer);
+    expect(out.map((d) => d.fmt)).toEqual(['parquet', 'pmtiles']);
+  });
+
   it('preserves bytes (including null) and url verbatim', () => {
     const out = availableDownloads({
       parquet: { url: 'https://r2/x.parquet', bytes: null },
@@ -54,6 +77,7 @@ describe('format-hints — labels + hints', () => {
     expect(formatLabel('pmtiles')).toBe('PMTiles');
     expect(formatLabel('geojson')).toBe('GeoJSON');
     expect(formatLabel('kml')).toBe('KML');
+    expect(formatLabel('shapefile')).toBe('Shapefile');
   });
 
   it('hints mention the canonical use case', () => {
@@ -61,6 +85,7 @@ describe('format-hints — labels + hints', () => {
     expect(formatHint('pmtiles')).toMatch(/vector tiles|MapLibre/);
     expect(formatHint('geojson')).toMatch(/QGIS|web|Earth/);
     expect(formatHint('kml')).toMatch(/Google Earth/);
+    expect(formatHint('shapefile')).toMatch(/QGIS|ArcGIS|\.shp/);
   });
 });
 


### PR DESCRIPTION
## Summary

Twitter [@Kyangs_Thang](https://twitter.com/Kyangs_Thang): *"Is there a way to download the whole layer as GeoJSON/Shapefile/KML without filtering? That would help since many people work on QGIS."*

Today only parquet + pmtiles are surfaced whole-layer on the catalog. GeoJSON / KML / Shapefile force a viewer trip + in-browser conversion. This PR ships the pipeline + frontend wiring so they land as direct R2 download buttons on the card.

## Pipeline (build-side, runs locally)

- **`scripts/bake_whole_layer.py`** (NEW): bake `<basename>.geojson`, `<basename>.kml`, `<basename>.shp.zip` for every curated layer whose source parquet is **≤ 100 MB** (override via `WHOLE_LAYER_MAX_PARQUET_MB` env). Reuses `bake_extracts.py`'s GDAL GeoJSON writer + pure-Python KML writer; shapefile uses `ogr2ogr` + zip. Idempotent (skips outputs already present at non-zero size).
- **Generic size rule** (no hardcoded skiplist) gates `lgd_villages` (475 MB parquet → ~1.5 GB geojson) + `lgd_panchayats`. Those stay viewer-only; per-state slices still work as before.
- **`scripts/build_catalog.py`**: new `baked_downloads(prefix, basename)` helper reads `data/baked/` and emits `{url, bytes}` per format only when the file exists. Catalog stays honest — a layer doesn't advertise a format that isn't on R2.
- **`scripts/upload_r2.sh`**: pushes the new `data/baked/` tree mirrored to R2 keys. `.zip` → `application/zip` Content-Type.

## India national boundary (osm-in)

The same India-correct outline the Bharatlas Minimal basemap renders, now downloadable for QGIS:
- New `LEVELS` entry `country` under the administrative category (`order: 0` so it sits above States).
- New `ATTR` entry `osm-in` crediting the upstream community.
- `build_catalog` appends an `india_boundary` layer entry **only when the baked geojson exists**. Bake script copies `web/public/india-boundary.geojson` into `data/baked/reference/india_boundary.geojson` and derives kml + shp from it.

## Frontend

- **`web/scripts/prerender.mjs`**:
  - `downloadLinks()` adds kml + shp items alongside parquet/pmtiles/geojson.
  - `formatTokens()` extends the search haystack with `kml`, `google earth`, `shapefile`, `shp`, `qgis` for layers that ship those.
  - Viewer-hint line adapts when a layer has baked derivatives — promotes state-slicing for sub-state subsets instead of full-layer conversion (which is now a direct download).
- **`web/src/format-hints.ts`** (used by the in-viewer download menu too):
  - `DownloadFormat` extended to include `'shapefile'`.
  - `LayerLike` extended with `kml` + `shapefile` slots.
  - `availableDownloads` surfaces them in stable order: parquet → pmtiles → geojson → kml → shapefile.

## Tests

- `web/tests/format-hints.test.ts`: 2 new cases pinning kml + shapefile in the surfaced order; null-graceful fallback when bake hasn't run. Label + hint assertions extended.
- 387/387 vitest passing (was 385).
- `build_catalog.py` smoke-tested locally: `country` level + `osm-in` attribution import cleanly; `baked_downloads('admin/states', 'LGD_States')` returns `{}` when no files exist (correct no-op until bake runs).

## Runbook (post-merge, run locally)

```bash
brew install gdal                           # ogr2ogr for shapefile
python scripts/bake_whole_layer.py          # ~5-10 min, ~3-5 GB output under data/baked/
python scripts/build_catalog.py             # regenerates catalog.json with new URLs
./scripts/upload_r2.sh                      # pushes data/baked/* to R2 (idempotent)
git add catalog.json web/public/catalog.json && git commit -m "data: bake whole-layer downloads"
git push                                    # CI auto-deploys main → cards show new buttons
```

The PR is **safely mergeable before the bake**: prerender only renders kml/shp buttons when URLs exist in catalog.json, and `bake_whole_layer.py` doesn't run as part of CI. Until the bake + catalog regen ships, the live site is unchanged.

## What's NOT in scope

- The bake itself (yours to run — multi-GB compute + R2 creds).
- Shapefile column-name truncation handling (ogr2ogr's default 10-char cap may shorten property names in the .dbf — fine for the current curated layers; revisit if a column name collision matters).
- Per-state shapefile bakes (current per-state extracts ship geojson + kml + parquet only; could extend later if asked).

## Test plan

- [x] vitest 387/387 green
- [x] `python -c "import build_catalog"` clean import; new helper returns `{}` for missing files
- [x] Local prerender output still emits 32 `row__downloads` lines + all expected JSON-LD types
- [ ] After bake + upload + catalog regen + deploy: visit `bharatlas.com/`, confirm `States` card shows `parquet · pmtiles · geojson · kml · shp` (or whichever subset baked), and the new "India national boundary" card appears at the top of Administrative
- [ ] `bharatlas.com/view/lgd_states` download popover shows the new formats too

🤖 Generated with [Claude Code](https://claude.com/claude-code)