### PR TITLE
feat: API v1 -- locate, catalog, submissions, rate limiting, docs

### DIFF
--- a/scripts/build_api_indexes.py
+++ b/scripts/build_api_indexes.py
@@ -1,0 +1,203 @@
+"""
+Generate pre-computed API indexes from LGD parquets.
+
+Outputs:
+  web/public/api-data/counts.json        -- per-layer, per-state feature counts
+  web/public/api-data/hierarchy/<SC>.json -- per-state admin hierarchy (LGD chain)
+
+Run after scripts/fetch.sh (needs local parquets in sources/india-geodata/).
+Gracefully skips if parquets are absent -- the API endpoints fall back to
+catalog.json rows counts and return 404 for hierarchy.
+
+Usage:
+    python3 scripts/build_api_indexes.py
+"""
+from __future__ import annotations
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / 'sources' / 'india-geodata'
+OUT = ROOT / 'web' / 'public' / 'api-data'
+
+# LGD parquet files and the columns we need
+LGD_LAYERS = [
+    ('lgd_states', 'LGD_States.parquet', 'State_LGD', None),
+    ('lgd_districts', 'LGD_Districts.parquet', 'State_LGD', 'Dist_LGD'),
+    ('lgd_subdistricts', 'LGD_Subdistricts.parquet', 'State_LGD', 'SubDist_LGD'),
+    ('lgd_blocks', 'LGD_Blocks.parquet', 'State_LGD', 'Block_LGD'),
+    ('lgd_villages', 'LGD_Villages.parquet', 'State_LGD', 'Vill_LGD'),
+]
+
+STATE_COL = 'State_LGD'
+
+
+def build_counts(con) -> dict:
+    """Per-layer, per-state feature counts."""
+    counts = {}
+    for layer_id, parquet, state_col, _code_col in LGD_LAYERS:
+        path = SRC / parquet
+        if not path.exists():
+            print(f'  counts: skip {layer_id} (no local parquet)')
+            continue
+        try:
+            total = con.execute(f"SELECT COUNT(*) FROM '{path}'").fetchone()[0]
+            by_state = {}
+            rows = con.execute(
+                f"SELECT \"{state_col}\", COUNT(*) as n FROM '{path}' GROUP BY 1"
+            ).fetchall()
+            for sc, n in rows:
+                if sc is not None:
+                    by_state[str(int(sc))] = n
+            counts[layer_id] = {'_total': total, 'by_state': by_state}
+            print(f'  counts: {layer_id} = {total} total, {len(by_state)} states')
+        except Exception as e:
+            print(f'  counts: {layer_id} failed: {e}')
+    return counts
+
+
+def build_hierarchy(con) -> dict[str, dict]:
+    """Per-state hierarchy JSON files. Returns {state_code: hierarchy_dict}."""
+    # First, get the state list
+    states_pq = SRC / 'LGD_States.parquet'
+    if not states_pq.exists():
+        print('  hierarchy: skip (no LGD_States.parquet)')
+        return {}
+
+    states = {}
+    for row in con.execute(f"""
+        SELECT State_LGD, STNAME FROM '{states_pq}'
+        WHERE State_LGD IS NOT NULL
+    """).fetchall():
+        sc = str(int(row[0]))
+        states[sc] = {'lgd_code': int(row[0]), 'name': row[1]}
+
+    if not states:
+        return {}
+
+    print(f'  hierarchy: {len(states)} states')
+    hierarchies: dict[str, dict] = {}
+
+    for sc, state_info in states.items():
+        h: dict[str, dict] = {'state': state_info}
+
+        # Districts
+        dist_pq = SRC / 'LGD_Districts.parquet'
+        if dist_pq.exists():
+            h['districts'] = {}
+            try:
+                rows = con.execute(f"""
+                    SELECT Dist_LGD, DTNAME FROM '{dist_pq}'
+                    WHERE State_LGD = {sc} AND Dist_LGD IS NOT NULL
+                """).fetchall()
+                for code, name in rows:
+                    h['districts'][str(int(code))] = {
+                        'lgd_code': int(code), 'name': name, 'state_lgd': int(sc),
+                    }
+            except Exception as e:
+                print(f'    districts for {sc}: {e}')
+
+        # Subdistricts
+        subdist_pq = SRC / 'LGD_Subdistricts.parquet'
+        if subdist_pq.exists():
+            h['subdistricts'] = {}
+            try:
+                rows = con.execute(f"""
+                    SELECT SubDist_LGD, SDTNAME, Dist_LGD FROM '{subdist_pq}'
+                    WHERE State_LGD = {sc} AND SubDist_LGD IS NOT NULL
+                """).fetchall()
+                for code, name, dlgd in rows:
+                    h['subdistricts'][str(int(code))] = {
+                        'lgd_code': int(code), 'name': name,
+                        'district_lgd': int(dlgd) if dlgd else None,
+                        'state_lgd': int(sc),
+                    }
+            except Exception as e:
+                print(f'    subdistricts for {sc}: {e}')
+
+        # Blocks
+        blocks_pq = SRC / 'LGD_Blocks.parquet'
+        if blocks_pq.exists():
+            h['blocks'] = {}
+            try:
+                rows = con.execute(f"""
+                    SELECT Block_LGD, BNAME, Dist_LGD FROM '{blocks_pq}'
+                    WHERE State_LGD = {sc} AND Block_LGD IS NOT NULL
+                """).fetchall()
+                for code, name, dlgd in rows:
+                    h['blocks'][str(int(code))] = {
+                        'lgd_code': int(code), 'name': name,
+                        'district_lgd': int(dlgd) if dlgd else None,
+                        'state_lgd': int(sc),
+                    }
+            except Exception as e:
+                print(f'    blocks for {sc}: {e}')
+
+        # Villages (can be large)
+        villages_pq = SRC / 'LGD_Villages.parquet'
+        if villages_pq.exists():
+            h['villages'] = {}
+            try:
+                rows = con.execute(f"""
+                    SELECT Vill_LGD, VILNAME, Block_LGD, Dist_LGD FROM '{villages_pq}'
+                    WHERE State_LGD = {sc} AND Vill_LGD IS NOT NULL
+                """).fetchall()
+                for code, name, blgd, dlgd in rows:
+                    h['villages'][str(int(code))] = {
+                        'lgd_code': int(code), 'name': name,
+                        'block_lgd': int(blgd) if blgd else None,
+                        'district_lgd': int(dlgd) if dlgd else None,
+                        'state_lgd': int(sc),
+                    }
+            except Exception as e:
+                print(f'    villages for {sc}: {e}')
+
+        hierarchies[sc] = h
+
+    return hierarchies
+
+
+def main():
+    try:
+        import duckdb
+    except ImportError:
+        sys.exit('duckdb not installed. pip install duckdb')
+
+    # Check if any parquets exist
+    available = [p for _, p, _, _ in LGD_LAYERS if (SRC / p).exists()]
+    if not available:
+        print('No local LGD parquets found. Skipping API index generation.')
+        print(f'Run scripts/fetch.sh to download them to {SRC}/')
+        return
+
+    print(f'Found {len(available)}/{len(LGD_LAYERS)} LGD parquets')
+
+    con = duckdb.connect()
+    con.install_extension('spatial')
+    con.load_extension('spatial')
+
+    # Build counts
+    OUT.mkdir(parents=True, exist_ok=True)
+    counts = build_counts(con)
+    if counts:
+        counts_path = OUT / 'counts.json'
+        counts_path.write_text(json.dumps(counts, separators=(',', ':')))
+        print(f'  wrote {counts_path.relative_to(ROOT)} ({len(counts)} layers)')
+
+    # Build hierarchy
+    hierarchies = build_hierarchy(con)
+    if hierarchies:
+        hier_dir = OUT / 'hierarchy'
+        hier_dir.mkdir(parents=True, exist_ok=True)
+        for sc, h in hierarchies.items():
+            p = hier_dir / f'{sc}.json'
+            p.write_text(json.dumps(h, separators=(',', ':')))
+        total_size = sum(f.stat().st_size for f in hier_dir.glob('*.json'))
+        print(f'  wrote {len(hierarchies)} hierarchy files ({total_size / 1024:.0f} KB total)')
+
+    con.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/web/docs.template.html
+++ b/web/docs.template.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="color-scheme" content="light dark" />
+    <!-- SEO_HEAD -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+    <link rel="icon" sizes="any" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0b0b0d" media="(prefers-color-scheme: dark)" />
+    <style>
+      <!-- TOKENS -->
+      :root { --row-hover: var(--bg-card); }
+      body { max-width: 800px; margin: 0 auto; padding: 48px 24px 80px; line-height: 1.6; }
+      h1 { font-size: 28px; margin: 0 0 var(--sp-2); font-weight: 700; }
+      h2 { font-size: 20px; margin: var(--sp-6) 0 var(--sp-2); font-weight: 600; color: var(--fg); border-bottom: 1px solid var(--line); padding-bottom: 6px; }
+      h3 { font-size: 16px; margin: var(--sp-4) 0 var(--sp-1); font-weight: 600; }
+      p, li { font-size: 15px; color: var(--muted); }
+      code { font: 13px ui-monospace, SFMono-Regular, monospace; background: var(--row-hover); padding: 1px 5px; border-radius: 3px; color: var(--fg); }
+      pre { background: var(--row-hover); padding: var(--sp-3); border-radius: 8px; overflow-x: auto; font-size: 13px; line-height: 1.5; }
+      pre code { background: none; padding: 0; }
+      table { width: 100%; border-collapse: collapse; font-size: 14px; margin: var(--sp-2) 0; }
+      th, td { text-align: left; padding: 8px 12px; border-bottom: 1px solid var(--line); }
+      th { font-weight: 600; color: var(--fg); font-size: 13px; text-transform: uppercase; letter-spacing: 0.03em; }
+      td { color: var(--muted); }
+      td code { font-size: 12px; }
+      a { color: var(--accent); text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .method { display: inline-block; font-weight: 700; font-size: 12px; padding: 2px 8px; border-radius: 4px; background: #22c55e22; color: #22c55e; margin-right: 6px; }
+      .endpoint { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 14px; }
+      .try-it { font-size: 13px; color: var(--accent); margin-left: 8px; }
+      .badge { display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 10px; font-weight: 500; }
+      .badge--stable { background: #22c55e22; color: #22c55e; }
+      .badge--beta { background: #f59e0b22; color: #f59e0b; }
+    </style>
+  </head>
+  <body>
+    <!-- NAV -->
+
+      <h1>API v1 <span class="badge badge--beta">beta</span></h1>
+      <p>Public, read-only JSON API for India's open geo layers. No auth, no API key. All endpoints return JSON with CORS enabled.</p>
+      <p>Base URL: <code>https://bharatlas.com/api/v1</code></p>
+
+      <h2>Layers</h2>
+
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/layers</span></h3>
+      <p>List all curated layers with pagination and filters.</p>
+      <table>
+        <tr><th>Param</th><th>Type</th><th>Description</th></tr>
+        <tr><td><code>category</code></td><td>string</td><td>Filter by category (e.g. <code>boundaries</code>, <code>city-wards</code>, <code>environment</code>)</td></tr>
+        <tr><td><code>level</code></td><td>string</td><td>Filter by admin level (e.g. <code>state</code>, <code>district</code>)</td></tr>
+        <tr><td><code>source</code></td><td>string</td><td>Filter by data source (e.g. <code>LGD</code>, <code>OpenCity</code>)</td></tr>
+        <tr><td><code>q</code></td><td>string</td><td>Text search across id, source, notes</td></tr>
+        <tr><td><code>limit</code></td><td>int</td><td>Results per page (default 100, max 500)</td></tr>
+        <tr><td><code>offset</code></td><td>int</td><td>Skip N results (default 0)</td></tr>
+      </table>
+      <pre><code>curl https://bharatlas.com/api/v1/layers?category=city-wards&amp;limit=5</code></pre>
+
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/layers/:id</span></h3>
+      <p>Single layer detail with download URLs, attribution, and column schema.</p>
+      <pre><code>curl https://bharatlas.com/api/v1/layers/lgd_states</code></pre>
+
+      <h2>Locate <span class="badge badge--stable">stable</span></h2>
+
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/locate</span></h3>
+      <p>Given a lat/lng, returns all polygon layers that contain that point: state, district, ward, pincode, forest, eco-zone, seismic zone, and more. The "where am I?" endpoint.</p>
+      <table>
+        <tr><th>Param</th><th>Type</th><th>Description</th></tr>
+        <tr><td><code>lat</code></td><td>float <b>*</b></td><td>Latitude (6 to 38, India bounding box)</td></tr>
+        <tr><td><code>lng</code></td><td>float <b>*</b></td><td>Longitude (68 to 98, India bounding box)</td></tr>
+        <tr><td><code>layers</code></td><td>string</td><td>Comma-separated layer IDs (default: 12 essential layers)</td></tr>
+        <tr><td><code>zoom</code></td><td>int</td><td>Tile resolution 4-16 (default 14, auto-capped to layer max zoom)</td></tr>
+      </table>
+      <pre><code>curl "https://bharatlas.com/api/v1/locate?lat=12.97&amp;lng=77.59"</code></pre>
+      <p>Response groups results by category:</p>
+      <pre><code>{
+  "point": { "lat": 12.97, "lng": 77.59 },
+  "results": {
+    "boundaries": [{
+      "layer_id": "lgd_states",
+      "level": "state",
+      "feature": {
+        "properties": { "STNAME": "KARNATAKA", "State_LGD": 29 }
+      }
+    }]
+  },
+  "queried_layers": ["lgd_states", "lgd_districts", ...],
+  "timing_ms": 450
+}</code></pre>
+
+      <h2>Categories and Levels</h2>
+
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/categories</span></h3>
+      <p>List all categories with layer counts.</p>
+      <pre><code>curl https://bharatlas.com/api/v1/categories</code></pre>
+
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/levels</span></h3>
+      <p>List admin hierarchy levels in order (country, state, district, subdistrict, block, village, ...).</p>
+      <pre><code>curl https://bharatlas.com/api/v1/levels</code></pre>
+
+      <h2>Downloads</h2>
+
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/downloads/counts</span></h3>
+      <p>Download counts per layer and format, plus a grand total.</p>
+      <pre><code>curl https://bharatlas.com/api/v1/downloads/counts</code></pre>
+
+      <h2>Community Submissions</h2>
+
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/submissions</span></h3>
+      <p>List accepted community submissions.</p>
+      <table>
+        <tr><th>Param</th><th>Type</th><th>Description</th></tr>
+        <tr><td><code>sort</code></td><td>string</td><td><code>recent</code> (default) or <code>useful</code></td></tr>
+        <tr><td><code>category</code></td><td>string</td><td>Filter by category</td></tr>
+        <tr><td><code>q</code></td><td>string</td><td>Search name and description</td></tr>
+        <tr><td><code>limit</code></td><td>int</td><td>Results per page (default 20, max 100)</td></tr>
+        <tr><td><code>offset</code></td><td>int</td><td>Skip N results</td></tr>
+      </table>
+
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/submissions/:id</span></h3>
+      <p>Single submission detail.</p>
+
+      <h2>Response Format</h2>
+      <p>All endpoints return JSON. List endpoints wrap results in:</p>
+      <pre><code>{ "data": [...], "total": 77, "limit": 100, "offset": 0 }</code></pre>
+      <p>Detail endpoints wrap in:</p>
+      <pre><code>{ "data": { ... } }</code></pre>
+      <p>Errors return:</p>
+      <pre><code>{ "error": "Not found", "status": 404 }</code></pre>
+
+      <h2>Stability</h2>
+      <p>All v1 endpoints follow additive-only evolution: new fields may appear, but existing fields will not be renamed or removed. If a breaking change is needed, it ships as v2.</p>
+      <p>Rate limits: reads are unlimited. Cloudflare DDoS protection applies. Write endpoints (submission, rating) are rate-limited per IP.</p>
+
+      <h2>Download Formats</h2>
+      <p>Each layer may offer up to 5 formats. Use the <code>downloads</code> object from <code>/api/v1/layers/:id</code> to get direct URLs:</p>
+      <table>
+        <tr><th>Format</th><th>Best for</th></tr>
+        <tr><td><code>parquet</code></td><td>DuckDB, Pandas, R, Spark</td></tr>
+        <tr><td><code>pmtiles</code></td><td>MapLibre, Leaflet, web maps</td></tr>
+        <tr><td><code>geojson</code></td><td>QGIS, D3, Mapbox, general GIS</td></tr>
+        <tr><td><code>kml</code></td><td>Google Earth</td></tr>
+        <tr><td><code>shapefile</code></td><td>ArcGIS, legacy GIS tools</td></tr>
+      </table>
+
+    <!-- FOOTER -->
+  </body>
+</html>

--- a/web/functions/api/v1/_middleware.ts
+++ b/web/functions/api/v1/_middleware.ts
@@ -1,0 +1,40 @@
+import type { Env } from '../_middleware';
+import { checkApiRateLimit } from '../../lib/api-ratelimit';
+
+export const onRequest: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+  const ip = ctx.request.headers.get('cf-connecting-ip') || ctx.request.headers.get('x-forwarded-for') || 'unknown';
+  const ipHash = await sha256(ip);
+
+  const isLocate = url.pathname.endsWith('/locate');
+  const limit = isLocate ? 60 : 120;
+
+  try {
+    const rl = await checkApiRateLimit(ctx.env.DB, ipHash, limit);
+    if (!rl.ok) {
+      return new Response(JSON.stringify({ error: 'Rate limit exceeded', retryAfter: rl.retryAfter, status: 429 }), {
+        status: 429,
+        headers: {
+          'content-type': 'application/json',
+          'retry-after': String(rl.retryAfter),
+          'x-api-version': 'v1',
+        },
+      });
+    }
+  } catch {
+    // D1 failure should not block reads
+  }
+
+  const resp = await ctx.next();
+  const headers = new Headers(resp.headers);
+  headers.set('x-api-version', 'v1');
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'application/json');
+  }
+  return new Response(resp.body, { status: resp.status, headers });
+};
+
+async function sha256(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/web/functions/api/v1/categories.ts
+++ b/web/functions/api/v1/categories.ts
@@ -1,0 +1,13 @@
+import type { Env } from '../_middleware';
+import { loadCatalog } from '../../lib/catalog-loader';
+import { toApiCategory } from '../../lib/catalog-api';
+
+const CACHE = 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+  const catalog = await loadCatalog(url.origin);
+  return new Response(JSON.stringify({ data: toApiCategory(catalog) }), {
+    headers: { 'content-type': 'application/json', 'cache-control': CACHE },
+  });
+};

--- a/web/functions/api/v1/downloads/counts.ts
+++ b/web/functions/api/v1/downloads/counts.ts
@@ -1,0 +1,28 @@
+import type { Env } from '../../_middleware';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  try {
+    const rows = await ctx.env.DB.prepare(
+      'SELECT layer_id, format, count FROM download_counts',
+    ).all<{ layer_id: string; format: string; count: number }>();
+
+    const counts: Record<string, Record<string, number>> = {};
+    let total = 0;
+    for (const r of rows.results ?? []) {
+      if (!counts[r.layer_id]) counts[r.layer_id] = {};
+      counts[r.layer_id][r.format] = r.count;
+      total += r.count;
+    }
+
+    return new Response(JSON.stringify({ data: counts, total }), {
+      headers: {
+        'content-type': 'application/json',
+        'cache-control': 'public, max-age=30, stale-while-revalidate=120',
+      },
+    });
+  } catch {
+    return new Response(JSON.stringify({ data: {}, total: 0 }), {
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+};

--- a/web/functions/api/v1/hierarchy/resolve.ts
+++ b/web/functions/api/v1/hierarchy/resolve.ts
@@ -1,0 +1,81 @@
+import type { Env } from '../../_middleware';
+
+const CACHE = 'public, max-age=86400, stale-while-revalidate=86400';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+  const code = url.searchParams.get('code');
+  const level = url.searchParams.get('level');
+
+  if (!code || !level) {
+    return json(400, { error: 'code and level query params are required', status: 400 });
+  }
+
+  const validLevels = ['state', 'district', 'subdistrict', 'block', 'village'];
+  if (!validLevels.includes(level)) {
+    return json(400, { error: `level must be one of: ${validLevels.join(', ')}`, status: 400 });
+  }
+
+  // Determine which state file to load. For state-level, code IS the state code.
+  // For sub-state levels, we need to search or the caller provides ?state=.
+  const stateCode = url.searchParams.get('state') || (level === 'state' ? code : null);
+
+  if (!stateCode) {
+    return json(400, { error: 'state query param is required for sub-state levels (or use level=state)', status: 400 });
+  }
+
+  try {
+    const r = await fetch(`${url.origin}/api-data/hierarchy/${stateCode}.json`);
+    if (!r.ok) {
+      return json(404, { error: `No hierarchy data for state ${stateCode}`, status: 404 });
+    }
+    const hierarchy = await r.json() as Record<string, Record<string, { name: string; lgd_code: number; [k: string]: unknown }>>;
+
+    const levelKey = level + 's'; // 'districts', 'villages', etc.
+    const bucket = hierarchy[levelKey] || hierarchy[level];
+    if (!bucket) {
+      return json(404, { error: `No ${level} data in hierarchy for state ${stateCode}`, status: 404 });
+    }
+
+    // Find the entry by LGD code
+    const entry = Object.values(bucket).find(
+      (e: Record<string, unknown>) => String(e.lgd_code) === String(code),
+    );
+    if (!entry) {
+      return json(404, { error: `Code ${code} not found at level ${level} in state ${stateCode}`, status: 404 });
+    }
+
+    // Build the chain from the entry's parent references
+    const chain: Record<string, unknown> = { [level]: entry };
+    if (entry.district_lgd && hierarchy.districts) {
+      const d = Object.values(hierarchy.districts).find(
+        (e: Record<string, unknown>) => String(e.lgd_code) === String(entry.district_lgd),
+      );
+      if (d) chain.district = d;
+    }
+    if (entry.subdistrict_lgd && hierarchy.subdistricts) {
+      const s = Object.values(hierarchy.subdistricts).find(
+        (e: Record<string, unknown>) => String(e.lgd_code) === String(entry.subdistrict_lgd),
+      );
+      if (s) chain.subdistrict = s;
+    }
+    if (entry.block_lgd && hierarchy.blocks) {
+      const b = Object.values(hierarchy.blocks).find(
+        (e: Record<string, unknown>) => String(e.lgd_code) === String(entry.block_lgd),
+      );
+      if (b) chain.block = b;
+    }
+    const stateEntry = hierarchy.state || hierarchy.states;
+    if (stateEntry) chain.state = stateEntry;
+
+    return new Response(JSON.stringify({ data: chain }), {
+      headers: { 'content-type': 'application/json', 'cache-control': CACHE },
+    });
+  } catch {
+    return json(404, { error: 'Hierarchy data not available. Run scripts/build_api_indexes.py to generate.', status: 404 });
+  }
+};
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}

--- a/web/functions/api/v1/hierarchy/search.ts
+++ b/web/functions/api/v1/hierarchy/search.ts
@@ -1,0 +1,55 @@
+import type { Env } from '../../_middleware';
+
+const CACHE = 'public, max-age=3600, stale-while-revalidate=86400';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+  const q = url.searchParams.get('q');
+  if (!q || q.length < 2) {
+    return json(400, { error: 'q param required (min 2 chars)', status: 400 });
+  }
+
+  const level = url.searchParams.get('level');
+  const stateCode = url.searchParams.get('state');
+  const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') || '10', 10), 1), 50);
+
+  if (!stateCode) {
+    return json(400, { error: 'state query param is required for hierarchy search', status: 400 });
+  }
+
+  try {
+    const r = await fetch(`${url.origin}/api-data/hierarchy/${stateCode}.json`);
+    if (!r.ok) {
+      return json(404, { error: `No hierarchy data for state ${stateCode}`, status: 404 });
+    }
+    const hierarchy = await r.json() as Record<string, Record<string, { name: string; lgd_code: number; [k: string]: unknown }>>;
+
+    const qLower = q.toLowerCase();
+    const results: Array<{ lgd_code: number; name: string; level: string }> = [];
+
+    const levelsToSearch = level ? [level + 's'] : ['districts', 'subdistricts', 'blocks', 'villages'];
+
+    for (const lvlKey of levelsToSearch) {
+      const bucket = hierarchy[lvlKey];
+      if (!bucket) continue;
+      const lvl = lvlKey.replace(/s$/, '');
+      for (const entry of Object.values(bucket)) {
+        if (results.length >= limit) break;
+        if (entry.name && entry.name.toLowerCase().includes(qLower)) {
+          results.push({ lgd_code: entry.lgd_code, name: entry.name, level: lvl });
+        }
+      }
+      if (results.length >= limit) break;
+    }
+
+    return new Response(JSON.stringify({ data: results, total: results.length }), {
+      headers: { 'content-type': 'application/json', 'cache-control': CACHE },
+    });
+  } catch {
+    return json(404, { error: 'Hierarchy data not available. Run scripts/build_api_indexes.py to generate.', status: 404 });
+  }
+};
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}

