### PR TITLE
fix(map): preserve point layer geometry filter during filter ops

### DIFF
--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -661,8 +661,12 @@ function applyActiveFilters(
   mapFilter: MaplibreFilter,
 ): void {
   if (!map) return;
+  const pointGeomFilter: maplibregl.FilterSpecification = ['==', ['geometry-type'], 'Point'];
   for (const id of ['fill', 'line-halo', 'line', 'point']) {
-    if (map.getLayer(id)) {
+    if (!map.getLayer(id)) continue;
+    if (id === 'point') {
+      map.setFilter(id, mapFilter ? ['all', pointGeomFilter, mapFilter as maplibregl.FilterSpecification] : pointGeomFilter);
+    } else {
       map.setFilter(id, (mapFilter as maplibregl.FilterSpecification | null) ?? null);
     }
   }


### PR DESCRIPTION
## Summary
- Fixes circle points appearing on polygon layers after using Filter & export
- Root cause: `applyActiveFilters` replaced the point layer's `['==', ['geometry-type'], 'Point']` filter with the data filter, then set it to `null` on clear
- Fix: always wrap the point layer filter with `['all', geometryTypeFilter, dataFilter]`

## Test plan
- [x] Open subdistricts, click Filter, select a state, close filter: polygons stay as polygons
- [x] 405 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)