### PR TITLE
docs: README + /docs + /mcp update for API v1 + MCP launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![uptime](https://img.shields.io/website?url=https%3A%2F%2Fbharatlas.com&label=bharatlas.com)](https://bharatlas.com)
 [![Lighthouse: 98+](https://img.shields.io/badge/Lighthouse-98%2B-brightgreen?logo=lighthouse)](https://pagespeed.web.dev/analysis?url=https%3A%2F%2Fbharatlas.com)
 
-A visual catalog, drag-drop verifier, and anonymous contribution flow for India's geo data. Admin boundaries from state to village, plus community-submitted layers under open licences.
+A visual catalog, REST API, MCP server, drag-drop verifier, and anonymous contribution flow for India's geo data. Admin boundaries from state to village, plus community-submitted layers under open licences.
 
 **Live**: https://bharatlas.com
 
@@ -28,6 +28,11 @@ view (/view/<id>)     → curated layer with per-layer OG card
 view (/c/<id>)        → community submission, edge-rendered HTML, 👍 useful
                         vote, per-submission OG card
 embed                 → /embed/<id> iframe + PNG export from any map
+API (/api/v1)         → REST API: list, query, filter, group_by any layer;
+                        locate (point-in-polygon across all layers);
+                        nearby (tile-based spatial proximity)
+MCP (npx bharatlas-mcp) → 8 tools for LLMs: list, schema, query, locate,
+                        nearby, categories, submissions, downloads
 ```
 
 ## What's in this repo
@@ -43,6 +48,7 @@ embed                 → /embed/<id> iframe + PNG export from any map
 | `scripts/upload_r2.sh` | Mirrors `sources/` + `data/` to Cloudflare R2 via wrangler. |
 | `scripts/upload_baked.py` | Pushes `data/baked/*` to R2 via boto3 (S3-compat fallback when wrangler is unavailable). |
 | `scripts/admin/cleanup_submission.sh` | Delete community submissions by name pattern (R2 + D1). |
+| `mcp/` | MCP server for LLMs ([npm](https://www.npmjs.com/package/bharatlas-mcp)). 8 tools: list, schema, query, locate, nearby, categories, submissions, downloads. |
 | `catalog.json` | Curated-layer index used by the viewer. Single source of truth. |
 | [/about#caveats](https://bharatlas.com/about#caveats) | Data caveats (cross-source drift, coverage gaps, precision). |
 
@@ -54,7 +60,10 @@ Large data files (`sources/`, `data/`) are not in git — they live in R2. See `
 |---|---|
 | Frontend | Vanilla TypeScript, Vite, MapLibre GL JS, PMTiles, DuckDB-WASM (lazy) |
 | Static hosting | Cloudflare Pages |
-| Edge functions | Cloudflare Pages Functions (`web/functions/`) — submit, vote, sitemap, edge-rendered `/c/<id>` |
+| Edge functions | Cloudflare Pages Functions (`web/functions/`) — REST API v1, submit, vote, sitemap, edge-rendered `/c/<id>` |
+| Parquet query | [hyparquet](https://github.com/hyparam/hyparquet) (pure JS, runtime reads from R2) |
+| Spatial query | PMTiles tile reads + MVT decode + ray-casting PIP / Haversine proximity |
+| MCP server | [`bharatlas-mcp`](https://www.npmjs.com/package/bharatlas-mcp) — 8 tools for Claude, GPT, Gemini, Cursor, etc. |
 | Storage | Cloudflare R2 (open data, no egress) |
 | Submissions DB | Cloudflare D1 (SQLite at the edge) |
 | Anti-abuse | Cloudflare Turnstile + per-IP rate limits |
@@ -68,7 +77,7 @@ git clone git@github.com:urbanmorph/geodata.git
 cd geodata/web
 npm install
 npm run dev    # http://localhost:5173
-npm test       # 410+ vitest tests
+npm test       # 447+ vitest tests
 ```
 
 For the full submission flow (D1 + R2 + Turnstile + Pages Functions), see [docs/full-dev.md](./docs/full-dev.md) (TODO) or read `wrangler.toml` + `.dev.vars.example`.
@@ -85,8 +94,8 @@ Commit messages: short subject, body explains *why* not *what*. Examples in `git
 
 ## Roadmap
 
-- **Next**: REST API + MCP server + Claude Code plugin (v5)
-- **Shipped**: CSP; catalog with cross-source compare; in-browser filter + slice + typeahead export; whole-layer downloads (Parquet / PMTiles / GeoJSON / KML / Shapefile); data vintage years on all layers; India-correct minimal basemap + national boundary layer; drag-and-drop verify + anonymous contribution; "Your submissions" panel; embed iframe + PNG export; edge-rendered `/view/<id>` + `/c/<id>` with per-layer OG cards; schema-driven dynamic filters with statistical column classification; live category counts; privacy + ToS + disputed-borders policy; a11y refactor; AEO crawler allowlist + JSON-LD (Dataset, BreadcrumbList, FAQPage, Person)
+- **Next**: mobile responsive audit; spatial join primitives; npm provenance for MCP
+- **Shipped**: REST API v1 (13 endpoints: layers, schema, query, locate, nearby, categories, levels, counts, downloads, submissions, hierarchy); MCP server ([`bharatlas-mcp`](https://www.npmjs.com/package/bharatlas-mcp)) with 8 LLM tools; CSP; catalog with cross-source compare; in-browser filter + slice + typeahead export; whole-layer downloads (Parquet / PMTiles / GeoJSON / KML / Shapefile); data vintage years on all layers; India-correct minimal basemap + national boundary layer; drag-and-drop verify + anonymous contribution; "Your submissions" panel; embed iframe + PNG export; edge-rendered `/view/<id>` + `/c/<id>` with per-layer OG cards; schema-driven dynamic filters with statistical column classification; live category counts; privacy + ToS + disputed-borders policy; a11y refactor; AEO crawler allowlist + JSON-LD (Dataset, BreadcrumbList, FAQPage, Person)
 
 Track active work in [Issues](https://github.com/urbanmorph/geodata/issues) and [Milestones](https://github.com/urbanmorph/geodata/milestones).
 
@@ -126,4 +135,4 @@ Pipelines + patterns:
 
 Built by [Urban Morph](https://urbanmorph.com) · [Sathya Sankaran](https://www.sathyasankaran.com). Drop a ⭐ if you find it useful.
 
-**Status:** v1.0. 77 curated layers, community submissions, dynamic filters with typeahead, whole-layer downloads in 5 formats. The schema and external API may still shift. Community submissions are permanent under the open licence the contributor selected.
+**Status:** v1.0. 77 curated layers, community submissions, REST API v1 (13 endpoints), MCP server (8 tools, [npm](https://www.npmjs.com/package/bharatlas-mcp)), dynamic filters with typeahead, whole-layer downloads in 5 formats. API docs at [/docs](https://bharatlas.com/docs), MCP setup at [/mcp](https://bharatlas.com/mcp). Community submissions are permanent under the open licence the contributor selected.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,84 @@
+# bharatlas-mcp
+
+[![npm](https://img.shields.io/npm/v/bharatlas-mcp)](https://www.npmjs.com/package/bharatlas-mcp)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+
+Ask questions about India's geo data in natural language. This MCP server connects any LLM to bharatlas: open-licensed layers covering admin boundaries (state to village), city wards, forests, wildlife sanctuaries, rivers, reservoirs, dams, eco-sensitive zones, seismic zones, flood history, highways, airports, health facilities, pincodes, electoral constituencies, and community submissions.
+
+## Install
+
+Add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "bharatlas": {
+      "command": "npx",
+      "args": ["-y", "bharatlas-mcp"]
+    }
+  }
+}
+```
+
+**Where to put it:**
+
+| Client | Config file |
+|--------|------------|
+| Claude Code | `.mcp.json` (project root) or `~/.claude.json` |
+| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Cursor | `~/.cursor/mcp.json` |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` |
+| VS Code | `.vscode/mcp.json` |
+
+## Tools
+
+| Tool | What it does |
+|------|-------------|
+| **list_layers** | Discover layers by category, level, source, or text search |
+| **get_layer_schema** | Column names, types, distinct values. Call before querying. |
+| **query_layer** | Filter, select, group_by on any column. Runtime parquet reads. |
+| **locate** | Point-in-polygon: what state, district, ward, zone is this point in? |
+| **nearby** | Find features within a radius. Works for points, polygons, and lines. |
+| **get_layer_detail** | Download URLs in 5 formats (parquet, pmtiles, geojson, kml, shapefile) |
+| **list_categories** | Browse categories with layer counts |
+| **list_submissions** | Community-contributed layers under open licenses |
+
+## What you can ask
+
+**Counting and filtering**
+- "How many national parks vs wildlife sanctuaries?" (101 vs 560)
+- "How many villages in Bengaluru Urban district?" (949)
+- "How many health facilities in Bihar?" (8,363: 3,232 sub-centres, 591 PHCs, 74 CHCs)
+- "How many wards does Chennai have vs Pune?" (200 vs 58)
+
+**Spatial**
+- "What state, district, seismic zone is Bengaluru in?" (Karnataka, Bengaluru Urban, Zone II)
+- "Reservoirs within 50km of Bengaluru?" (12 found)
+- "Wildlife sanctuaries near Mysuru?" (Ranganathittu 15km, Nagarahole NP 60km)
+
+**Cross-layer**
+- "Which airports in Karnataka are near water bodies?" (Hubballi: Unkal Lake 2.3km, 14 rivers)
+- "Which blocks are in district 571?" (10 blocks: Kunigal, Tumakuru, Gubbi...)
+- "Which villages in Madhya Pradesh are in eco-sensitive zones?" (narrows by district, then locates)
+
+## How it works
+
+Thin wrapper over the [bharatlas REST API](https://bharatlas.com/docs). Each tool call becomes one or more API requests to Cloudflare Workers that read parquet files and PMTiles directly from R2 at runtime. No pre-computation, no API key, no auth.
+
+The server sends instructions to the LLM at connection time that teach:
+- **Schema-first pattern**: check column names and sample values before querying (column names vary: `state` vs `State_LGD` vs `stname`)
+- **Source preference**: LGD for admin boundaries, with SOI/Bhuvan/geoBoundaries as alternates
+- **Concept-to-layer mapping**: "water bodies" = rivers + reservoirs + wetlands + ramsar sites + dams
+- **Spatial join workflow**: locate for context, query for data, nearby for proximity
+
+## Links
+
+- [bharatlas.com](https://bharatlas.com) -- the atlas
+- [REST API docs](https://bharatlas.com/docs)
+- [MCP setup guide](https://bharatlas.com/mcp) -- install + example questions
+- [GitHub](https://github.com/urbanmorph/geodata) -- source code
+- [npm](https://www.npmjs.com/package/bharatlas-mcp) -- this package
+
+## License
+
+MIT. Data: each layer carries its own open license (CC0, CC-BY, ODbL, GODL-India).

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,10 @@
 {
   "name": "bharatlas-mcp",
-  "version": "1.0.0",
-  "description": "MCP server for India's open geo data. Query 77 layers, locate points, filter and group data.",
+  "version": "1.0.1",
+  "description": "MCP server for India's open geo data. Query layers, locate points, find nearby features, filter and group data.",
+  "keywords": ["mcp", "india", "geo", "geospatial", "gis", "boundaries", "parquet", "pmtiles", "llm", "claude", "bharatlas"],
+  "repository": { "type": "git", "url": "https://github.com/urbanmorph/geodata", "directory": "mcp" },
+  "homepage": "https://bharatlas.com/mcp",
   "type": "module",
   "main": "index.js",
   "bin": {

--- a/web/about.template.html
+++ b/web/about.template.html
@@ -68,7 +68,8 @@
     <ul>
       <li><strong>Journalists + researchers:</strong> pull a state's districts, villages or constituencies in ten seconds; download as GeoJSON or Parquet.</li>
       <li><strong>Civic technologists:</strong> share city-scale layers (wards, bike lanes, polling booths) with attribution baked in.</li>
-      <li><strong>App developers:</strong> direct PMTiles URLs, no rate limits, no API key.</li>
+      <li><strong>App developers:</strong> <a href="/docs">REST API</a> with 13 endpoints, direct PMTiles URLs, no rate limits, no API key.</li>
+      <li><strong>AI agents:</strong> <a href="/mcp">MCP server</a> (<code>npx bharatlas-mcp</code>) connects Claude, GPT, or any LLM to all 77 layers.</li>
     </ul>
     <p>If you came looking for places to visit, you want Google. If you want to fix the base map itself, you want OSM.</p>
 

--- a/web/docs.template.html
+++ b/web/docs.template.html
@@ -89,7 +89,7 @@ curl "https://bharatlas.com/api/v1/layers/gs_wildlife/query?group_by=type"
 curl "https://bharatlas.com/api/v1/layers/lgd_blocks/query?where=Dist_LGD=571&amp;select=BNAME,Block_LGD"</code></pre>
       <p>Columns with geometry data (geom, wkb_geometry) are excluded from results. For large layers, queries may take 1-5 seconds on first call (cached afterward).</p>
 
-      <h2>Locate <span class="badge badge--stable">stable</span></h2>
+      <h2>Spatial</h2>
 
       <h3><span class="method">GET</span> <span class="endpoint">/api/v1/locate</span></h3>
       <p>Given a lat/lng, returns all polygon layers that contain that point: state, district, ward, pincode, forest, eco-zone, seismic zone, and more. The "where am I?" endpoint.</p>
@@ -116,6 +116,22 @@ curl "https://bharatlas.com/api/v1/layers/lgd_blocks/query?where=Dist_LGD=571&am
   "queried_layers": ["lgd_states", "lgd_districts", ...],
   "timing_ms": 450
 }</code></pre>
+
+      <h3><span class="method">GET</span> <span class="endpoint">/api/v1/nearby</span></h3>
+      <p>Find features from any layer near a point. Reads PMTiles tiles in a radius, extracts features with computed centroids, filters by Haversine distance. Works for points, polygons, and lines.</p>
+      <table>
+        <tr><th>Param</th><th>Type</th><th>Description</th></tr>
+        <tr><td><code>lat</code></td><td>float <b>*</b></td><td>Center latitude (6-38)</td></tr>
+        <tr><td><code>lng</code></td><td>float <b>*</b></td><td>Center longitude (68-98)</td></tr>
+        <tr><td><code>layer</code></td><td>string <b>*</b></td><td>Layer ID to search</td></tr>
+        <tr><td><code>radius_km</code></td><td>float</td><td>Search radius in km (default 25, max 200)</td></tr>
+        <tr><td><code>limit</code></td><td>int</td><td>Max results (default 20, max 100)</td></tr>
+      </table>
+      <pre><code># Reservoirs within 50km of Bengaluru
+curl "https://bharatlas.com/api/v1/nearby?lat=12.97&amp;lng=77.59&amp;layer=wris_reservoirs&amp;radius_km=50"
+
+# Wildlife sanctuaries within 100km of Mysuru
+curl "https://bharatlas.com/api/v1/nearby?lat=12.30&amp;lng=76.65&amp;layer=gs_wildlife&amp;radius_km=100"</code></pre>
 
       <h2>Categories and Levels</h2>
 
@@ -175,9 +191,17 @@ curl https://bharatlas.com/api/v1/layers/wards_pcmc/counts?group_by=zone</code><
       <p>Errors return:</p>
       <pre><code>{ "error": "Not found", "status": 404 }</code></pre>
 
-      <h2>Stability</h2>
-      <p>All v1 endpoints follow additive-only evolution: new fields may appear, but existing fields will not be renamed or removed. If a breaking change is needed, it ships as v2.</p>
-      <p>Rate limits: reads are unlimited. Cloudflare DDoS protection applies. Write endpoints (submission, rating) are rate-limited per IP.</p>
+      <h2>Rate Limits</h2>
+      <table>
+        <tr><th>Endpoint</th><th>Limit</th></tr>
+        <tr><td>All read endpoints</td><td>120 requests/minute per IP</td></tr>
+        <tr><td><code>/locate</code>, <code>/nearby</code></td><td>60 requests/minute per IP</td></tr>
+        <tr><td>Submissions (write)</td><td>5/hour, 20/day per IP</td></tr>
+      </table>
+      <p>Exceeded limits return <code>429</code> with a <code>retry-after</code> header. Cloudflare DDoS protection applies to all endpoints.</p>
+
+      <h2>Versioning</h2>
+      <p>All v1 endpoints follow additive-only evolution: new fields may appear, but existing fields will not be renamed or removed. If a breaking change is needed, it ships as v2. All responses include an <code>x-api-version: v1</code> header.</p>
 
       <h2>Download Formats</h2>
       <p>Each layer may offer up to 5 formats. Use the <code>downloads</code> object from <code>/api/v1/layers/:id</code> to get direct URLs:</p>
@@ -189,6 +213,9 @@ curl https://bharatlas.com/api/v1/layers/wards_pcmc/counts?group_by=zone</code><
         <tr><td><code>kml</code></td><td>Google Earth</td></tr>
         <tr><td><code>shapefile</code></td><td>ArcGIS, legacy GIS tools</td></tr>
       </table>
+
+      <h2>For LLMs</h2>
+      <p>Use the <a href="/mcp">bharatlas MCP server</a> (<code>npx bharatlas-mcp</code>) to connect Claude, GPT, Gemini, or any MCP-compatible LLM directly to this API. 8 tools with built-in instructions for schema-first querying, spatial joins, and multi-source awareness.</p>
 
     <!-- FOOTER -->
   </body>

--- a/web/mcp.template.html
+++ b/web/mcp.template.html
@@ -72,11 +72,7 @@
 .vscode/mcp.json (project) or settings.json</code></pre>
       </div>
 
-      <div class="install-box">
-        <h3>MCP Inspector (test without an LLM)</h3>
-        <pre><code>npx @modelcontextprotocol/inspector npx bharatlas-mcp</code></pre>
-        <p>Opens a web UI to call tools interactively and inspect responses.</p>
-      </div>
+      <p style="font-size:13px;color:var(--subtle)">Developers: test tools without an LLM via <code>npx @modelcontextprotocol/inspector npx bharatlas-mcp</code></p>
 
       <h2>What you can ask</h2>
 
@@ -123,6 +119,7 @@
         <li><strong>get_layer_schema</strong> -- column names, types, distinct values (call before querying)</li>
         <li><strong>query_layer</strong> -- filter, select, group by any column, with optional centroid coordinates</li>
         <li><strong>locate</strong> -- point-in-polygon across all admin layers + zones at once</li>
+        <li><strong>nearby</strong> -- find features within a radius (works for points, polygons, and lines)</li>
         <li><strong>get_layer_detail</strong> -- download URLs in 5 formats (parquet, pmtiles, geojson, kml, shapefile)</li>
         <li><strong>list_categories</strong> -- browse by category with layer counts</li>
         <li><strong>list_submissions</strong> -- community-contributed layers under open licenses</li>
@@ -142,8 +139,12 @@
       <p>77 curated layers across 10 categories: admin boundaries (state to village), city wards (34 cities), forests, wildlife, eco-zones, rivers, reservoirs, dams, seismic zones, floods, highways, airports, health facilities, pincodes, electoral constituencies. Plus community submissions.</p>
       <p>Sources: LGD, SOI, Bhuvan, OpenCity, DataMeet, PMGSY, GatiShakti, Bharatmaps, bharatviz, CWC, data.gov.in. All open-licensed.</p>
 
-      <h2>Source</h2>
-      <p><a href="https://github.com/urbanmorph/geodata/tree/main/mcp">github.com/urbanmorph/geodata/tree/main/mcp</a></p>
+      <h2>Links</h2>
+      <ul>
+        <li><a href="https://www.npmjs.com/package/bharatlas-mcp">npm: bharatlas-mcp</a></li>
+        <li><a href="/docs">REST API reference</a></li>
+        <li><a href="https://github.com/urbanmorph/geodata/tree/main/mcp">GitHub source</a></li>
+      </ul>
 
     <!-- FOOTER -->
   </body>

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -1004,6 +1004,15 @@ await renderPage('docs', {
     "Public JSON API for India's open geo layers. List layers, locate a point across 77 datasets, download in 5 formats. No auth, no API key.",
   url: ORIGIN + '/docs',
   image: ORIGIN + '/og-default.png',
+  structuredData: {
+    '@context': 'https://schema.org',
+    '@type': 'WebAPI',
+    name: 'bharatlas API v1',
+    description: "Public JSON API for India's open geo layers. 13 endpoints: list, query, filter, locate, nearby, schema, categories, levels, counts, downloads, submissions.",
+    url: ORIGIN + '/docs',
+    provider: { '@type': 'Organization', name: 'Urban Morph', url: 'https://urbanmorph.com' },
+    documentation: ORIGIN + '/docs',
+  },
 });
 
 await renderPage('mcp', {
@@ -1012,6 +1021,17 @@ await renderPage('mcp', {
     "Ask questions about India's geo data in natural language. Connect Claude, GPT, or any LLM to 77 geo layers via the bharatlas MCP server.",
   url: ORIGIN + '/mcp',
   image: ORIGIN + '/og-default.png',
+  structuredData: {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'bharatlas-mcp',
+    description: "MCP server for India's open geo data. 8 tools for LLMs: list, schema, query, locate, nearby, categories, submissions, downloads.",
+    url: ORIGIN + '/mcp',
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    softwareRequirements: 'Node.js, any MCP-compatible LLM client',
+  },
 });
 
 // Static sitemap.xml — emitted at build time. Edge function later stitches in /c/[id].


### PR DESCRIPTION
## Summary
- README: API + MCP in description, stack table, repo paths, roadmap, status
- /docs: nearby endpoint documented with examples
- /mcp: Inspector demoted to footnote, cleaner install section
- Test count updated (447+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)