### PR TITLE
fix: add ZSTD decompression for parquet queries

### DIFF
--- a/web/functions/lib/parquet-query.ts
+++ b/web/functions/lib/parquet-query.ts
@@ -4,6 +4,7 @@
  * No hardcoded layer or column names.
  */
 import { parquetMetadataAsync, parquetQuery } from 'hyparquet';
+import { compressors } from 'hyparquet-compressors';
 import type { AsyncBuffer } from './parquet-r2';
 
 export interface ColumnSchema {
@@ -49,7 +50,7 @@ export async function getSchema(file: AsyncBuffer): Promise<{
   if (rowCount > 0 && columns.length > 0) {
     const colNames = columns.map((c) => c.name);
     const sampleRows: Record<string, unknown>[] = [];
-    await parquetQuery({
+    await parquetQuery({ compressors,
       file,
       columns: colNames,
       rowEnd: Math.min(SAMPLE_SIZE, rowCount),

--- a/web/functions/lib/parquet-query.ts
+++ b/web/functions/lib/parquet-query.ts
@@ -3,7 +3,7 @@
  * Reads only the columns needed, supports where filters and group_by.
  * No hardcoded layer or column names.
  */
-import { parquetMetadataAsync, parquetQuery } from 'hyparquet/src/index.js';
+import { parquetMetadataAsync, parquetQuery } from 'hyparquet';
 import type { AsyncBuffer } from './parquet-r2';
 
 export interface ColumnSchema {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "@resvg/resvg-wasm": "^2.6.2",
         "@tmcw/togeojson": "^5.8.1",
         "hyparquet": "^1.26.0",
+        "hyparquet-compressors": "^1.1.1",
         "jszip": "^3.10.1",
         "maplibre-gl": "^4.7.1",
         "pbf": "^4.0.2",
@@ -1522,6 +1523,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
+    },
     "node_modules/geojson-vt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.3.tgz",
@@ -1646,6 +1653,22 @@
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.26.0.tgz",
       "integrity": "sha512-yxUiViPZ+z5h+xdX4rA1G+k30jXoEsG9I2xEpjaM84imGznbKjZzxuZFsdzqg6C4LxNnnAlDFvzpk4uxQWTbTQ==",
+      "license": "MIT"
+    },
+    "node_modules/hyparquet-compressors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyparquet-compressors/-/hyparquet-compressors-1.1.1.tgz",
+      "integrity": "sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A==",
+      "license": "MIT",
+      "dependencies": {
+        "fzstd": "0.1.1",
+        "hysnappy": "1.0.0"
+      }
+    },
+    "node_modules/hysnappy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hysnappy/-/hysnappy-1.0.0.tgz",
+      "integrity": "sha512-MNrC4NfwDGPb889O6gIfEtbvEZCSWUsSEhsz4Oq2FRcpGtXHfeVz3KciSPp5Pnnz1NjFMgDQNfxdJozymJEDDA==",
       "license": "MIT"
     },
     "node_modules/ieee754": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "@resvg/resvg-wasm": "^2.6.2",
     "@tmcw/togeojson": "^5.8.1",
     "hyparquet": "^1.26.0",
+    "hyparquet-compressors": "^1.1.1",
     "jszip": "^3.10.1",
     "maplibre-gl": "^4.7.1",
     "pbf": "^4.0.2",


### PR DESCRIPTION
Parquets use ZSTD. Add hyparquet-compressors.