### PR TITLE
feat: runtime parquet query engine (schema + query)

### DIFF
--- a/web/docs.template.html
+++ b/web/docs.template.html
@@ -63,6 +63,32 @@
       <p>Single layer detail with download URLs, attribution, and column schema.</p>
       <pre><code>curl https://bharatlas.com/api/v1/layers/lgd_states</code></pre>
 
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/layers/:id/schema</span></h3>
+      <p>Column names, types, and sample values. Reads parquet metadata from R2 at runtime. Use this to discover what columns a layer has before querying.</p>
+      <pre><code>curl https://bharatlas.com/api/v1/layers/airports/schema</code></pre>
+
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/layers/:id/query</span></h3>
+      <p>Query layer data with filters and grouping. Reads the parquet from R2 at runtime, no pre-computation needed. Works for curated and community layers.</p>
+      <table>
+        <tr><th>Param</th><th>Type</th><th>Description</th></tr>
+        <tr><td><code>select</code></td><td>string</td><td>Comma-separated column names to return</td></tr>
+        <tr><td><code>where</code></td><td>string</td><td>Filters: <code>col1=val1,col2=val2</code></td></tr>
+        <tr><td><code>group_by</code></td><td>string</td><td>Group by column, returns value counts</td></tr>
+        <tr><td><code>limit</code></td><td>int</td><td>Max rows (default 100, max 1000)</td></tr>
+      </table>
+      <pre><code># How many airports in Bengaluru district?
+curl "https://bharatlas.com/api/v1/layers/airports/query?where=district=Bengaluru Urban&amp;select=name,type"
+
+# How many reserve forests in Karnataka?
+curl "https://bharatlas.com/api/v1/layers/soi_forests/query?where=State_LGD=29&amp;group_by=type"
+
+# National parks vs wildlife sanctuaries
+curl "https://bharatlas.com/api/v1/layers/gs_wildlife/query?group_by=type"
+
+# Which blocks are in district 571?
+curl "https://bharatlas.com/api/v1/layers/lgd_blocks/query?where=Dist_LGD=571&amp;select=BNAME,Block_LGD"</code></pre>
+      <p>Columns with geometry data (geom, wkb_geometry) are excluded from results. For large layers, queries may take 1-5 seconds on first call (cached afterward).</p>
+
       <h2>Locate <span class="badge badge--stable">stable</span></h2>
 
       <h3><span class="method">GET</span> <span class="endpoint">/api/v1/locate</span></h3>

--- a/web/functions/api/v1/layers/[id]/query.ts
+++ b/web/functions/api/v1/layers/[id]/query.ts
@@ -1,0 +1,61 @@
+import type { Env } from '../../../_middleware';
+import { loadCatalog } from '../../../../lib/catalog-loader';
+import { r2KeyFromLayer, asyncBufferFromR2 } from '../../../../lib/parquet-r2';
+import { query } from '../../../../lib/parquet-query';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const id = (ctx.params as { id: string }).id;
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    return json(400, { error: 'Invalid layer ID', status: 400 });
+  }
+
+  const url = new URL(ctx.request.url);
+  const catalog = await loadCatalog(url.origin);
+  const layer = catalog.layers.find((l) => l.id === id);
+  if (!layer) return json(404, { error: 'Layer not found', status: 404 });
+
+  const r2Key = r2KeyFromLayer(layer);
+  if (!r2Key) return json(404, { error: 'No parquet file for this layer', status: 404 });
+
+  // Parse query params
+  const select = url.searchParams.get('select')?.split(',').map((s) => s.trim()).filter(Boolean);
+  const groupBy = url.searchParams.get('group_by') || undefined;
+  const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') || '100', 10), 1), 1000);
+
+  // Parse where: supports ?where=col1=val1,col2=val2 or ?col1=val1&col2=val2 style
+  const where: Record<string, string> = {};
+  const whereParam = url.searchParams.get('where');
+  if (whereParam) {
+    for (const pair of whereParam.split(',')) {
+      const eq = pair.indexOf('=');
+      if (eq > 0) where[pair.slice(0, eq).trim()] = pair.slice(eq + 1).trim();
+    }
+  }
+  // Also check for direct column=value params (skip reserved params)
+  const reserved = new Set(['select', 'group_by', 'limit', 'where', 'order_by']);
+  for (const [k, v] of url.searchParams.entries()) {
+    if (!reserved.has(k) && v) where[k] = v;
+  }
+
+  try {
+    const start = Date.now();
+    const file = await asyncBufferFromR2(ctx.env.R2, r2Key);
+    const result = await query(file, { select, where: Object.keys(where).length ? where : undefined, groupBy, limit });
+    const timing = Date.now() - start;
+
+    return new Response(JSON.stringify({ data: result, layer_id: id, timing_ms: timing }), {
+      headers: {
+        'content-type': 'application/json',
+        'cache-control': groupBy ? 'public, max-age=3600, stale-while-revalidate=86400' : 'public, max-age=300, stale-while-revalidate=3600',
+      },
+    });
+  } catch (e) {
+    const msg = (e as Error).message;
+    if (msg.includes('not found')) return json(400, { error: msg, status: 400 });
+    return json(500, { error: `Query failed: ${msg}`, status: 500 });
+  }
+};
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}

