### PR TITLE
fix: mobile responsive audit (18 issues)

### DIFF
--- a/web/docs.template.html
+++ b/web/docs.template.html
@@ -35,6 +35,16 @@
       .badge { display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 10px; font-weight: 500; }
       .badge--stable { background: #22c55e22; color: #22c55e; }
       .badge--beta { background: #f59e0b22; color: #f59e0b; }
+      @media (max-width: 640px) {
+        body { padding: 24px 14px 60px; }
+        h1 { font-size: 22px; }
+        h2 { font-size: 17px; }
+        pre { font-size: 11px; }
+        table { font-size: 12px; }
+        th, td { padding: 6px 8px; }
+        .endpoint { font-size: 12px; }
+        td code { font-size: 11px; word-break: break-all; }
+      }
     </style>
   </head>
   <body>

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -637,14 +637,46 @@
         }
         .filter-panel__btn .muted { font-size: 10px; }
 
-        /* Bigger touch targets in map header */
+        /* Touch targets: 44px minimum */
         #map-overlay button.close,
         #map-overlay button.filter-toggle,
-        .filter-panel__close { min-height: 38px; padding-left: 14px; padding-right: 14px; }
-        /* Trim the verbose map title on narrow screens */
+        .filter-panel__close { min-height: 44px; padding: 8px 14px; }
+        .filter-panel__select,
+        .filter-search,
+        .filter-range__input { min-height: 44px; padding: 10px 12px; font-size: 16px; }
+
+        /* Map header: title on its own line, buttons wrap evenly below */
+        #map-overlay header.map-bar {
+          flex-wrap: wrap;
+          padding: 8px 12px;
+          gap: 6px;
+        }
         #map-overlay .map-title {
-          font-size: 12px;
+          font-size: 13px;
           overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+          width: 100%;
+          order: -1;
+        }
+        #map-overlay button.close,
+        #map-overlay button.filter-toggle {
+          font-size: 12px;
+          flex: 1;
+          text-align: center;
+        }
+        .map-pop-wrap { flex: 1; }
+        .map-pop-wrap button { width: 100%; }
+
+        /* Popovers: full-width bottom sheet on mobile */
+        .map-popover {
+          position: fixed;
+          left: 0; right: 0; bottom: 0;
+          top: auto;
+          width: 100%;
+          max-height: 60vh;
+          border-radius: 14px 14px 0 0;
+          box-shadow: 0 -8px 24px rgba(0,0,0,0.15);
+          z-index: 20;
+          overflow-y: auto;
         }
       }
 

--- a/web/mcp.template.html
+++ b/web/mcp.template.html
@@ -30,6 +30,14 @@
       .install-box { background: var(--row-hover); border-radius: 8px; padding: 16px 20px; margin: 16px 0; }
       .install-box h3 { margin-top: 0; }
       .badge { display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 10px; font-weight: 500; background: #6366f122; color: var(--accent); }
+      @media (max-width: 640px) {
+        body { padding: 24px 14px 60px; }
+        h1 { font-size: 22px; }
+        h2 { font-size: 17px; }
+        pre { font-size: 11px; }
+        .install-box { padding: 12px 14px; }
+        .install-box pre { font-size: 10px; }
+      }
     </style>
   </head>
   <body>

--- a/web/preview.template.html
+++ b/web/preview.template.html
@@ -268,6 +268,8 @@
         #drop { padding: 36px 16px; }
         #workspace { grid-template-columns: 1fr; }
         #map { position: relative; top: auto; height: 50vh; min-height: 280px; }
+        .field input, .field select, .field textarea { min-height: 44px; padding: 10px 12px; font-size: 16px; }
+        button.primary, button.secondary { min-height: 44px; padding: 12px 16px; }
       }
     </style>
   </head>

--- a/web/scripts/shared-chrome.mjs
+++ b/web/scripts/shared-chrome.mjs
@@ -53,10 +53,19 @@ export const TOKENS = `
   .site-nav { display: flex; gap: var(--sp-3); flex-wrap: wrap; align-items: center; }
   .site-nav a {
     color: var(--muted); text-decoration: none; font-size: var(--fs-base);
-    padding: 4px 0;
+    padding: 6px 2px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
   }
   .site-nav a:hover { color: var(--fg); }
   .site-nav a[data-active] { color: var(--fg); font-weight: 500; }
+  @media (max-width: 480px) {
+    .site-header { gap: var(--sp-2); margin-bottom: var(--sp-4); }
+    .site-brand .tagline { display: none; }
+    .site-nav { gap: var(--sp-2); }
+    .site-nav a { font-size: var(--fs-sm); }
+  }
   .site-footer {
     margin-top: var(--sp-8); padding-top: var(--sp-5);
     border-top: 1px solid var(--line);


### PR DESCRIPTION
## Summary
Full mobile responsive audit addressing 18 issues across all pages.

Key fixes:
- Nav: tagline hidden at 480px, 44px touch targets on links
- Map: header wraps on mobile, popovers become bottom sheets, 44px buttons
- Filter: inputs get 44px height + 16px font (prevents iOS zoom)
- Docs/MCP: mobile breakpoints for padding, tables, code blocks
- Preview: form inputs + buttons meet 44px touch target

## Test plan
- [ ] Open bharatlas.com on 375px Chrome DevTools
- [ ] Nav doesn't overflow, links are tappable
- [ ] Open a layer map, buttons visible and tappable
- [ ] Download popover opens as bottom sheet
- [ ] Filter panel opens, inputs are tap-friendly
- [ ] /docs tables readable without horizontal scroll
- [ ] /preview form inputs are 44px height

🤖 Generated with [Claude Code](https://claude.com/claude-code)