### PR TITLE
fix: query engine BigInt, where-column reads, row projection

### DIFF
--- a/web/docs.template.html
+++ b/web/docs.template.html
@@ -72,7 +72,7 @@
       <table>
         <tr><th>Param</th><th>Type</th><th>Description</th></tr>
         <tr><td><code>select</code></td><td>string</td><td>Comma-separated column names to return</td></tr>
-        <tr><td><code>where</code></td><td>string</td><td>Filters: <code>col1=val1,col2=val2</code></td></tr>
+        <tr><td><code>where</code></td><td>string</td><td>Filters: <code>col1=val1,col2=val2</code>. Or pass columns directly as params: <code>?state=KA&amp;type=INTERNATIONAL</code></td></tr>
         <tr><td><code>group_by</code></td><td>string</td><td>Group by column, returns value counts</td></tr>
         <tr><td><code>limit</code></td><td>int</td><td>Max rows (default 100, max 1000)</td></tr>
       </table>

--- a/web/functions/api/v1/layers/[id]/query.ts
+++ b/web/functions/api/v1/layers/[id]/query.ts
@@ -43,7 +43,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
     const result = await query(file, { select, where: Object.keys(where).length ? where : undefined, groupBy, limit });
     const timing = Date.now() - start;
 
-    return new Response(JSON.stringify({ data: result, layer_id: id, timing_ms: timing }), {
+    return new Response(safeStringify({ data: result, layer_id: id, timing_ms: timing }), {
       headers: {
         'content-type': 'application/json',
         'cache-control': groupBy ? 'public, max-age=3600, stale-while-revalidate=86400' : 'public, max-age=300, stale-while-revalidate=3600',
@@ -56,6 +56,10 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   }
 };
 
+function safeStringify(obj: unknown): string {
+  return JSON.stringify(obj, (_k, v) => typeof v === 'bigint' ? Number(v) : v);
+}
+
 function json(status: number, body: unknown) {
-  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+  return new Response(safeStringify(body), { status, headers: { 'content-type': 'application/json' } });
 }

--- a/web/functions/api/v1/layers/[id]/schema.ts
+++ b/web/functions/api/v1/layers/[id]/schema.ts
@@ -22,7 +22,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   try {
     const file = await asyncBufferFromR2(ctx.env.R2, r2Key);
     const schema = await getSchema(file);
-    return new Response(JSON.stringify({ data: schema }), {
+    return new Response(safeStringify({ data: schema }), {
       headers: { 'content-type': 'application/json', 'cache-control': CACHE },
     });
   } catch (e) {
@@ -30,6 +30,10 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   }
 };
 
+function safeStringify(obj: unknown): string {
+  return JSON.stringify(obj, (_k, v) => typeof v === 'bigint' ? Number(v) : v);
+}
+
 function json(status: number, body: unknown) {
-  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+  return new Response(safeStringify(body), { status, headers: { 'content-type': 'application/json' } });
 }

--- a/web/functions/lib/parquet-query.ts
+++ b/web/functions/lib/parquet-query.ts
@@ -97,8 +97,12 @@ async function selectQuery(
     return { columns: [], rows: [], total: 0, truncated: false };
   }
 
+  // Include where-filter columns in the read set so filtering works
+  const readCols = new Set(selectCols);
+  if (opts.where) Object.keys(opts.where).forEach((c) => { if (allCols.includes(c)) readCols.add(c); });
+
   const limit = Math.min(opts.limit ?? 100, MAX_ROWS);
-  const allRows = await parquetQuery({ compressors, file, columns: selectCols });
+  const allRows = await parquetQuery({ compressors, file, columns: [...readCols] });
 
   let filtered = allRows as Record<string, unknown>[];
   if (opts.where && Object.keys(opts.where).length > 0) {
@@ -113,7 +117,12 @@ async function selectQuery(
 
   const total = filtered.length;
   const truncated = total > limit;
-  const rows = filtered.slice(0, limit);
+  // Project back to only the requested columns
+  const rows = filtered.slice(0, limit).map((row) => {
+    const out: Record<string, unknown> = {};
+    for (const c of selectCols) out[c] = row[c];
+    return out;
+  });
 
   return { columns: selectCols, rows, total, truncated };
 }


### PR DESCRIPTION
## Summary
Three fixes found during thorough local testing with real airports parquet:
- **BigInt crash**: parquet int64 values came back as BigInt which JSON.stringify can't handle. Added safe serializer.
- **Cross-column where filter**: `?state=KA&select=name,type` returned 0 rows because `state` wasn't in the parquetQuery read set. Now auto-includes where-filter columns.
- **Row projection**: response rows now contain only the requested select columns, not the extra where-filter columns.
- **Docs**: added note about direct `?column=value` param syntax.

## Local test results
```
151 airports, 10 in Karnataka (KA)
  Kempegowda International Airport (INTERNATIONAL) — Bangalore Rural
  HAL Aerospace (DOMESTIC AIRPORT) — Bangalore
  Mysore Airport (DOMESTIC AIRPORT) — Mysore
  ...
group_by=type: DOMESTIC AIRPORT: 89, INTERNATIONAL: 29, ...
group_by=district (where state=KA): Bangalore: 2, Mysore: 1, ...
```

## Test plan
- [ ] `curl .../api/v1/layers/airports/schema` returns columns with samples (no BigInt crash)
- [ ] `curl .../api/v1/layers/airports/query?state=KA&select=name,type` returns 10 airports
- [ ] `curl .../api/v1/layers/airports/query?group_by=type` returns type counts
- [ ] /docs page shows direct param syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)