--- a/web/functions/api/v1/layers/[id].ts
+++ b/web/functions/api/v1/layers/[id].ts
@@ -1,0 +1,24 @@
+import type { Env } from '../../_middleware';
+import { loadCatalog } from '../../../lib/catalog-loader';
+import { toApiLayer } from '../../../lib/catalog-api';
+
+const CACHE = 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const id = (ctx.params as { id: string }).id;
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    return new Response(JSON.stringify({ error: 'Invalid layer ID', status: 400 }), { status: 400 });
+  }
+
+  const url = new URL(ctx.request.url);
+  const catalog = await loadCatalog(url.origin);
+  const layer = catalog.layers.find((l) => l.id === id);
+
+  if (!layer) {
+    return new Response(JSON.stringify({ error: 'Layer not found', status: 404 }), { status: 404 });
+  }
+
+  return new Response(JSON.stringify({ data: toApiLayer(layer, catalog, true) }), {
+    headers: { 'content-type': 'application/json', 'cache-control': CACHE },
+  });
+};

--- a/web/functions/api/v1/layers/[id]/counts.ts
+++ b/web/functions/api/v1/layers/[id]/counts.ts
@@ -1,0 +1,43 @@
+import type { Env } from '../../../_middleware';
+import { loadCatalog } from '../../../../lib/catalog-loader';
+
+const CACHE = 'public, max-age=86400, stale-while-revalidate=86400';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const id = (ctx.params as { id: string }).id;
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    return json(400, { error: 'Invalid layer ID', status: 400 });
+  }
+
+  const url = new URL(ctx.request.url);
+  const catalog = await loadCatalog(url.origin);
+  const layer = catalog.layers.find((l) => l.id === id);
+  if (!layer) return json(404, { error: 'Layer not found', status: 404 });
+
+  const groupBy = url.searchParams.get('group_by');
+
+  // Per-state counts from pre-built api-data/counts.json (deployed as static asset)
+  if (groupBy === 'state' || groupBy === 'district') {
+    try {
+      const r = await fetch(`${url.origin}/api-data/counts.json`);
+      if (r.ok) {
+        const allCounts = await r.json() as Record<string, { _total: number; by_state?: Record<string, number>; by_district?: Record<string, number> }>;
+        const layerCounts = allCounts[id];
+        if (layerCounts) {
+          const bucket = groupBy === 'state' ? layerCounts.by_state : layerCounts.by_district;
+          return new Response(JSON.stringify({
+            data: { layer_id: id, total: layerCounts._total, group_by: groupBy, counts: bucket || {} },
+          }), { headers: { 'content-type': 'application/json', 'cache-control': CACHE } });
+        }
+      }
+    } catch { /* fall through to basic count */ }
+  }
+
+  return new Response(JSON.stringify({
+    data: { layer_id: id, total: layer.rows ?? null },
+  }), { headers: { 'content-type': 'application/json', 'cache-control': CACHE } });
+};
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}

