### PR TITLE
refactor: full codebase cleanup — 24 audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ git clone git@github.com:urbanmorph/geodata.git
 cd geodata/web
 npm install
 npm run dev    # http://localhost:5173
-npm test       # 380+ vitest tests
+npm test       # 387+ vitest tests
 ```
 
 For the full submission flow (D1 + R2 + Turnstile + Pages Functions), see [docs/full-dev.md](./docs/full-dev.md) (TODO) or read `wrangler.toml` + `.dev.vars.example`.

--- a/scripts/bake_extracts.py
+++ b/scripts/bake_extracts.py
@@ -176,7 +176,6 @@ def write_geojson_manual(con: duckdb.DuckDBPyConnection, src: Path, col: str,
         f"FROM '{src.as_posix()}' WHERE {col} = {code}"
     ).fetchall()
 
-    out.parent.mkdir(parents=True, exist_ok=True)
     with out.open("w", encoding="utf-8") as f:
         f.write('{"type":"FeatureCollection","features":[')
         first = True
@@ -201,6 +200,7 @@ def write_geojson_manual(con: duckdb.DuckDBPyConnection, src: Path, col: str,
 
 # ---------------------------------------------------------------------------
 # GeoJSON -> KML (mirrors web/src/db.ts geoJSONFeaturesToKML)
+# Keep in sync with web/src/db.ts KML section
 # ---------------------------------------------------------------------------
 
 NAME_KEYS = (

--- a/scripts/bake_whole_layer.py
+++ b/scripts/bake_whole_layer.py
@@ -144,7 +144,6 @@ def write_geojson_whole(
         # Reuse the manual writer's logic but without the state filter.
         # write_geojson_manual takes (con, src, col, code, out) — we don't
         # have a column filter here, so inline a no-WHERE variant.
-        import json
         schema = con.execute(
             f"DESCRIBE SELECT * FROM '{parquet.as_posix()}' LIMIT 0"
         ).fetchall()
@@ -263,7 +262,7 @@ def curated_layers() -> list[tuple[str, str, str, int]]:
     # etc.) are appended dynamically in build_catalog and appear in
     # catalog.json but not in the hardcoded bc.LAYERS tuple at import time.
     catalog_path = ROOT / "web" / "public" / "catalog.json"
-    r2_base = "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/"
+    r2_base = bc.R2 + "/"
     if catalog_path.exists():
         try:
             catalog = json.loads(catalog_path.read_text())

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -56,17 +56,17 @@ LEVELS = {
     'reservoir':              {'order': 47, 'plural': 'reservoirs',                               'path': 'water/waterbodies',           'category': 'environment'},
 
     # Transport
-    'airport':                {'order': 47, 'plural': 'airports',                                 'path': 'transport/airports',          'category': 'transport'},
-    'national_highway':       {'order': 48, 'plural': 'national highways',                       'path': 'infra/national-highways',     'category': 'transport'},
+    'airport':                {'order': 48, 'plural': 'airports',                                 'path': 'transport/airports',          'category': 'transport'},
+    'national_highway':       {'order': 49, 'plural': 'national highways',                       'path': 'infra/national-highways',     'category': 'transport'},
 
     # Health
-    'health_facility':        {'order': 49, 'plural': 'health facilities',                       'path': 'healthcare/facilities',       'category': 'health-edu'},
+    'health_facility':        {'order': 50, 'plural': 'health facilities',                       'path': 'healthcare/facilities',       'category': 'health-edu'},
 
     # Weather
-    'weather_station':        {'order': 50, 'plural': 'weather stations',                        'path': 'environment/weather',         'category': 'environment'},
+    'weather_station':        {'order': 51, 'plural': 'weather stations',                        'path': 'environment/weather',         'category': 'environment'},
 
     # Judiciary — dissolved from LGD states per jurisdiction mappings.
-    'high_court':             {'order': 51, 'plural': 'high court jurisdictions',                'path': 'judiciary',             'category': 'people'},
+    'high_court':             {'order': 52, 'plural': 'high court jurisdictions',                'path': 'judiciary',             'category': 'people'},
     'ngt_zone':               {'order': 41, 'plural': 'NGT zonal benches',                      'path': 'judiciary',             'category': 'people'},
     'nclt_bench':             {'order': 42, 'plural': 'NCLT benches',                            'path': 'judiciary',             'category': 'people'},
 
@@ -244,6 +244,10 @@ if EXTERNAL_MANIFEST.exists():
             'pmtiles': x.get('pmtiles_bytes'),
         }
 
+# Reverse map: directory uses plural ("districts"), catalog uses singular ("district").
+# Computed once after LEVELS is finalised (including external-ingested additions).
+PLURAL_TO_SINGULAR = {v['plural']: k for k, v in LEVELS.items()}
+
 # geoBoundaries cross-check layers (geojson only)
 GEOBOUNDARIES = [
     ('gb_adm1', 'state',       'IND_ADM1.geojson', 36,   'name-only'),
@@ -397,14 +401,12 @@ def build_extracts():
     EXT = ROOT / 'data' / 'extracts'
     if not EXT.exists():
         return {}
-    # Reverse map: directory uses plural ("districts"), catalog uses singular ("district").
-    plural_to_singular = {v['plural']: k for k, v in LEVELS.items()}
     out: dict = {}
     for level_dir in sorted(EXT.iterdir()):
         if not level_dir.is_dir():
             continue
         plural = level_dir.name
-        singular = plural_to_singular.get(plural, plural)
+        singular = PLURAL_TO_SINGULAR.get(plural, plural)
         out[singular] = {}
         for state_dir in sorted(level_dir.iterdir()):
             if not state_dir.is_dir():
@@ -597,14 +599,13 @@ def build():
     for level_dir in sorted(DATA.glob('*')):
         if not level_dir.is_dir():
             continue
-        plural_to_singular = {v['plural']: k for k, v in LEVELS.items()}
         for gj in sorted(level_dir.glob('*.geojson')):
             stem = gj.stem
             parts = stem.split('_')
             state = parts[-1]
             state_extracts.append({
                 'state': state,
-                'level': plural_to_singular.get(level_dir.name, level_dir.name),
+                'level': PLURAL_TO_SINGULAR.get(level_dir.name, level_dir.name),
                 'url': f'{R2}/boundaries/{level_dir.name}/{gj.name}',
                 'bytes': size_of(gj),
             })

--- a/scripts/upload_baked.py
+++ b/scripts/upload_baked.py
@@ -24,6 +24,10 @@ from pathlib import Path
 import boto3
 from botocore.config import Config
 
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+from build_catalog import R2 as _R2_BASE  # noqa: E402
+
 BUCKET = "geodata-data"
 ROOT = Path(__file__).resolve().parent.parent
 BAKED = ROOT / "data" / "baked"
@@ -73,7 +77,7 @@ def collect_local_files() -> list[tuple[Path, str, int]]:
     if catalog_path.exists():
         catalog = json.loads(catalog_path.read_text())
         sources_dir = ROOT / "sources" / "india-geodata"
-        r2_prefix = "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/"
+        r2_prefix = _R2_BASE + "/"
         seen: set[str] = set()
         for layer in catalog.get("layers", []) or []:
             for fmt in ("parquet", "pmtiles", "geojson"):

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -19,6 +19,7 @@ if (!existsSync(catalogPath)) {
 const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
 await copyFile(catalogPath, resolve(WEB, 'public', 'catalog.json'));
 
+// Keep in sync with web/src/format-hints.ts:fmtBytes
 function fmtBytes(n) {
   if (n == null) return '—';
   if (n < 1024) return n + ' B';
@@ -54,6 +55,7 @@ function isStale(iso) {
   if (!iso) return false;
   return (Date.now() - new Date(iso).getTime()) / 86400000 > STALE_DAYS;
 }
+// Keep in sync with web/src/util.ts:escapeHtml
 const esc = (s) => String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
 
 // Build-time mirror of web/src/seo.ts. Both produce the same head block;
@@ -185,7 +187,6 @@ const LEVEL_META = {
     label: 'NCLT benches',
     unit: 'NCLT benches',
     description: "National Company Law Tribunal's 15 bench jurisdictions. Dissolved from LGD state polygons per nclt.gov.in bench assignments.",
-    description: 'State legislative assembly constituency polygons across India.',
   },
 
   // Postal
@@ -972,7 +973,7 @@ await renderPage(
     structuredData: {
       '@context': 'https://schema.org',
       '@type': 'WebApplication',
-      name: 'geodata · preview',
+      name: 'bharatlas · preview',
       url: ORIGIN + '/preview',
       applicationCategory: 'UtilityApplication',
       operatingSystem: 'Web',

--- a/web/src/db.ts
+++ b/web/src/db.ts
@@ -109,19 +109,19 @@ function toUint8Array(v: unknown): Uint8Array | null {
 
 // ----- WKB → GeoJSON parser (ISO WKB, the format DuckDB uses for geometry blobs) -----
 
-type GeomOut =
+type Geometry =
   | { type: 'Point'; coordinates: [number, number] }
   | { type: 'LineString'; coordinates: [number, number][] }
   | { type: 'Polygon'; coordinates: [number, number][][] }
   | { type: 'MultiPoint'; coordinates: [number, number][] }
   | { type: 'MultiLineString'; coordinates: [number, number][][] }
   | { type: 'MultiPolygon'; coordinates: [number, number][][][] }
-  | { type: 'GeometryCollection'; geometries: GeomOut[] };
+  | { type: 'GeometryCollection'; geometries: Geometry[] };
 
-export function parseWKB(buf: Uint8Array): GeomOut {
+export function parseWKB(buf: Uint8Array): Geometry {
   const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
   let p = 0;
-  function readGeom(): GeomOut {
+  function readGeom(): Geometry {
     const le = dv.getUint8(p) === 1; p += 1;
     const typeWithFlags = dv.getUint32(p, le); p += 4;
     // Strip Z/M flags. Two encodings in the wild:
@@ -180,7 +180,7 @@ export function parseWKB(buf: Uint8Array): GeomOut {
       }
       case 7: {
         const n = dv.getUint32(p, le); p += 4;
-        const geoms: GeomOut[] = [];
+        const geoms: Geometry[] = [];
         for (let i = 0; i < n; i++) geoms.push(readGeom());
         return { type: 'GeometryCollection', geometries: geoms };
       }
@@ -214,6 +214,7 @@ export async function exportFilteredKML(
 }
 
 // --- inline GeoJSON → KML conversion (avoids a dep; handles Polygon/MultiPolygon/Point) ---
+// Keep in sync with scripts/bake_extracts.py KML section
 
 // Try most-specific first (village name) so a feature's KML <name> matches
 // the level you're looking at, not its parent.
@@ -258,14 +259,6 @@ function geoJSONFeaturesToKML(
 </kml>`;
 }
 
