### PR TITLE
fix: use direct avatars URL for about page logo

### DIFF
--- a/web/about.template.html
+++ b/web/about.template.html
@@ -141,7 +141,7 @@
     <h2 style="text-transform:none;letter-spacing:0;color:var(--fg);font-size:var(--fs-xl);margin-top:var(--sp-7)">Built by</h2>
     <div class="built-by">
       <a href="https://urbanmorph.com" rel="noopener" aria-label="Urban Morph">
-        <img src="https://github.com/urbanmorph.png?size=160" alt="Urban Morph" width="80" height="80" loading="lazy" />
+        <img src="https://avatars.githubusercontent.com/u/68658616?s=160&amp;v=4" alt="Urban Morph" width="80" height="80" loading="lazy" />
       </a>
       <div class="built-by__text">
         <p><a href="https://www.sathyasankaran.com" target="_blank" rel="noopener">Sathya Sankaran</a> · <a href="https://linkedin.com/in/sathyasankaran" target="_blank" rel="noopener">LinkedIn</a></p>


### PR DESCRIPTION
## Summary
- Replace `github.com/urbanmorph.png` with the direct `avatars.githubusercontent.com` URL
- The 302 redirect from github.com was blocked by CSP (github.com not in img-src, only avatars.githubusercontent.com is)

## Test plan
- [ ] Logo visible on /about in incognito

🤖 Generated with [Claude Code](https://claude.com/claude-code)