--- a/web/functions/api/v1/layers/index.ts
+++ b/web/functions/api/v1/layers/index.ts
@@ -1,0 +1,29 @@
+import type { Env } from '../../_middleware';
+import { loadCatalog } from '../../../lib/catalog-loader';
+import { filterLayers, paginateResults, toApiLayer } from '../../../lib/catalog-api';
+
+const CACHE = 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+  const catalog = await loadCatalog(url.origin);
+
+  const filtered = filterLayers(catalog.layers, {
+    category: url.searchParams.get('category') || undefined,
+    level: url.searchParams.get('level') || undefined,
+    source: url.searchParams.get('source') || undefined,
+    q: url.searchParams.get('q') || undefined,
+  });
+
+  const page = paginateResults(
+    filtered.map((l) => toApiLayer(l, catalog)),
+    {
+      limit: Number(url.searchParams.get('limit')) || undefined,
+      offset: Number(url.searchParams.get('offset')) || undefined,
+    },
+  );
+
+  return new Response(JSON.stringify(page), {
+    headers: { 'content-type': 'application/json', 'cache-control': CACHE },
+  });
+};

--- a/web/functions/api/v1/levels.ts
+++ b/web/functions/api/v1/levels.ts
@@ -1,0 +1,13 @@
+import type { Env } from '../_middleware';
+import { loadCatalog } from '../../lib/catalog-loader';
+import { toApiLevel } from '../../lib/catalog-api';
+
+const CACHE = 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+  const catalog = await loadCatalog(url.origin);
+  return new Response(JSON.stringify({ data: toApiLevel(catalog) }), {
+    headers: { 'content-type': 'application/json', 'cache-control': CACHE },
+  });
+};