--- a/web/functions/api/v1/layers/[id]/schema.ts
+++ b/web/functions/api/v1/layers/[id]/schema.ts
@@ -1,0 +1,35 @@
+import type { Env } from '../../../_middleware';
+import { loadCatalog } from '../../../../lib/catalog-loader';
+import { r2KeyFromLayer, asyncBufferFromR2 } from '../../../../lib/parquet-r2';
+import { getSchema } from '../../../../lib/parquet-query';
+
+const CACHE = 'public, max-age=86400, stale-while-revalidate=86400';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const id = (ctx.params as { id: string }).id;
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    return json(400, { error: 'Invalid layer ID', status: 400 });
+  }
+
+  const url = new URL(ctx.request.url);
+  const catalog = await loadCatalog(url.origin);
+  const layer = catalog.layers.find((l) => l.id === id);
+  if (!layer) return json(404, { error: 'Layer not found', status: 404 });
+
+  const r2Key = r2KeyFromLayer(layer);
+  if (!r2Key) return json(404, { error: 'No parquet file for this layer', status: 404 });
+
+  try {
+    const file = await asyncBufferFromR2(ctx.env.R2, r2Key);
+    const schema = await getSchema(file);
+    return new Response(JSON.stringify({ data: schema }), {
+      headers: { 'content-type': 'application/json', 'cache-control': CACHE },
+    });
+  } catch (e) {
+    return json(500, { error: `Schema read failed: ${(e as Error).message}`, status: 500 });
+  }
+};
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}