-type Geom =
-  | { type: 'Point'; coordinates: [number, number] }
-  | { type: 'LineString'; coordinates: [number, number][] }
-  | { type: 'Polygon'; coordinates: [number, number][][] }
-  | { type: 'MultiPolygon'; coordinates: [number, number][][][] }
-  | { type: 'MultiLineString'; coordinates: [number, number][][] }
-  | { type: 'GeometryCollection'; geometries: Geom[] };
-
 function coordPair(c: [number, number]): string {
   return `${c[0]},${c[1]}`;
 }
@@ -283,7 +276,7 @@ function polygon(p: [number, number][][]): string {
 
 function geometryToKML(g: unknown): string {
   if (!g || typeof g !== 'object' || !('type' in g)) return '';
-  const geom = g as Geom;
+  const geom = g as Geometry;
   switch (geom.type) {
     case 'Point':
       return `<Point><coordinates>${coordPair(geom.coordinates)}</coordinates></Point>`;

--- a/web/src/filter-probe.ts
+++ b/web/src/filter-probe.ts
@@ -6,6 +6,7 @@
 
 import { query } from './db';
 import type { ColumnStats, ColumnType } from './filter-schema';
+import { escIdent } from './filter-where';
 
 const DUCKDB_TO_NORM: Record<string, ColumnType> = {
   BOOLEAN: 'bool',
@@ -26,10 +27,6 @@ const MAX_TOP_VALUES = 50;
 function normaliseType(t: string): ColumnType {
   const base = t.split('(')[0].trim().toUpperCase();
   return DUCKDB_TO_NORM[base] ?? 'string';
-}
-
-function escIdent(s: string): string {
-  return `"${s.replace(/"/g, '""')}"`;
 }
 
 // Aggregate column aliases need to be valid SQL identifiers — strip anything

--- a/web/src/filter-where.ts
+++ b/web/src/filter-where.ts
@@ -11,7 +11,7 @@ export type ActiveFilter =
   | { col: string; kind: 'search'; q: string }
   | { col: string; kind: 'bool'; v: boolean };
 
-function escIdent(s: string): string {
+export function escIdent(s: string): string {
   return `"${s.replace(/"/g, '""')}"`;
 }
 

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -14,6 +14,7 @@ import {
 import { inlineLoader, VERBS_ENGINE, VERBS_EXPORT, VERBS_GEOJSON, VERBS_KML, VERBS_COUNT } from './loading';
 import { getFullCatalog } from './catalog';
 import { escapeHtml } from './util';
+import { fmtBytes } from './format-hints';
 import { pickAffordance, type Affordance, type ColumnStats } from './filter-schema';
 import {
   buildMaplibreFilter,
@@ -189,7 +190,7 @@ export function mountFilterPanel(
         if (bake?.url) {
           const fn = `${layer.id}__state${code}.${fmt}`;
           downloadUrl(bake.url, fn);
-          status.innerHTML = `<span class="filter-panel__ok">Downloaded ${escapeHtml(fn)} (${formatSize(bake.bytes)}, pre-baked).</span>`;
+          status.innerHTML = `<span class="filter-panel__ok">Downloaded ${escapeHtml(fn)} (${fmtBytes(bake.bytes)}, pre-baked).</span>`;
           return;
         }
       }
@@ -226,7 +227,7 @@ export function mountFilterPanel(
         // /api/dl/ so the Pages Function increments D1.
         const countKey = parquetUrl.replace(/^https?:\/\/[^/]+\//, '').replace(/\.parquet$/, `.${fmt}`);
         fetch(`/api/dl/${countKey}`, { keepalive: true }).catch(() => {});
-        status.innerHTML = `<span class="filter-panel__ok">Downloaded ${escapeHtml(filename)} (${formatSize(blob.size)}).</span>`;
+        status.innerHTML = `<span class="filter-panel__ok">Downloaded ${escapeHtml(filename)} (${fmtBytes(blob.size)}).</span>`;
       } catch (e) {
         clearTimeout(warmTimer);
         loader.dismiss();
@@ -394,10 +395,4 @@ function downloadBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   downloadUrl(url, filename);
   setTimeout(() => URL.revokeObjectURL(url), 30000);
-}
-
-function formatSize(n: number): string {
-  if (n < 1024) return n + ' B';
-  if (n < 1024 * 1024) return (n / 1024).toFixed(0) + ' KB';
-  return (n / 1024 / 1024).toFixed(1) + ' MB';
 }

--- a/web/src/loading.ts
+++ b/web/src/loading.ts
@@ -4,6 +4,8 @@
 // Themed verb sets capture the "what's happening" feel of each phase so
 // long waits never feel dead. Pick a set or pass your own.
 
+import { escapeHtml } from './util';
+
 export const VERBS_MAP = [
   'Triangulating polygons…',
   'Plotting boundaries…',
@@ -100,8 +102,6 @@ export const VERBS_VERIFY_RENDER = [
   'Fitting the bounds…',
   'Stroking edges…',
 ];
-
-import { escapeHtml } from './util';
 
 type Handle = { dismiss: () => void; setVerbs: (v: string[]) => void };
 

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -81,6 +81,16 @@ function setBasemap(id: BasemapId): void {
 const INDIA_BOUNDS: [number, number, number, number] = [68, 6, 98, 38];
 const BASE_PADDING = { top: 60, bottom: 20, left: 20, right: 20 };
 const MAX_POPUP_PROPS = 10;
+
+// If the layer's data extent covers >80% of India's area, snap to
+// INDIA_BOUNDS so all India-level layers start at the same zoom.
+// City-scale layers (wards, BDA) keep their own tight bounds.
+function snapToIndiaIfLarge(bounds: [number, number, number, number]): [number, number, number, number] {
+  const indiaArea = (INDIA_BOUNDS[2] - INDIA_BOUNDS[0]) * (INDIA_BOUNDS[3] - INDIA_BOUNDS[1]);
+  const layerArea = (bounds[2] - bounds[0]) * (bounds[3] - bounds[1]);
+  return layerArea / indiaArea > 0.5 ? INDIA_BOUNDS : bounds;
+}
+
 // The layer's data extent — set by attachData from the PMTiles header
 // or geojson source. Every fitBounds in the session uses this instead
 // of hardcoding INDIA_BOUNDS so city-scale layers (wards, BDA) return
@@ -216,7 +226,7 @@ async function attachData(layer: Layer) {
       minzoom: header.minZoom,
       maxzoom: header.maxZoom,
     });
-    layerBounds = [header.minLon, header.minLat, header.maxLon, header.maxLat];
+    layerBounds = snapToIndiaIfLarge([header.minLon, header.minLat, header.maxLon, header.maxLat]);
     map.fitBounds([
       [layerBounds[0], layerBounds[1]],
       [layerBounds[2], layerBounds[3]],

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -9,7 +9,7 @@ import { availableDownloads, fmtBytes } from './format-hints';
 import { BASEMAPS, getStoredBasemap, setStoredBasemap, type BasemapId } from './basemaps';
 import { embedIframeHtml } from './embed-snippet';
 import { imageFilename, dataUrlToBlob, triggerDownload } from './image-export';
-import { resolveStateCodes, type ActiveFilter, type MaplibreFilter } from './filter-where';
+import { type ActiveFilter, type MaplibreFilter } from './filter-where';
 
 type Layer = {
   id: string;
@@ -79,6 +79,8 @@ function setBasemap(id: BasemapId): void {
 }
 
 const INDIA_BOUNDS: [number, number, number, number] = [68, 6, 98, 38];
+const BASE_PADDING = { top: 60, bottom: 20, left: 20, right: 20 };
+const MAX_POPUP_PROPS = 10;
 // The layer's data extent — set by attachData from the PMTiles header
 // or geojson source. Every fitBounds in the session uses this instead
 // of hardcoding INDIA_BOUNDS so city-scale layers (wards, BDA) return
@@ -113,7 +115,7 @@ export async function openLayer(layerId: string, opts: { titleEl: HTMLElement })
     container,
     style: buildBaseStyle(activeBasemap),
     bounds: INDIA_BOUNDS,
-    fitBoundsOptions: { padding: { top: 60, bottom: 20, left: 20, right: 20 } },
+    fitBoundsOptions: { padding: BASE_PADDING },
     attributionControl: { compact: true },
     // Required so map.getCanvas().toDataURL() returns pixels for the
     // "Export image (PNG)" menu entry. Tiny perf cost; acceptable here.
@@ -218,7 +220,7 @@ async function attachData(layer: Layer) {
     map.fitBounds([
       [layerBounds[0], layerBounds[1]],
       [layerBounds[2], layerBounds[3]],
-    ], { padding: { top: 60, bottom: 20, left: 20, right: 20 }, duration: 0 });
+    ], { padding: BASE_PADDING, duration: 0 });
     addFillLayers('layer', sourceLayer);
   } else if (layer.geojson?.url) {
     map.addSource('layer', { type: 'geojson', data: layer.geojson.url, attribution: layer.source });
@@ -309,7 +311,7 @@ function addFillLayers(sourceId: string, sourceLayer?: string) {
   function buildRows(props: Record<string, unknown> | null | undefined): string {
     return Object.entries(props || {})
       .filter(([k, v]) => !k.startsWith('_') && v != null && v !== '')
-      .slice(0, 10)
+      .slice(0, MAX_POPUP_PROPS)
       .map(
         ([k, v]) =>
           `<div class="geo-popup__row"><span class="geo-popup__k">${escapeHtml(k)}</span><span class="geo-popup__v">${escapeHtml(String(v))}</span></div>`
@@ -600,10 +602,10 @@ async function wireFilterButton(layer: Layer) {
             btn.disabled = false;
             btn.textContent = 'Filter & export';
             applyActiveFilters([], null);
-            if (map) map.fitBounds([[layerBounds[0], layerBounds[1]], [layerBounds[2], layerBounds[3]]], { padding: { top: 60, bottom: 20, left: 20, right: 20 }, duration: 600 });
+            if (map) map.fitBounds([[layerBounds[0], layerBounds[1]], [layerBounds[2], layerBounds[3]]], { padding: BASE_PADDING, duration: 600 });
           },
           onActiveFiltersChange: (filters, mapFilter) => {
-            applyActiveFilters(filters, mapFilter, fullCat);
+            applyActiveFilters(filters, mapFilter);
           },
         });
         // Re-center India for the uncovered viewport now that the
@@ -647,10 +649,6 @@ function panelAwarePadding(): { top: number; bottom: number; left: number; right
 function applyActiveFilters(
   filters: ActiveFilter[],
   mapFilter: MaplibreFilter,
-  fullCatalog?: {
-    state_bounds?: Record<string, [number, number, number, number]>;
-    states?: Array<{ code: number; name: string }>;
-  },
 ): void {
   if (!map) return;
   for (const id of ['fill', 'line-halo', 'line', 'point']) {
@@ -660,10 +658,9 @@ function applyActiveFilters(
   }
   const padding = panelAwarePadding();
 
-  // Zoom to the filtered area. Old approach used LGD state codes which
-  // only worked for LGD-coded layers. New approach: wait for MapLibre to
-  // apply the filter, then compute bbox from the rendered features.
-  // Generic — works for ANY layer regardless of column schema.
+  // Zoom to the filtered area by computing a bbox from rendered features
+  // after MapLibre applies the filter. Generic: works for any layer
+  // regardless of column schema (no LGD-specific state-code logic).
   if (filters.length) {
     const m = map;
     const p = padding;

--- a/web/submit.html
+++ b/web/submit.html
@@ -1,0 +1,332 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Submit · contribute a geo layer · bharatlas</title>
+    <meta name="description" content="Submit your own geo content to India's open atlas under an open licence — no signup, no email. Get a shareable URL and admin token in seconds." />
+    <link rel="canonical" href="https://bharatlas.com/submit" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Submit · contribute a geo layer · bharatlas" />
+    <meta property="og:description" content="Submit your own geo content to India's open atlas under an open licence — no signup, no email. Get a shareable URL and admin token in seconds." />
+    <meta property="og:url" content="https://bharatlas.com/submit" />
+    <meta property="og:image" content="https://bharatlas.com/og-default.png" />
+    <meta property="og:site_name" content="bharatlas" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Submit · contribute a geo layer · bharatlas" />
+    <meta name="twitter:description" content="Submit your own geo content to India's open atlas under an open licence — no signup, no email. Get a shareable URL and admin token in seconds." />
+    <meta name="twitter:image" content="https://bharatlas.com/og-default.png" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","name":"bharatlas · submit","url":"https://bharatlas.com/submit","applicationCategory":"UtilityApplication","operatingSystem":"Web"}</script>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0b0b0d" media="(prefers-color-scheme: dark)" />
+    <style>
+      
+  :root {
+    --fs-xs: 11px; --fs-sm: 12px; --fs-md: 13px; --fs-base: 14px;
+    --fs-lg: 16px; --fs-xl: 20px; --fs-2xl: 28px; --fs-display: 36px;
+    --sp-1: 4px; --sp-2: 8px; --sp-3: 12px; --sp-4: 16px;
+    --sp-5: 20px; --sp-6: 24px; --sp-7: 32px; --sp-8: 48px;
+    --radius-sm: 4px; --radius-md: 6px; --radius-lg: 8px; --radius-xl: 12px;
+    --bg: #ffffff; --bg-elevated: #fafafa; --bg-card: #f5f5f5;
+    --fg: #0a0a0a; --muted: #6b7280; --muted-strong: #374151;
+    --subtle: #9ca3af; --line: #e5e7eb; --line-bright: #d1d5db;
+    --accent: #6366f1; --accent-strong: #4f46e5;
+    --accent-fill: #6366f1; --accent-fill-hover: #4f46e5;
+    --ok: #16a34a; --warn: #d97706; --err: #dc2626;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0a0a0a; --bg-elevated: #15151a; --bg-card: #1a1a1f;
+      --fg: #ededed; --muted: #9ca3af; --muted-strong: #d4d4d8;
+      --subtle: #525252; --line: #262626; --line-bright: #404040;
+      --accent: #818cf8; --accent-strong: #6366f1;
+      --accent-fill: #6366f1; --accent-fill-hover: #818cf8;
+      --ok: #4ade80; --warn: #fbbf24; --err: #f87171;
+    }
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); }
+  body {
+    font: var(--fs-base)/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", "Inter", sans-serif;
+  }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  a:focus-visible, button:focus-visible, [role=button]:focus-visible,
+  input:focus-visible, textarea:focus-visible, select:focus-visible {
+    outline: 2px solid var(--accent-strong) !important;
+    outline-offset: 2px !important;
+    border-radius: var(--radius-sm);
+  }
+  .site-header {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: var(--sp-4); flex-wrap: wrap; margin-bottom: var(--sp-6);
+  }
+  .site-brand {
+    font-size: var(--fs-lg); font-weight: 600; letter-spacing: -.01em;
+    color: var(--fg); text-decoration: none;
+  }
+  .site-brand:hover { text-decoration: none; }
+  .site-brand .mark-accent { color: var(--accent); }
+  .site-brand .tagline { color: var(--muted); font-weight: 400; margin-left: 6px; font-size: var(--fs-base); }
+  .site-nav { display: flex; gap: var(--sp-3); flex-wrap: wrap; align-items: center; }
+  .site-nav a {
+    color: var(--muted); text-decoration: none; font-size: var(--fs-base);
+    padding: 4px 0;
+  }
+  .site-nav a:hover { color: var(--fg); }
+  .site-nav a[data-active] { color: var(--fg); font-weight: 500; }
+  .site-footer {
+    margin-top: var(--sp-8); padding-top: var(--sp-5);
+    border-top: 1px solid var(--line);
+    color: var(--muted); font-size: var(--fs-sm); line-height: 1.7;
+  }
+  .site-footer p { margin: 0 0 var(--sp-2); }
+  .site-footer a { color: var(--muted); text-decoration: underline; text-underline-offset: 2px; }
+  .site-footer a:hover { color: var(--fg); }
+
+      :root { --card-bg: var(--bg-card); }
+      body { max-width: 680px; margin: 0 auto; padding: 32px 24px 80px; }
+
+      #drop {
+        display: block;
+        border: 2px dashed var(--line); border-radius: 12px; padding: 44px 24px;
+        text-align: center; cursor: pointer; transition: border-color .15s, background .15s;
+        background: var(--card-bg);
+      }
+      #drop:hover, #drop.dragover {
+        border-color: var(--accent);
+        background: color-mix(in srgb, var(--accent) 8%, var(--card-bg));
+      }
+      #drop strong { font-size: 16px; font-weight: 600; display: block; margin-bottom: 6px; }
+      #drop .hint { color: var(--muted); font-size: 13px; }
+      #drop input[type=file] { display: none; }
+
+      #report { margin: 20px 0 0; display: none; }
+      #report.show { display: block; }
+      #report .row {
+        display: flex; gap: 10px; padding: 6px 0; font-size: 13px;
+        border-bottom: 1px solid var(--line);
+      }
+      #report .row:last-child { border-bottom: 0; }
+      #report .row.ok::before { content: "✓"; color: var(--ok); width: 16px; font-weight: 700; }
+      #report .row.warn::before { content: "⚠"; color: var(--warn); width: 16px; font-weight: 700; }
+      #report .row.err::before { content: "✗"; color: var(--err); width: 16px; font-weight: 700; }
+      #report .row .k { flex: 1; }
+      #report .row .v { color: var(--muted); font-variant-numeric: tabular-nums; }
+
+      form { margin: 28px 0 0; display: none; }
+      form.show { display: block; }
+      .field { margin-bottom: 16px; }
+      .field label {
+        display: block; font-weight: 500; font-size: 13px; margin-bottom: 4px;
+      }
+      .field label .req { color: var(--err); margin-left: 2px; }
+      .field .hint { color: var(--muted); font-size: 12px; margin-top: 4px; line-height: 1.4; }
+      .field input:not([type=radio]):not([type=checkbox]),
+      .field textarea, .field select {
+        width: 100%; padding: 8px 10px; font: inherit; font-size: 14px;
+        background: var(--bg); color: var(--fg);
+        border: 1px solid var(--line); border-radius: 6px;
+      }
+      .field input:not([type=radio]):not([type=checkbox]):focus,
+      .field textarea:focus, .field select:focus {
+        outline: none; border-color: var(--accent);
+      }
+      .field textarea { resize: vertical; min-height: 60px; }
+      .legal {
+        font-size: 12px; color: var(--muted); line-height: 1.5;
+        background: var(--card-bg); padding: 10px 12px; border-radius: 6px;
+        border-left: 3px solid var(--accent); margin: 16px 0;
+      }
+      .radio-group { display: flex; flex-direction: column; gap: 8px; margin-top: 6px; }
+      .radio-group label {
+        display: flex; align-items: center; gap: 10px;
+        font-size: 14px; font-weight: 400; cursor: pointer;
+        margin: 0; padding: 4px 0;
+      }
+      .radio-group input[type=radio] { margin: 0; flex-shrink: 0; }
+      #captcha { margin: 16px 0; min-height: 65px; }
+
+      button.primary {
+        background: var(--accent); color: #fff; border: 0;
+        padding: 10px 20px; border-radius: 6px; font: inherit; font-weight: 500; font-size: 14px;
+        cursor: pointer;
+      }
+      button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
+      button.secondary {
+        background: transparent; color: var(--fg); border: 1px solid var(--line);
+        padding: 8px 14px; border-radius: 6px; font: inherit; font-size: 13px;
+        cursor: pointer;
+      }
+
+      #submit-status { margin-top: 12px; color: var(--muted); font-size: 13px; min-height: 18px; }
+      #submit-status.err { color: var(--err); }
+
+      #success { display: none; }
+      #success.show { display: block; }
+      #success h2 {
+        font-size: 18px; margin: 0 0 4px; color: var(--ok);
+      }
+      #success .ok-line { color: var(--muted); font-size: 14px; margin-bottom: 24px; }
+      #success .warn {
+        background: color-mix(in srgb, var(--warn) 12%, var(--card-bg));
+        border-left: 3px solid var(--warn);
+        padding: 14px 16px; border-radius: 6px; margin: 16px 0;
+      }
+      #success .warn strong { color: var(--warn); }
+      #success .token {
+        font: 13px ui-monospace, SFMono-Regular, Menlo, monospace;
+        background: var(--bg); border: 1px solid var(--line); border-radius: 6px;
+        padding: 10px 12px; word-break: break-all; margin: 10px 0;
+      }
+      #success .actions { display: flex; gap: 8px; flex-wrap: wrap; margin: 10px 0 24px; }
+      #success a.cta {
+        display: inline-block; background: var(--accent); color: #fff; text-decoration: none;
+        padding: 10px 20px; border-radius: 6px; font-weight: 500; font-size: 14px;
+      }
+      #success a.cta:hover { opacity: 0.92; }
+
+      .helper {
+        margin-top: 32px; padding-top: 16px; border-top: 1px dashed var(--line);
+        font-size: 12px; color: var(--muted); line-height: 1.6;
+      }
+      .helper code {
+        font: 11px ui-monospace, SFMono-Regular, monospace;
+        background: var(--card-bg); padding: 1px 4px; border-radius: 3px;
+      }
+
+      @media (max-width: 640px) {
+        body { padding: 24px 16px 60px; }
+        #drop { padding: 32px 16px; }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="site-brand" href="/">bhar<span class="mark-accent">atlas</span><span class="tagline">India's open atlas</span></a>
+      <nav class="site-nav">
+        <a href="/">catalog</a>
+        <a href="/verify">verify</a>
+        <a href="/submit" data-active>submit</a>
+        <a href="/about">about</a>
+        <a href="https://github.com/urbanmorph/geodata" target="_blank" rel="noopener">github</a>
+      </nav>
+    </header>
+
+    <label id="drop" for="file">
+      <strong>Drop a file or click to choose</strong>
+      <span class="hint">GeoJSON · KML · KMZ · GPX · TCX · Parquet · up to 500 MB · open licences only</span>
+      <input type="file" id="file" accept=".geojson,.json,.kml,.kmz,.gpx,.tcx,.parquet" />
+    </label>
+
+    <div id="report" aria-live="polite"></div>
+
+    <form id="meta" novalidate>
+      <div class="field">
+        <label for="f-name">Name <span class="req">*</span></label>
+        <input id="f-name" name="name" maxlength="120" required placeholder="Bangalore bike lanes" />
+        <div class="hint">A short title — shown on the catalog card and view page.</div>
+      </div>
+
+      <div class="field">
+        <label for="f-desc">Description</label>
+        <textarea id="f-desc" name="description" maxlength="500" placeholder="What does this layer contain? Where did it come from?"></textarea>
+      </div>
+
+      <div class="field">
+        <label for="f-cat">Category <span class="req">*</span></label>
+        <select id="f-cat" name="category" required>
+          <option value="">— pick one —</option>
+          <option value="administrative">Administrative boundaries</option>
+          <option value="people">People &amp; places</option>
+          <option value="environment">Environment &amp; nature</option>
+          <option value="agriculture">Agriculture &amp; land use</option>
+          <option value="transport">Transport &amp; mobility</option>
+          <option value="infrastructure">Infrastructure &amp; utilities</option>
+          <option value="culture">Culture &amp; heritage</option>
+          <option value="health-edu">Health &amp; education</option>
+          <option value="other">Other</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="f-lic">Licence <span class="req">*</span></label>
+        <select id="f-lic" name="license" required>
+          <option value="">— pick one —</option>
+          <option value="CC0-1.0">CC0 1.0 — Public Domain Dedication</option>
+          <option value="CC-BY-4.0">CC BY 4.0 — Attribution</option>
+          <option value="CC-BY-SA-4.0">CC BY-SA 4.0 — Attribution-ShareAlike</option>
+          <option value="ODbL-1.0">ODbL 1.0 — Open Database License</option>
+          <option value="ODC-PDDL-1.0">ODC PDDL — Public Domain Dedication</option>
+          <option value="GODL-India">Government Open Data Licence — India</option>
+        </select>
+        <div class="hint">Only open licences are accepted — your file must be redistributable.</div>
+      </div>
+
+      <div class="field">
+        <label for="f-attr">Attribution <span class="req">*</span></label>
+        <input id="f-attr" name="attribution" minlength="3" maxlength="200" required placeholder="e.g. BBMP Open Data Portal" />
+        <div class="hint">Credit line shown on every card and the view page (3–200 chars).</div>
+      </div>
+
+      <div class="field">
+        <label>Provenance <span class="req">*</span></label>
+        <div class="radio-group">
+          <label><input type="radio" name="is_original" value="0" checked /> <span>Republished from a public source</span></label>
+          <label><input type="radio" name="is_original" value="1" /> <span>Original work (I created this — hand-drawn, surveyed, compiled)</span></label>
+        </div>
+      </div>
+
+      <div class="field" id="src-field">
+        <label for="f-src"><span id="src-label">Source URL</span> <span class="req" id="src-req">*</span></label>
+        <input id="f-src" name="source_url" type="url" required placeholder="https://example.gov.in/dataset" />
+        <div class="hint" id="src-hint">The page where this data was originally published.</div>
+      </div>
+
+      <p class="legal">
+        By submitting you confirm you have the right to share this content under the selected
+        open licence. Copyrighted or proprietary data is not accepted.
+      </p>
+
+      <div id="captcha" data-sitekey="1x00000000000000000000AA"></div>
+
+      <button type="submit" class="primary" id="submit-btn" disabled>Submit →</button>
+      <div id="submit-status"></div>
+    </form>
+
+    <section id="success" aria-live="polite">
+      <h2>✓ Your submission is live</h2>
+      <p class="ok-line" id="success-url"></p>
+
+      <div class="warn">
+        <strong>Admin token — shown once. Save it.</strong>
+        <div class="token" id="success-token"></div>
+        <div class="actions">
+          <button type="button" class="secondary" id="copy-token">Copy token</button>
+          <button type="button" class="secondary" id="download-token">Download as .txt</button>
+        </div>
+        <div class="hint">Lose this and you can't edit or delete your submission.</div>
+      </div>
+
+      <a href="#" class="cta" id="goto-submission">Take me to my submission →</a>
+    </section>
+
+    <div class="helper">
+      <strong>Accepts:</strong> <code>.geojson</code> · <code>.json</code> · <code>.kml</code> · <code>.kmz</code> · <code>.gpx</code> · <code>.tcx</code> · <code>.parquet</code><br />
+      Files are parsed in your browser before upload — no server-side processing.<br />
+      Rate limit: 5 submissions per hour, 20 per day, per IP.
+    </div>
+
+    <footer class="site-footer">
+      <p>Open licences only. Each layer carries its source link on the card.</p>
+      <p>
+        <a href="https://github.com/urbanmorph/geodata">code</a> ·
+        made by <a href="https://urbanmorph.com">urbanmorph</a>
+      </p>
+    </footer>
+
+    <script type="module" src="/src/submit.ts"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Full codebase audit identified 1 critical + 10 medium + 12 low findings. All fixed in one pass.

### Critical
- **Duplicate `description` key in nclt_bench LEVEL_META** — JS silently took the last one, rendering NCLT benches with the assembly constituency description on prod.

### Medium (dead code + duplication + hardcodings)
- Removed unused `resolveStateCodes` import + dead `fullCatalog` param
- Replaced duplicate `formatSize` → uses `fmtBytes` from format-hints
- Shared `escIdent` between filter-probe and filter-where (was duplicated)
- Fixed duplicate `order` values for airport/reservoir in LEVELS
- Single-sourced R2 base URL (was hardcoded in 3 files)
- Added cross-reference comments for JS/Python duplicated logic (KML, fmtBytes, escapeHtml)

### Low (constants + cleanup)
- Extracted `BASE_PADDING` + `MAX_POPUP_PROPS` constants
- Merged duplicate geometry types in db.ts
- Moved misplaced import in loading.ts
- Removed redundant mkdir + import json
- Computed `plural_to_singular` once at module level

### SEO
- Fixed og:site_name "geodata" → "bharatlas" in submit.html
- Fixed WebApplication JSON-LD name in prerender.mjs
- Removed deleted REPORT.md link from submit.html footer
- Updated test count in README (380+ → 387+)

387/387 vitest green. 13 files changed.