--- a/web/functions/api/v1/locate.ts
+++ b/web/functions/api/v1/locate.ts
@@ -1,0 +1,44 @@
+import type { Env } from '../_middleware';
+import { loadCatalog } from '../../lib/catalog-loader';
+import { locate, DEFAULT_LOCATE_LAYERS } from '../../lib/locate';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+  const latStr = url.searchParams.get('lat');
+  const lngStr = url.searchParams.get('lng');
+
+  if (!latStr || !lngStr) {
+    return json(400, { error: 'lat and lng query params are required', status: 400 });
+  }
+
+  const lat = parseFloat(latStr);
+  const lng = parseFloat(lngStr);
+
+  if (isNaN(lat) || isNaN(lng) || lat < 6 || lat > 38 || lng < 68 || lng > 98) {
+    return json(400, { error: 'lat must be 6-38, lng must be 68-98 (India bounding box)', status: 400 });
+  }
+
+  const zoom = Math.min(Math.max(parseInt(url.searchParams.get('zoom') || '14', 10), 4), 16);
+
+  const layersParam = url.searchParams.get('layers');
+  const layerIds = layersParam
+    ? layersParam.split(',').map((s) => s.trim()).filter(Boolean)
+    : [...DEFAULT_LOCATE_LAYERS];
+
+  const catalog = await loadCatalog(url.origin);
+  const result = await locate(lat, lng, layerIds, zoom, catalog, ctx.env.R2);
+
+  return new Response(JSON.stringify(result), {
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'private, no-store',
+    },
+  });
+};
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/web/functions/api/v1/submissions/[id].ts
+++ b/web/functions/api/v1/submissions/[id].ts
@@ -1,0 +1,33 @@
+import type { Env } from '../../_middleware';
+
+type Params = { id: string };
+
+export const onRequestGet: PagesFunction<Env, keyof Params> = async (ctx) => {
+  const id = ctx.params.id as string;
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    return json(400, { error: 'Invalid submission ID', status: 400 });
+  }
+
+  const row = await ctx.env.DB.prepare(
+    `SELECT id, created_at, updated_at, status, name, description, category, license,
+            attribution, source_url, data_year, format, bytes, feature_count,
+            geometry_types, r2_key, useful_count
+     FROM submissions WHERE id = ? AND status = 'accepted'`,
+  ).bind(id).first();
+
+  if (!row) return json(404, { error: 'Submission not found', status: 404 });
+
+  return new Response(JSON.stringify({ data: row }), {
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'public, max-age=30, stale-while-revalidate=300',
+    },
+  });
+};
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/web/functions/api/v1/submissions/index.ts
+++ b/web/functions/api/v1/submissions/index.ts
@@ -1,0 +1,44 @@
+import type { Env } from '../../_middleware';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+  const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') || '20', 10), 1), 100);
+  const offset = Math.max(parseInt(url.searchParams.get('offset') || '0', 10), 0);
+  const sort = url.searchParams.get('sort') === 'useful' ? 'useful_count DESC' : 'created_at DESC';
+  const category = url.searchParams.get('category');
+  const q = url.searchParams.get('q');
+
+  let where = "status = 'accepted'";
+  const binds: unknown[] = [];
+
+  if (category) {
+    where += ' AND category = ?';
+    binds.push(category);
+  }
+  if (q) {
+    where += ' AND (name LIKE ? OR description LIKE ?)';
+    binds.push(`%${q}%`, `%${q}%`);
+  }
+
+  const countRow = await ctx.env.DB.prepare(`SELECT COUNT(*) as n FROM submissions WHERE ${where}`)
+    .bind(...binds).first<{ n: number }>();
+  const total = countRow?.n ?? 0;
+
+  const rows = await ctx.env.DB.prepare(
+    `SELECT id, created_at, name, description, category, license, attribution,
+            source_url, data_year, format, bytes, feature_count, geometry_types, useful_count
+     FROM submissions WHERE ${where} ORDER BY ${sort} LIMIT ? OFFSET ?`,
+  ).bind(...binds, limit, offset).all();
+
+  return new Response(JSON.stringify({
+    data: rows.results ?? [],
+    total,
+    limit,
+    offset,
+  }), {
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'public, max-age=60, stale-while-revalidate=300',
+    },
+  });
+};

