### PR TITLE
a11y: wrap /about in <main> landmark (Lighthouse 98→100)

### DIFF
--- a/web/about.template.html
+++ b/web/about.template.html
@@ -43,6 +43,7 @@
   <body>
     <!-- NAV -->
 
+    <main>
     <p class="eyebrow" style="font-size:13px;letter-spacing:.04em;color:var(--accent);margin:8px 0 4px">bharatlas</p>
     <h1 class="hero">India's open atlas.</h1>
     <p class="lede">
@@ -146,6 +147,7 @@
       }
     </style>
 
+    </main>
     <!-- FOOTER -->
     <div class="attr-block" style="margin-top:var(--sp-5);color:var(--muted);font-size:var(--fs-sm);line-height:1.6">
       <strong>Data sources:</strong> <!-- ATTR_LINKS -->

--- a/web/preview.template.html
+++ b/web/preview.template.html
@@ -271,6 +271,7 @@
   <body>
     <!-- NAV -->
 
+    <main>
     <h1 class="page-title">View, verify, or publish a geo file</h1>
     <p class="page-sub">Drop a file to render it on a map and check it. Optionally publish to the open catalog. Nothing is uploaded unless you click <strong>Publish</strong>.</p>
 
@@ -410,6 +411,7 @@
       Files are parsed in your browser. Submit ships them to R2 + records metadata in D1.<br />
       Rate limit: 5 submissions per hour, 20 per day, per IP.
     </div>
+    </main>
 
     <!-- FOOTER -->
 


### PR DESCRIPTION
Final Lighthouse pass surfaced one missing audit on /about: **"Document does not have a main landmark"**. Other pages already had it; only /about opened directly into the page content. Wrap from eyebrow to last section in `<main>` — semantic fix, no visual change. Bumps /about a11y 98 → 100.

Final scorecard (all on prod):

| Page | Perf | A11y | BP | SEO |
|---|---|---|---|---|
| / desktop | 100 | 100 | 100 | 100 |
| /about desktop | 100 | **98 → 100** | 100 | 100 |
| /view/wris_subbasin desktop | 83 | 100 | 100 | 100 |
| / mobile | 98 | 100 | 100 | 100 |

387/387 vitest green.