### PR TITLE
security: enable Content-Security-Policy

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -3,18 +3,12 @@
 # later block overrides earlier).
 
 # Security headers applied to every route.
-# Lighthouse Best Practices ~50 → ~75 with this block.
-#
-# NOTE: Content-Security-Policy was temporarily removed after it surfaced
-# a DuckDB-WASM runtime error in production ("Out of bounds call_indirect").
-# Hardening CSP needs proper debugging of DuckDB worker init + WASM
-# module loading — tracked in the v4.0.2 follow-on. The other headers
-# below are safe and stay.
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com; img-src 'self' blob: data: https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://services.arcgisonline.com https://*.tile.opentopomap.org; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'
 
 # Hashed Vite assets — safe to cache forever.
 /assets/*

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -3,6 +3,8 @@
 import { isEmbedPath, isViewPath, nextStateOnClose } from './embed-snippet';
 import { filterCards, type CardLike } from './catalog-filter';
 
+document.querySelector('.view-seo')?.remove();
+
 const overlay = document.getElementById('map-overlay')!;
 const mapTitle = document.getElementById('map-title')!;
 const mapCloseBtn = document.getElementById('map-close') as HTMLButtonElement;

--- a/web/tests/security-headers.test.ts
+++ b/web/tests/security-headers.test.ts
@@ -36,10 +36,40 @@ describe('Security headers — Cloudflare Pages _headers file', () => {
     }
   });
 
-  // CSP temporarily removed pending v4.0.2 DuckDB debugging.
-  // Tests will reinstate once we know the safe directive set.
-  it('CSP is intentionally OFF — re-enable in v4.0.2 after debugging DuckDB worker init', () => {
-    expect(headersFile).not.toMatch(/^\s*Content-Security-Policy:/m);
+  it('sets Content-Security-Policy', () => {
+    expect(headersFile).toMatch(/^\s*Content-Security-Policy:/m);
+  });
+
+  it('CSP allows WASM execution via wasm-unsafe-eval', () => {
+    const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/);
+    expect(csp).not.toBeNull();
+    expect(csp![1]).toContain("'wasm-unsafe-eval'");
+  });
+
+  it('CSP allows blob: workers for DuckDB', () => {
+    const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/);
+    expect(csp).not.toBeNull();
+    expect(csp![1]).toContain('worker-src');
+    expect(csp![1]).toContain('blob:');
+  });
+
+  it('CSP allows jsdelivr for DuckDB WASM bundles', () => {
+    const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/);
+    expect(csp).not.toBeNull();
+    expect(csp![1]).toContain('https://cdn.jsdelivr.net');
+  });
+
+  it('CSP allows Cloudflare Turnstile', () => {
+    const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/);
+    expect(csp).not.toBeNull();
+    expect(csp![1]).toContain('https://challenges.cloudflare.com');
+  });
+
+  it('CSP does not use unsafe-eval (only wasm-unsafe-eval)', () => {
+    const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/);
+    expect(csp).not.toBeNull();
+    const stripped = csp![1].replace(/'wasm-unsafe-eval'/g, '');
+    expect(stripped).not.toContain("'unsafe-eval'");
   });
 
   it('keeps X-Content-Type-Options nosniff (already on by CF default; pin it)', () => {


### PR DESCRIPTION
## Summary
- Adds CSP header to `_headers` covering DuckDB-WASM (`wasm-unsafe-eval` + `blob:` workers + jsdelivr), MapLibre tile sources, and Cloudflare Turnstile
- No `unsafe-eval`, only `wasm-unsafe-eval`
- Removes edge-injected SEO article on JS init so it never flashes during SPA navigation
- Isolated branch: easy revert if anything breaks in production

## CSP directives
- `script-src`: self, blob:, jsdelivr, cloudflare turnstile, wasm-unsafe-eval
- `worker-src`: self, blob: (DuckDB + MapLibre workers)
- `connect-src`: self, blob:, jsdelivr, R2 bucket, turnstile
- `img-src`: self, blob:, data:, tile servers (carto, OSM, esri, opentopomap)
- `style-src`: self, unsafe-inline (MapLibre injects inline styles)
- `frame-src`: turnstile only
- `object-src`: none

## Test plan
- [x] 405 tests pass (6 new CSP tests)
- [x] Catalog loads on localhost:8788
- [x] Map renders with tiles on all basemaps
- [x] Filter panel opens, DuckDB loads, counts appear
- [x] Export downloads work
- [x] SEO article hidden on page load, not visible on back navigation
- [ ] Verify on production after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)