--- a/web/functions/lib/api-ratelimit.ts
+++ b/web/functions/lib/api-ratelimit.ts
@@ -1,0 +1,60 @@
+/**
+ * Per-minute rate limiter for API v1 endpoints.
+ * Uses the existing rate_limits D1 table with an "api:" prefix on the key.
+ * Separate from the submission rate limiter (which uses raw IP hashes).
+ */
+
+type RunnableD1 = Pick<D1Database, 'prepare'>;
+
+const MINUTE_MS = 60 * 1000;
+
+type Row = {
+  hour_window_start: string;
+  hour_count: number;
+};
+
+export async function checkApiRateLimit(
+  db: RunnableD1,
+  ipHash: string,
+  limitPerMinute: number,
+): Promise<{ ok: true } | { ok: false; retryAfter: number }> {
+  const key = `api:${ipHash}`;
+  const now = Date.now();
+  const nowIso = new Date(now).toISOString();
+
+  const cur = (await db
+    .prepare('SELECT hour_window_start, hour_count FROM rate_limits WHERE ip_hash = ?')
+    .bind(key)
+    .first()) as Row | null;
+
+  if (!cur) {
+    await db
+      .prepare(
+        'INSERT OR IGNORE INTO rate_limits (ip_hash, hour_window_start, hour_count, day_window_start, day_count) VALUES (?, ?, ?, ?, ?)',
+      )
+      .bind(key, nowIso, 1, nowIso, 0)
+      .run();
+    return { ok: true };
+  }
+
+  let windowStart = new Date(cur.hour_window_start).getTime();
+  let count = cur.hour_count;
+
+  if (now - windowStart >= MINUTE_MS) {
+    windowStart = now;
+    count = 0;
+  }
+
+  if (count >= limitPerMinute) {
+    const retryAfter = Math.max(1, Math.ceil((windowStart + MINUTE_MS - now) / 1000));
+    return { ok: false, retryAfter };
+  }
+
+  count++;
+  await db
+    .prepare('UPDATE rate_limits SET hour_window_start = ?, hour_count = ? WHERE ip_hash = ?')
+    .bind(new Date(windowStart).toISOString(), count, key)
+    .run();
+
+  return { ok: true };
+}

--- a/web/functions/lib/catalog-api.ts
+++ b/web/functions/lib/catalog-api.ts
@@ -1,0 +1,128 @@
+export interface CatalogLayer {
+  id: string;
+  level: string;
+  source: string;
+  rows: number | null;
+  parquet?: { url: string; bytes: number | null } | null;
+  pmtiles?: { url: string; bytes: number | null } | null;
+  geojson?: { url: string; bytes: number | null } | null;
+  kml?: { url: string; bytes: number | null } | null;
+  shapefile?: { url: string; bytes: number | null } | null;
+  licence?: string;
+  attribution?: { primary?: { name: string; url: string }; publisher?: { name: string; url: string } | null };
+  category: string;
+  provenance: string;
+  notes?: string;
+  fetched_at?: string | null;
+}
+
+export interface CatalogData {
+  layers: CatalogLayer[];
+  categories: Record<string, string>;
+  levels: Record<string, { order: number; plural: string; path: string; category: string }>;
+  level_meta: Record<string, { label: string; unit: string; description: string }>;
+  level_order: string[];
+  filter_stats?: Record<string, unknown>;
+}
+
+export interface LayerFilter {
+  category?: string;
+  level?: string;
+  source?: string;
+  q?: string;
+}
+
+export interface PaginationOpts {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface ApiLayer {
+  id: string;
+  level: string;
+  source: string;
+  category: string;
+  rows: number | null;
+  provenance: string;
+  licence?: string;
+  attribution?: CatalogLayer['attribution'];
+  notes?: string;
+  downloads: Record<string, { url: string; bytes: number | null }>;
+  level_meta?: { label: string; unit: string; description: string };
+  filter_stats?: unknown;
+}
+
+export function filterLayers(layers: CatalogLayer[], filter: LayerFilter): CatalogLayer[] {
+  return layers.filter((l) => {
+    if (filter.category && l.category !== filter.category) return false;
+    if (filter.level && l.level !== filter.level) return false;
+    if (filter.source && l.source !== filter.source) return false;
+    if (filter.q) {
+      const q = filter.q.toLowerCase();
+      const hay = `${l.id} ${l.source} ${l.notes || ''} ${l.category} ${l.level}`.toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  });
+}
+
+export function paginateResults<T>(items: T[], opts: PaginationOpts): PaginatedResult<T> {
+  const limit = Math.min(Math.max(opts.limit ?? 100, 1), 500);
+  const offset = Math.max(opts.offset ?? 0, 0);
+  return {
+    data: items.slice(offset, offset + limit),
+    total: items.length,
+    limit,
+    offset,
+  };
+}
+
+const FORMATS = ['parquet', 'pmtiles', 'geojson', 'kml', 'shapefile'] as const;
+
+export function toApiLayer(layer: CatalogLayer, catalog: CatalogData, detail = false): ApiLayer {
+  const downloads: Record<string, { url: string; bytes: number | null }> = {};
+  for (const fmt of FORMATS) {
+    const d = layer[fmt];
+    if (d?.url) downloads[fmt] = { url: d.url, bytes: d.bytes ?? null };
+  }
+  const result: ApiLayer = {
+    id: layer.id,
+    level: layer.level,
+    source: layer.source,
+    category: layer.category,
+    rows: layer.rows,
+    provenance: layer.provenance,
+    licence: layer.licence,
+    attribution: layer.attribution,
+    notes: layer.notes,
+    downloads,
+    level_meta: catalog.level_meta?.[layer.id],
+  };
+  if (detail && catalog.filter_stats?.[layer.id]) {
+    result.filter_stats = catalog.filter_stats[layer.id];
+  }
+  return result;
+}
+
+export function toApiCategory(catalog: CatalogData): Array<{ id: string; label: string; layer_count: number }> {
+  const counts: Record<string, number> = {};
+  for (const l of catalog.layers) counts[l.category] = (counts[l.category] || 0) + 1;
+  return Object.entries(catalog.categories).map(([id, label]) => ({
+    id,
+    label,
+    layer_count: counts[id] || 0,
+  }));
+}
+
+export function toApiLevel(catalog: CatalogData): Array<{ id: string; order: number; plural: string; category: string }> {
+  return Object.entries(catalog.levels)
+    .map(([id, v]) => ({ id, order: v.order, plural: v.plural, category: v.category }))
+    .sort((a, b) => a.order - b.order);
+}

--- a/web/functions/lib/catalog-loader.ts
+++ b/web/functions/lib/catalog-loader.ts
@@ -1,0 +1,11 @@
+import type { CatalogData } from './catalog-api';
+
+let cached: CatalogData | null = null;
+
+export async function loadCatalog(origin: string): Promise<CatalogData> {
+  if (cached) return cached;
+  const r = await fetch(`${origin}/catalog.json`);
+  if (!r.ok) throw new Error(`catalog.json fetch failed: ${r.status}`);
+  cached = await r.json() as CatalogData;
+  return cached;
+}

--- a/web/functions/lib/locate.ts
+++ b/web/functions/lib/locate.ts
@@ -1,0 +1,93 @@
+import { PMTiles } from 'pmtiles';
+import { R2Source } from './r2-source';
+import { lngLatToTile } from './tile-math';
+import { findFeaturesAtPoint } from './mvt-locate';
+import type { CatalogData, CatalogLayer } from './catalog-api';
+
+export const DEFAULT_LOCATE_LAYERS = [
+  'lgd_states', 'lgd_districts', 'lgd_subdistricts', 'lgd_blocks',
+  'lgd_parliament', 'lgd_assembly',
+  'bharatviz_pincodes', 'seismic_zones',
+  'wris_basins', 'soi_forests', 'gs_wildlife', 'bm_eco_zones',
+  'high_courts',
+] as const;
+
+export interface LocateResult {
+  layer_id: string;
+  level: string;
+  category: string;
+  feature: { properties: Record<string, unknown> };
+}
+
+export interface LocateResponse {
+  point: { lat: number; lng: number };
+  zoom: number;
+  results: Record<string, LocateResult[]>;
+  queried_layers: string[];
+  timing_ms: number;
+}
+
+export async function locate(
+  lat: number,
+  lng: number,
+  layerIds: string[],
+  zoom: number,
+  catalog: CatalogData,
+  r2: R2Bucket,
+): Promise<LocateResponse> {
+  const start = Date.now();
+
+  const layers = layerIds
+    .map((id) => catalog.layers.find((l) => l.id === id))
+    .filter((l): l is CatalogLayer => !!l && !!l.pmtiles);
+
+  const settled = await Promise.allSettled(
+    layers.map((layer) => queryLayer(layer, zoom, lng, lat, r2)),
+  );
+
+  const grouped: Record<string, LocateResult[]> = {};
+  for (let i = 0; i < layers.length; i++) {
+    const s = settled[i];
+    if (s.status !== 'fulfilled' || !s.value.length) continue;
+    const layer = layers[i];
+    for (const hit of s.value) {
+      const cat = layer.category;
+      if (!grouped[cat]) grouped[cat] = [];
+      grouped[cat].push({
+        layer_id: layer.id,
+        level: layer.level,
+        category: cat,
+        feature: { properties: hit.properties },
+      });
+    }
+  }
+
+  return {
+    point: { lat, lng },
+    zoom,
+    results: grouped,
+    queried_layers: layers.map((l) => l.id),
+    timing_ms: Date.now() - start,
+  };
+}
+
+async function queryLayer(
+  layer: CatalogLayer,
+  z: number,
+  lng: number, lat: number,
+  r2: R2Bucket,
+) {
+  const pmtilesUrl = layer.pmtiles!.url;
+  const r2Key = pmtilesUrl.replace(/^https:\/\/[^/]+\//, '');
+  const source = new R2Source(r2, r2Key);
+  const pm = new PMTiles(source);
+
+  // Use the layer's max zoom if lower than requested
+  const header = await pm.getHeader();
+  const effectiveZ = Math.min(z, header.maxZoom);
+  const { x, y } = lngLatToTile(lng, lat, effectiveZ);
+
+  const tileData = await pm.getZxy(effectiveZ, x, y);
+  if (!tileData?.data) return [];
+  return findFeaturesAtPoint(tileData.data, effectiveZ, x, y, lng, lat);
+}

--- a/web/functions/lib/mvt-locate.ts
+++ b/web/functions/lib/mvt-locate.ts
@@ -1,0 +1,84 @@
+import { VectorTile } from '@mapbox/vector-tile';
+import Pbf from 'pbf';
+import { tileBounds } from './tile-math';
+import { pointInPolygon } from './point-in-polygon';
+
+export interface LocateHit {
+  layer_name: string;
+  properties: Record<string, unknown>;
+}
+
+export function findFeaturesAtPoint(
+  tileData: ArrayBuffer,
+  z: number, x: number, y: number,
+  lng: number, lat: number,
+): LocateHit[] {
+  const tile = new VectorTile(new Pbf(tileData));
+  const bounds = tileBounds(x, y, z);
+  const hits: LocateHit[] = [];
+
+  for (const layerName of Object.keys(tile.layers)) {
+    const layer = tile.layers[layerName];
+    for (let i = 0; i < layer.length; i++) {
+      const feat = layer.feature(i);
+      if (feat.type !== 3) continue; // only polygons
+
+      const rings = toGeoRings(feat, bounds, layer.extent);
+      if (!rings.length) continue;
+
+      // MultiPolygon: test each polygon separately
+      const polys = splitMultiPolygon(rings);
+      for (const poly of polys) {
+        if (pointInPolygon([lng, lat], poly)) {
+          hits.push({ layer_name: layerName, properties: feat.properties });
+          break;
+        }
+      }
+    }
+  }
+
+  return hits;
+}
+
+function toGeoRings(
+  feat: { loadGeometry(): { x: number; y: number }[][] },
+  bounds: { west: number; south: number; east: number; north: number },
+  extent: number,
+): [number, number][][] {
+  const geom = feat.loadGeometry();
+  return geom.map((ring) =>
+    ring.map(({ x, y }) => [
+      bounds.west + (x / extent) * (bounds.east - bounds.west),
+      bounds.north - (y / extent) * (bounds.north - bounds.south),
+    ] as [number, number]),
+  );
+}
+
+/**
+ * MVT packs MultiPolygons as a flat list of rings. After conversion to
+ * geographic coordinates, outer rings have negative signed area (CCW in
+ * screen space becomes CW in lng/lat). Split into separate polygons at
+ * each outer ring boundary.
+ */
+function splitMultiPolygon(rings: [number, number][][]): [number, number][][][] {
+  const polys: [number, number][][][] = [];
+  let current: [number, number][][] | null = null;
+  for (const ring of rings) {
+    if (signedArea(ring) < 0) {
+      if (current) polys.push(current);
+      current = [ring];
+    } else if (current) {
+      current.push(ring);
+    }
+  }
+  if (current) polys.push(current);
+  return polys;
+}
+
+function signedArea(ring: [number, number][]): number {
+  let sum = 0;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    sum += (ring[j][0] - ring[i][0]) * (ring[j][1] + ring[i][1]);
+  }
+  return sum;
+}

--- a/web/functions/lib/point-in-polygon.ts
+++ b/web/functions/lib/point-in-polygon.ts
@@ -1,0 +1,29 @@
+/**
+ * Ray-casting point-in-polygon for a polygon with optional holes.
+ * rings[0] = outer ring, rings[1..n] = holes.
+ * Each ring is [[x,y], [x,y], ...] with first == last (closed).
+ * Returns true if the point is inside the outer ring and outside all holes.
+ */
+export function pointInPolygon(
+  point: [number, number],
+  rings: [number, number][][],
+): boolean {
+  let inside = ringContains(point, rings[0]);
+  for (let i = 1; i < rings.length; i++) {
+    if (ringContains(point, rings[i])) inside = false;
+  }
+  return inside;
+}
+
+function ringContains(point: [number, number], ring: [number, number][]): boolean {
+  const [px, py] = point;
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i];
+    const [xj, yj] = ring[j];
+    if ((yi > py) !== (yj > py) && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}

--- a/web/functions/lib/r2-source.ts
+++ b/web/functions/lib/r2-source.ts
@@ -1,0 +1,19 @@
+import type { Source, RangeResponse } from 'pmtiles';
+
+export class R2Source implements Source {
+  constructor(private bucket: R2Bucket, private key: string) {}
+
+  getKey(): string {
+    return this.key;
+  }
+
+  async getBytes(offset: number, length: number): Promise<RangeResponse> {
+    const obj = await this.bucket.get(this.key, { range: { offset, length } });
+    if (!obj) throw new Error(`R2 key not found: ${this.key}`);
+    return {
+      data: await obj.arrayBuffer(),
+      etag: obj.etag,
+      cacheControl: obj.httpMetadata?.cacheControl,
+    };
+  }
+}

--- a/web/functions/lib/tile-math.ts
+++ b/web/functions/lib/tile-math.ts
@@ -1,0 +1,20 @@
+export function lngLatToTile(lng: number, lat: number, zoom: number): { x: number; y: number } {
+  const n = 2 ** zoom;
+  const x = Math.floor(((lng + 180) / 360) * n);
+  const latRad = (lat * Math.PI) / 180;
+  const y = Math.floor(((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n);
+  return { x: Math.min(Math.max(x, 0), n - 1), y: Math.min(Math.max(y, 0), n - 1) };
+}
+
+export function tileBounds(x: number, y: number, z: number): { west: number; south: number; east: number; north: number } {
+  const n = 2 ** z;
+  const west = (x / n) * 360 - 180;
+  const east = ((x + 1) / n) * 360 - 180;
+  const north = tileToLat(y, n);
+  const south = tileToLat(y + 1, n);
+  return { west, south, east, north };
+}
+
+function tileToLat(y: number, n: number): number {
+  return (Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / n))) * 180) / Math.PI;
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+        "@mapbox/vector-tile": "^2.0.5",
         "@resvg/resvg-wasm": "^2.6.2",
         "@tmcw/togeojson": "^5.8.1",
         "jszip": "^3.10.1",
         "maplibre-gl": "^4.7.1",
+        "pbf": "^4.0.2",
         "pmtiles": "^3.2.1"
       },
       "devDependencies": {
@@ -477,13 +479,21 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
-      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@mapbox/point-geometry": "~0.1.0"
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.2"
       }
+    },
+    "node_modules/@mapbox/vector-tile/node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
     },
     "node_modules/@mapbox/whoots-js": {
       "version": "3.1.0",
@@ -1801,6 +1811,28 @@
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
+    "node_modules/maplibre-gl/node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/maplibre-gl/node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1887,12 +1919,11 @@
       }
     },
     "node_modules/pbf": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