--- a/web/functions/lib/parquet-query.ts
+++ b/web/functions/lib/parquet-query.ts
@@ -1,0 +1,194 @@
+/**
+ * Generic parquet query engine backed by hyparquet + R2.
+ * Reads only the columns needed, supports where filters and group_by.
+ * No hardcoded layer or column names.
+ */
+import { parquetMetadataAsync, parquetQuery } from 'hyparquet';
+import type { AsyncBuffer } from './parquet-r2';
+
+export interface ColumnSchema {
+  name: string;
+  type: string;
+  sample?: unknown[];
+}
+
+export interface QueryResult {
+  columns: string[];
+  rows: Record<string, unknown>[];
+  total: number;
+  truncated: boolean;
+}
+
+export interface GroupByResult {
+  column: string;
+  counts: Record<string, number>;
+  total: number;
+}
+
+const MAX_ROWS = 1000;
+const MAX_GROUP_BY_VALUES = 500;
+const SAMPLE_SIZE = 5;
+
+export async function getSchema(file: AsyncBuffer): Promise<{
+  row_count: number;
+  columns: ColumnSchema[];
+}> {
+  const metadata = await parquetMetadataAsync(file);
+  const rowCount = metadata.row_groups.reduce((s, rg) => s + Number(rg.num_rows), 0);
+
+  const columns: ColumnSchema[] = [];
+  for (const el of metadata.schema.slice(1)) {
+    if (!el.name || el.name.toLowerCase().includes('geom') || el.name === 'wkb_geometry') continue;
+    columns.push({
+      name: el.name,
+      type: schemaType(el.type, el.converted_type),
+    });
+  }
+
+  // Read a few rows to get sample values
+  if (rowCount > 0 && columns.length > 0) {
+    const colNames = columns.map((c) => c.name);
+    const sampleRows: Record<string, unknown>[] = [];
+    await parquetQuery({
+      file,
+      columns: colNames,
+      rowEnd: Math.min(SAMPLE_SIZE, rowCount),
+      onComplete: (rows: Record<string, unknown>[]) => sampleRows.push(...rows),
+    });
+    for (const col of columns) {
+      const vals = sampleRows
+        .map((r) => r[col.name])
+        .filter((v) => v !== null && v !== undefined);
+      if (vals.length > 0) col.sample = vals.slice(0, SAMPLE_SIZE);
+    }
+  }
+
+  return { row_count: rowCount, columns };
+}
+
+export async function query(
+  file: AsyncBuffer,
+  opts: {
+    select?: string[];
+    where?: Record<string, string>;
+    groupBy?: string;
+    limit?: number;
+    orderBy?: string;
+  },
+): Promise<QueryResult | GroupByResult> {
+  const metadata = await parquetMetadataAsync(file);
+  const allCols = metadata.schema.slice(1).map((e) => e.name).filter(Boolean) as string[];
+
+  if (opts.groupBy) {
+    return groupByQuery(file, allCols, opts.groupBy, opts.where);
+  }
+
+  return selectQuery(file, allCols, opts);
+}
+
+async function selectQuery(
+  file: AsyncBuffer,
+  allCols: string[],
+  opts: { select?: string[]; where?: Record<string, string>; limit?: number },
+): Promise<QueryResult> {
+  const selectCols = opts.select?.length
+    ? opts.select.filter((c) => allCols.includes(c))
+    : allCols.filter((c) => !c.toLowerCase().includes('geom') && c !== 'wkb_geometry');
+
+  if (selectCols.length === 0) {
+    return { columns: [], rows: [], total: 0, truncated: false };
+  }
+
+  const limit = Math.min(opts.limit ?? 100, MAX_ROWS);
+  const allRows: Record<string, unknown>[] = [];
+
+  await parquetQuery({
+    file,
+    columns: selectCols,
+    onComplete: (rows: Record<string, unknown>[]) => allRows.push(...rows),
+  });
+
+  // Apply where filters in JS (hyparquet reads all rows, we filter post-hoc)
+  let filtered = allRows;
+  if (opts.where && Object.keys(opts.where).length > 0) {
+    filtered = allRows.filter((row) =>
+      Object.entries(opts.where!).every(([col, val]) => {
+        const rv = row[col];
+        if (rv === null || rv === undefined) return false;
+        return String(rv).toLowerCase() === val.toLowerCase();
+      }),
+    );
+  }
+
+  const total = filtered.length;
+  const truncated = total > limit;
+  const rows = filtered.slice(0, limit);
+
+  return { columns: selectCols, rows, total, truncated };
+}
+
+async function groupByQuery(
+  file: AsyncBuffer,
+  allCols: string[],
+  groupCol: string,
+  where?: Record<string, string>,
+): Promise<GroupByResult> {
+  if (!allCols.includes(groupCol)) {
+    const available = allCols.filter((c) => !c.toLowerCase().includes('geom') && c !== 'wkb_geometry');
+    throw new Error(`Column "${groupCol}" not found. Available: ${available.join(', ')}`);
+  }
+
+  // Read only the columns needed: groupBy col + any where filter cols
+  const readCols = new Set([groupCol]);
+  if (where) Object.keys(where).forEach((c) => readCols.add(c));
+  const colList = [...readCols].filter((c) => allCols.includes(c));
+
+  const allRows: Record<string, unknown>[] = [];
+  await parquetQuery({
+    file,
+    columns: colList,
+    onComplete: (rows: Record<string, unknown>[]) => allRows.push(...rows),
+  });
+
+  // Apply where filters
+  let filtered = allRows;
+  if (where && Object.keys(where).length > 0) {
+    filtered = allRows.filter((row) =>
+      Object.entries(where).every(([col, val]) => {
+        const rv = row[col];
+        if (rv === null || rv === undefined) return false;
+        return String(rv).toLowerCase() === val.toLowerCase();
+      }),
+    );
+  }
+
+  // Group by
+  const counts: Record<string, number> = {};
+  for (const row of filtered) {
+    const key = String(row[groupCol] ?? '(null)');
+    counts[key] = (counts[key] || 0) + 1;
+  }
+
+  // Sort by count descending, cap at MAX_GROUP_BY_VALUES
+  const sorted = Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, MAX_GROUP_BY_VALUES);
+
+  return {
+    column: groupCol,
+    counts: Object.fromEntries(sorted),
+    total: filtered.length,
+  };
+}
+
+function schemaType(type?: string | number, convertedType?: string | number): string {
+  const t = String(type ?? '').toUpperCase();
+  if (t.includes('INT') || t.includes('FLOAT') || t.includes('DOUBLE')) return 'number';
+  if (t.includes('BYTE_ARRAY') || t.includes('FIXED')) {
+    const ct = String(convertedType ?? '').toUpperCase();
+    if (ct.includes('UTF8') || ct.includes('STRING')) return 'string';
+    return 'binary';
+  }
+  if (t.includes('BOOLEAN')) return 'boolean';
+  return 'string';
+}

