### PR TITLE
docs: cite pdgi.org in shared footer

### DIFF
--- a/web/scripts/shared-chrome.mjs
+++ b/web/scripts/shared-chrome.mjs
@@ -93,6 +93,7 @@ export const FOOTER = `<footer class="site-footer">
         <a href="/terms">terms</a> ·
         <a href="https://github.com/urbanmorph/geodata">code</a> ·
         <a href="https://github.com/urbanmorph/geodata/blob/main/REPORT.md">data report</a> ·
-        made by <a href="https://urbanmorph.com">urbanmorph</a>
+        made by <a href="https://urbanmorph.com">urbanmorph</a> ·
+        a digital commons · <a href="https://pdgi.org">pdgi.org</a>
       </p>
     </footer>`;


### PR DESCRIPTION
Adds `a digital commons · pdgi.org` to the shared footer on every page. Not 'a PDGI initiative' (bharatlas isn't run by PDGI); it aligns with the framework's principles. 387/387 green.