-      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
       },
       "bin": {
@@ -2475,6 +2506,28 @@
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
         "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/vt-pbf/node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/vt-pbf/node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/which": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,10 +12,12 @@
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+    "@mapbox/vector-tile": "^2.0.5",
     "@resvg/resvg-wasm": "^2.6.2",
     "@tmcw/togeojson": "^5.8.1",
     "jszip": "^3.10.1",
     "maplibre-gl": "^4.7.1",
+    "pbf": "^4.0.2",
     "pmtiles": "^3.2.1"
   },
   "devDependencies": {

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -998,6 +998,14 @@ await renderPage('terms', {
   image: ORIGIN + '/og-default.png',
 });
 
+await renderPage('docs', {
+  title: 'API v1',
+  description:
+    "Public JSON API for India's open geo layers. List layers, locate a point across 77 datasets, download in 5 formats. No auth, no API key.",
+  url: ORIGIN + '/docs',
+  image: ORIGIN + '/og-default.png',
+});
+
 // Static sitemap.xml — emitted at build time. Edge function later stitches in /c/[id].
 const sitemapUrls = [
   { loc: ORIGIN + '/', changefreq: 'weekly', priority: '1.0' },
@@ -1005,6 +1013,7 @@ const sitemapUrls = [
   { loc: ORIGIN + '/preview', changefreq: 'monthly', priority: '0.8' },
   { loc: ORIGIN + '/privacy', changefreq: 'yearly', priority: '0.3' },
   { loc: ORIGIN + '/terms', changefreq: 'yearly', priority: '0.3' },
+  { loc: ORIGIN + '/docs', changefreq: 'monthly', priority: '0.7' },
 ];
 const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/web/scripts/shared-chrome.mjs
+++ b/web/scripts/shared-chrome.mjs
@@ -70,6 +70,7 @@ export const TOKENS = `
 export const NAV_LINKS = [
   { k: 'catalog', href: '/', label: 'catalog' },
   { k: 'preview', href: '/preview', label: 'contribute' },
+  { k: 'docs', href: '/docs', label: 'docs' },
   { k: 'about', href: '/about', label: 'about' },
   { k: 'github', href: 'https://github.com/urbanmorph/geodata', label: 'github' },
 ];

--- a/web/tests/api-ratelimit.test.ts
+++ b/web/tests/api-ratelimit.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { checkApiRateLimit } from '../functions/lib/api-ratelimit';
+
+function fakeD1() {
+  const rows = new Map<string, { hour_window_start: string; hour_count: number }>();
+  return {
+    prepare(sql: string) {
+      let args: unknown[] = [];
+      return {
+        bind(...a: unknown[]) { args = a; return this; },
+        async first() {
+          if (/SELECT/.test(sql)) return rows.get(args[0] as string) || null;
+          return null;
+        },
+        async run() {
+          if (/INSERT/.test(sql)) {
+            const key = args[0] as string;
+            rows.set(key, { hour_window_start: args[1] as string, hour_count: args[2] as number });
+          } else if (/UPDATE/.test(sql)) {
+            const key = args[2] as string;
+            rows.set(key, { hour_window_start: args[0] as string, hour_count: args[1] as number });
+          }
+          return { success: true };
+        },
+      };
+    },
+  };
+}
+
+describe('checkApiRateLimit', () => {
+  it('allows first request', async () => {
+    const db = fakeD1();
+    const r = await checkApiRateLimit(db as never, 'ip1', 5);
+    expect(r.ok).toBe(true);
+  });
+
+  it('allows requests up to the limit', async () => {
+    const db = fakeD1();
+    for (let i = 0; i < 5; i++) {
+      const r = await checkApiRateLimit(db as never, 'ip2', 5);
+      expect(r.ok).toBe(true);
+    }
+  });
+
+  it('blocks after exceeding the limit', async () => {
+    const db = fakeD1();
+    for (let i = 0; i < 5; i++) {
+      await checkApiRateLimit(db as never, 'ip3', 5);
+    }
+    const r = await checkApiRateLimit(db as never, 'ip3', 5);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.retryAfter).toBeGreaterThan(0);
+  });
+
+  it('uses separate keys per IP', async () => {
+    const db = fakeD1();
+    for (let i = 0; i < 5; i++) {
+      await checkApiRateLimit(db as never, 'ip4', 5);
+    }
+    const r = await checkApiRateLimit(db as never, 'ip5', 5);
+    expect(r.ok).toBe(true);
+  });
+});

--- a/web/tests/catalog-api.test.ts
+++ b/web/tests/catalog-api.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterLayers,
+  paginateResults,
+  toApiLayer,
+  toApiCategory,
+  toApiLevel,
+  type CatalogData,
+} from '../functions/lib/catalog-api';
+
+const SAMPLE_CATALOG: CatalogData = {
+  layers: [
+    {
+      id: 'lgd_states', level: 'state', source: 'LGD', rows: 36,
+      parquet: { url: 'https://r2.dev/states.parquet', bytes: 7000000 },
+      pmtiles: { url: 'https://r2.dev/states.pmtiles', bytes: 3000000 },
+      geojson: { url: 'https://r2.dev/states.geojson', bytes: 27000000 },
+      kml: { url: 'https://r2.dev/states.kml', bytes: 21000000 },
+      shapefile: { url: 'https://r2.dev/states.shp.zip', bytes: 11000000 },
+      licence: 'CC0-1.0', attribution: { primary: { name: 'LGD', url: 'https://lgd.gov.in' } },
+      category: 'boundaries', provenance: 'curated', notes: 'State boundaries',
+    },
+    {
+      id: 'wards_chennai', level: 'wards_chennai', source: 'OpenCity', rows: 200,
+      parquet: { url: 'https://r2.dev/chennai.parquet', bytes: 699072 },
+      pmtiles: { url: 'https://r2.dev/chennai.pmtiles', bytes: 214930 },
+      geojson: null, kml: null, shapefile: null,
+      licence: 'ODbL-1.0', attribution: { primary: { name: 'OpenCity', url: 'https://data.opencity.in' } },
+      category: 'city-wards', provenance: 'curated', notes: 'Chennai wards',
+    },
+    {
+      id: 'seismic_zones', level: 'seismic_zone', source: 'data.gov.in', rows: 5,
+      parquet: { url: 'https://r2.dev/seismic.parquet', bytes: 50000 },
+      pmtiles: { url: 'https://r2.dev/seismic.pmtiles', bytes: 30000 },
+      geojson: { url: 'https://r2.dev/seismic.geojson', bytes: 120000 },
+      kml: null, shapefile: null,
+      licence: 'GODL-India', attribution: { primary: { name: 'data.gov.in', url: 'https://data.gov.in' } },
+      category: 'environment', provenance: 'curated', notes: 'BIS seismic zones',
+    },
+  ],
+  categories: {
+    'boundaries': 'Boundaries',
+    'city-wards': 'City wards',
+    'environment': 'Environment',
+  },
+  levels: {
+    'state': { order: 1, plural: 'states', path: 'admin/states', category: 'boundaries' },
+    'seismic_zone': { order: 30, plural: 'seismic zones', path: 'environment/seismic', category: 'environment' },
+  },
+  level_meta: {
+    'lgd_states': { label: 'States (2024)', unit: 'states & UTs', description: 'All 36 states and UTs' },
+    'wards_chennai': { label: 'Chennai (GCC) Wards', unit: 'wards', description: '200 ward boundaries' },
+  },
+  level_order: ['state', 'seismic_zone'],
+  filter_stats: {
+    'lgd_states': { columns: [{ column_name: 'stname', kind: 'categorical' }] },
+  },
+};
+
+describe('filterLayers', () => {
+  it('returns all layers with no filters', () => {
+    const result = filterLayers(SAMPLE_CATALOG.layers, {});
+    expect(result).toHaveLength(3);
+  });
+
+  it('filters by category', () => {
+    const result = filterLayers(SAMPLE_CATALOG.layers, { category: 'boundaries' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('lgd_states');
+  });
+
+  it('filters by level', () => {
+    const result = filterLayers(SAMPLE_CATALOG.layers, { level: 'state' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('lgd_states');
+  });
+
+  it('filters by source', () => {
+    const result = filterLayers(SAMPLE_CATALOG.layers, { source: 'OpenCity' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('wards_chennai');
+  });
+
+  it('filters by text query (case-insensitive)', () => {
+    const result = filterLayers(SAMPLE_CATALOG.layers, { q: 'chennai' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('wards_chennai');
+  });
+
+  it('text query matches id, notes, and source', () => {
+    expect(filterLayers(SAMPLE_CATALOG.layers, { q: 'seismic' })).toHaveLength(1);
+    expect(filterLayers(SAMPLE_CATALOG.layers, { q: 'LGD' })).toHaveLength(1);
+    expect(filterLayers(SAMPLE_CATALOG.layers, { q: 'State boundaries' })).toHaveLength(1);
+  });
+
+  it('combines multiple filters (AND)', () => {
+    const result = filterLayers(SAMPLE_CATALOG.layers, { category: 'boundaries', q: 'state' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('lgd_states');
+  });
+
+  it('returns empty for no matches', () => {
+    expect(filterLayers(SAMPLE_CATALOG.layers, { q: 'nonexistent' })).toHaveLength(0);
+  });
+});
+
+describe('paginateResults', () => {
+  const items = Array.from({ length: 25 }, (_, i) => ({ id: `item_${i}` }));
+
+  it('returns first page with defaults', () => {
+    const result = paginateResults(items, {});
+    expect(result.data).toHaveLength(25);
+    expect(result.total).toBe(25);
+    expect(result.limit).toBe(100);
+    expect(result.offset).toBe(0);
+  });
+
+  it('respects limit', () => {
+    const result = paginateResults(items, { limit: 10 });
+    expect(result.data).toHaveLength(10);
+    expect(result.total).toBe(25);
+  });
+
+  it('respects offset', () => {
+    const result = paginateResults(items, { limit: 10, offset: 20 });
+    expect(result.data).toHaveLength(5);
+    expect(result.offset).toBe(20);
+  });
+
+  it('clamps limit to 1-500', () => {
+    expect(paginateResults(items, { limit: 0 }).limit).toBe(1);
+    expect(paginateResults(items, { limit: -5 }).limit).toBe(1);
+    expect(paginateResults(items, { limit: 1000 }).limit).toBe(500);
+  });
+
+  it('clamps offset to >= 0', () => {
+    expect(paginateResults(items, { offset: -10 }).offset).toBe(0);
+  });
+});
+
+describe('toApiLayer', () => {
+  it('transforms a catalog layer to the API shape', () => {
+    const api = toApiLayer(SAMPLE_CATALOG.layers[0], SAMPLE_CATALOG);
+    expect(api.id).toBe('lgd_states');
+    expect(api.downloads.parquet).toEqual({ url: 'https://r2.dev/states.parquet', bytes: 7000000 });
+    expect(api.downloads.kml).toEqual({ url: 'https://r2.dev/states.kml', bytes: 21000000 });
+    expect(api.level_meta?.label).toBe('States (2024)');
+    expect(api).not.toHaveProperty('parquet');
+    expect(api).not.toHaveProperty('pmtiles');
+  });
+
+  it('omits null download formats', () => {
+    const api = toApiLayer(SAMPLE_CATALOG.layers[1], SAMPLE_CATALOG);
+    expect(api.downloads.parquet).toBeTruthy();
+    expect(api.downloads.geojson).toBeUndefined();
+    expect(api.downloads.kml).toBeUndefined();
+  });
+
+  it('includes filter_stats on detail view', () => {
+    const api = toApiLayer(SAMPLE_CATALOG.layers[0], SAMPLE_CATALOG, true);
+    expect(api.filter_stats).toBeTruthy();
+    expect(api.filter_stats?.columns[0].column_name).toBe('stname');
+  });
+
+  it('excludes filter_stats on list view', () => {
+    const api = toApiLayer(SAMPLE_CATALOG.layers[0], SAMPLE_CATALOG, false);
+    expect(api.filter_stats).toBeUndefined();
+  });
+});
+
+describe('toApiCategory', () => {
+  it('produces category with layer count', () => {
+    const cats = toApiCategory(SAMPLE_CATALOG);
+    expect(cats).toHaveLength(3);
+    const boundaries = cats.find((c) => c.id === 'boundaries');
+    expect(boundaries?.label).toBe('Boundaries');
+    expect(boundaries?.layer_count).toBe(1);
+  });
+});
+
+describe('toApiLevel', () => {
+  it('produces ordered levels', () => {
+    const levels = toApiLevel(SAMPLE_CATALOG);
+    expect(levels[0].id).toBe('state');
+    expect(levels[0].order).toBe(1);
+    expect(levels[1].id).toBe('seismic_zone');
+  });
+});

--- a/web/tests/point-in-polygon.test.ts
+++ b/web/tests/point-in-polygon.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { pointInPolygon } from '../functions/lib/point-in-polygon';
+
+const square: [number, number][] = [
+  [0, 0], [10, 0], [10, 10], [0, 10], [0, 0],
+];
+
+const lShape: [number, number][] = [
+  [0, 0], [10, 0], [10, 5], [5, 5], [5, 10], [0, 10], [0, 0],
+];
+
+describe('pointInPolygon', () => {
+  it('returns true for point inside a square', () => {
+    expect(pointInPolygon([5, 5], [square])).toBe(true);
+  });
+
+  it('returns false for point outside a square', () => {
+    expect(pointInPolygon([15, 5], [square])).toBe(false);
+  });
+
+  it('returns false for point clearly outside', () => {
+    expect(pointInPolygon([-5, -5], [square])).toBe(false);
+  });
+
+  it('handles L-shaped polygon', () => {
+    expect(pointInPolygon([2, 2], [lShape])).toBe(true);
+    expect(pointInPolygon([7, 7], [lShape])).toBe(false);
+    expect(pointInPolygon([2, 8], [lShape])).toBe(true);
+  });
+
+  it('handles polygon with hole', () => {
+    const outer: [number, number][] = [
+      [0, 0], [20, 0], [20, 20], [0, 20], [0, 0],
+    ];
+    const hole: [number, number][] = [
+      [5, 5], [15, 5], [15, 15], [5, 15], [5, 5],
+    ];
+    expect(pointInPolygon([10, 10], [outer, hole])).toBe(false);
+    expect(pointInPolygon([2, 2], [outer, hole])).toBe(true);
+    expect(pointInPolygon([25, 25], [outer, hole])).toBe(false);
+  });
+
+  it('handles multi-ring input (outer only)', () => {
+    expect(pointInPolygon([5, 5], [square])).toBe(true);
+  });
+});

--- a/web/tests/tile-math.test.ts
+++ b/web/tests/tile-math.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { lngLatToTile, tileBounds } from '../functions/lib/tile-math';
+
+describe('lngLatToTile', () => {
+  it('converts Bengaluru to correct tile at zoom 14', () => {
+    const { x, y } = lngLatToTile(77.5946, 12.9716, 14);
+    expect(x).toBe(11723);
+    expect(y).toBe(7596);
+  });
+
+  it('converts Delhi to correct tile at zoom 14', () => {
+    const { x, y } = lngLatToTile(77.2090, 28.6139, 14);
+    expect(x).toBe(11705);
+    expect(y).toBe(6831);
+  });
+
+  it('handles 0,0 (null island)', () => {
+    const { x, y } = lngLatToTile(0, 0, 14);
+    expect(x).toBe(8192);
+    expect(y).toBe(8192);
+  });
+
+  it('handles zoom 0 (single tile)', () => {
+    const { x, y } = lngLatToTile(77.5, 12.9, 0);
+    expect(x).toBe(0);
+    expect(y).toBe(0);
+  });
+
+  it('clamps to valid tile range', () => {
+    const { x, y } = lngLatToTile(180, 0, 1);
+    expect(x).toBeLessThanOrEqual(1);
+    expect(y).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('tileBounds', () => {
+  it('returns valid bounds for a Bengaluru tile', () => {
+    const b = tileBounds(11723, 7596, 14);
+    expect(b.west).toBeCloseTo(77.585, 2);
+    expect(b.east).toBeCloseTo(77.607, 2);
+    expect(b.south).toBeCloseTo(12.962, 2);
+    expect(b.north).toBeCloseTo(12.983, 2);
+  });
+
+  it('tile 0/0/0 covers the world', () => {
+    const b = tileBounds(0, 0, 0);
+    expect(b.west).toBeCloseTo(-180, 0);
+    expect(b.east).toBeCloseTo(180, 0);
+    expect(b.north).toBeCloseTo(85.05, 0);
+    expect(b.south).toBeCloseTo(-85.05, 0);
+  });
+
+  it('west < east and south < north', () => {
+    const b = tileBounds(11674, 7567, 14);
+    expect(b.west).toBeLessThan(b.east);
+    expect(b.south).toBeLessThan(b.north);
+  });
+});


### PR DESCRIPTION
## Summary
- **11 new endpoints** under `/api/v1/` with pagination, filtering, CORS
- **Locate ("Where am I?")**: `GET /api/v1/locate?lat=12.97&lng=77.59` returns all polygon layers containing that point (state, district, ward, pincode, forest, eco-zone, seismic zone). Queries PMTiles on R2, decodes MVT, ray-casting PIP. Verified with real Karnataka data (41ms).
- **Catalog API**: layers list/detail, categories, levels, download counts
- **Submissions API**: list + detail for community submissions
- **Counts + hierarchy**: per-state feature counts, LGD code resolution (requires `scripts/build_api_indexes.py` with local parquets)
- **Rate limiting**: 120 req/min per IP (60 for locate) via D1
- **Docs page**: `/docs` with full endpoint reference, nav link added
- **37 new tests** (447 total): catalog-api, tile-math, point-in-polygon, api-ratelimit
- Dependencies: @mapbox/vector-tile, pbf@4 (promoted from transitive)

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | /api/v1/layers | List with ?category, ?level, ?source, ?q, ?limit, ?offset |
| GET | /api/v1/layers/:id | Detail with filter_stats |
| GET | /api/v1/layers/:id/counts | Feature counts, optionally grouped by state |
| GET | /api/v1/categories | Categories with layer counts |
| GET | /api/v1/levels | Admin hierarchy levels |
| GET | /api/v1/downloads/counts | Live download counts from D1 |
| GET | /api/v1/locate | Point-in-polygon across all layers |
| GET | /api/v1/hierarchy/resolve | LGD code to full admin chain |
| GET | /api/v1/hierarchy/search | Text search over hierarchy |
| GET | /api/v1/submissions | List accepted community submissions |
| GET | /api/v1/submissions/:id | Single submission detail |

## Test plan
- [ ] `curl https://bharatlas.com/api/v1/layers?limit=3` returns 3 layers
- [ ] `curl https://bharatlas.com/api/v1/layers/lgd_states` returns Karnataka detail
- [ ] `curl "https://bharatlas.com/api/v1/locate?lat=12.97&lng=77.59"` returns KARNATAKA
- [ ] `curl https://bharatlas.com/api/v1/categories` shows 10 categories
- [ ] /docs page renders with nav link
- [ ] 61+ rapid requests return 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)