--- a/web/functions/lib/parquet-r2.ts
+++ b/web/functions/lib/parquet-r2.ts
@@ -1,0 +1,32 @@
+/**
+ * R2-backed AsyncBuffer for hyparquet. Reads parquet files from R2
+ * via range requests without loading the entire file into memory.
+ */
+import type { CatalogLayer } from './catalog-api';
+
+export interface AsyncBuffer {
+  byteLength: number;
+  slice(start: number, end?: number): Promise<ArrayBuffer>;
+}
+
+export function r2KeyFromLayer(layer: CatalogLayer): string | null {
+  const url = layer.parquet?.url;
+  if (!url) return null;
+  return url.replace(/^https:\/\/[^/]+\//, '');
+}
+
+export async function asyncBufferFromR2(r2: R2Bucket, key: string): Promise<AsyncBuffer> {
+  const head = await r2.head(key);
+  if (!head) throw new Error(`R2 key not found: ${key}`);
+  const byteLength = head.size;
+
+  return {
+    byteLength,
+    async slice(start: number, end?: number): Promise<ArrayBuffer> {
+      const length = (end ?? byteLength) - start;
+      const obj = await r2.get(key, { range: { offset: start, length } });
+      if (!obj) throw new Error(`R2 range read failed: ${key} [${start}:${start + length}]`);
+      return obj.arrayBuffer();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Reads parquets directly from R2 at runtime via hyparquet (pure JS, no WASM). No build-time precomputation. Works for curated + community layers identically.

### New endpoints
- `GET /api/v1/layers/:id/schema` -- column names, types, sample values
- `GET /api/v1/layers/:id/query` -- filter, select, group_by on any column

### Examples
```bash
# Discover columns
curl .../api/v1/layers/airports/schema

# How many airports in Bengaluru district?
curl ".../api/v1/layers/airports/query?where=district=Bengaluru Urban&select=name,type"

# Reserve forests in Karnataka
curl ".../api/v1/layers/soi_forests/query?where=State_LGD=29&group_by=type"

# National parks vs wildlife sanctuaries
curl ".../api/v1/layers/gs_wildlife/query?group_by=type"
```

## Test plan
- [ ] `/api/v1/layers/airports/schema` returns columns with samples
- [ ] `/api/v1/layers/airports/query?group_by=type` returns airport type counts
- [ ] `/api/v1/layers/lgd_blocks/query?where=Dist_LGD=571&select=BNAME` returns Bengaluru blocks
- [ ] Query results cached (second call faster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)