### PR TITLE
perf: edge-cache HTML with stale-while-revalidate

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -39,8 +39,27 @@
 /world-land.geojson
   Cache-Control: public, max-age=604800, stale-while-revalidate=86400
 
-# HTML — always revalidate to pick up new asset hashes.
+# HTML — edge-cache with stale-while-revalidate. Earlier we had
+# max-age=0, must-revalidate which forced every HTML hit to origin
+# (TTFB ~1 s; cf-cache-status: DYNAMIC). Vite's hashed asset filenames
+# are immutable, so a stale HTML pointing at an old hash still works —
+# the must-revalidate was over-cautious.
+#
+# Policy: browser caches 1 min, edge caches 5 min, edge serves stale for
+# up to a day while async-revalidating. Hourly cron + per-submission
+# rebuild trigger means catalog changes propagate within ~5 min worst
+# case (cron rebuild + cache expiry). Repeat visits get ~30 ms TTFB
+# instead of ~1 s.
 /
-  Cache-Control: public, max-age=0, must-revalidate
+  Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=86400
 /index.html
-  Cache-Control: public, max-age=0, must-revalidate
+  Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=86400
+/about
+  Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=86400
+/preview
+  Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=86400
+# Legal pages — edits are rare and can wait a day to propagate.
+/privacy
+  Cache-Control: public, max-age=300, s-maxage=86400, stale-while-revalidate=86400
+/terms
+  Cache-Control: public, max-age=300, s-maxage=86400, stale-while-revalidate=86400


### PR DESCRIPTION
## Summary

Every HTML hit on the site was bypassing the CF edge cache and going to the Pages origin. Today's prod measurements:

| Page | TTFB | cf-cache-status |
|---|---|---|
| / | 1.07 s | DYNAMIC |
| /view/wris_subbasin | 0.87 s | DYNAMIC |
| /view/india_boundary | 0.33 s | DYNAMIC |
| /about | 0.39 s | DYNAMIC |

Cause: `web/public/_headers` set `Cache-Control: public, max-age=0, must-revalidate` for `/` and `/index.html`. SPA fallback inherits that for /about + /preview too.

The original "always revalidate to pick up new asset hashes" intent was overcautious — Vite hashed asset filenames are immutable, so a stale HTML pointing at an old hash still resolves to a working file. CF Pages also auto-purges on deploy.

## New policy

| Route | browser | edge | SWR |
|---|---|---|---|
| `/` + `/index.html` + `/about` + `/preview` | 60 s | 5 min | 1 day |
| `/privacy` + `/terms` | 5 min | 1 day | 1 day |

Edge serves stale instantly while async-refreshing. Repeat visits should drop from ~1 s TTFB to ~30 ms.

## Staleness audit (what gets stale)

- **Catalog cards on home** (titles, row counts, download URLs, JSON-LD): worst case ~5 min after a deploy or hourly cron rebuild.
- **About/preview/legal copy**: edits propagate within 5 min – 1 day.
- **Vote counts**: NOT affected — fetched live via `/api/community/scores` (separate 30 s cache).
- **DuckDB-loaded layer data**: NOT affected — fetched from R2 at runtime when the user opens a map.
- **R2 file bytes**: NOT affected — separate cache layer.

Worst case for "community submission accept → visible card": currently ~5 min (cron rebuild); becomes ~5–10 min (cron + edge expiry). For a manual deploy: ~5 min after merge instead of immediate.

## Test plan

- [x] vitest 387/387 green (test only asserts HSTS).
- [ ] After deploy: `curl -sI https://bharatlas.com/` should show `cache-control: public, max-age=60, s-maxage=300, stale-while-revalidate=86400`; first hit `cf-cache-status: EXPIRED`, second hit within 5 min `cf-cache-status: HIT`.
- [ ] Repeat-visit TTFB drop measurable via curl timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)