### PR TITLE
fix: MCP registry publish (mcpName + .npmignore)

### DIFF
--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,1 @@
+.mcpregistry_*

--- a/mcp/.npmignore
+++ b/mcp/.npmignore
@@ -1,0 +1,2 @@
+.mcpregistry_*
+test.js

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,10 +1,11 @@
 {
   "name": "bharatlas-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MCP server for India's open geo data. Query layers, locate points, find nearby features, filter and group data.",
   "keywords": ["mcp", "india", "geo", "geospatial", "gis", "boundaries", "parquet", "pmtiles", "llm", "claude", "bharatlas"],
   "repository": { "type": "git", "url": "https://github.com/urbanmorph/geodata", "directory": "mcp" },
   "homepage": "https://bharatlas.com/mcp",
+  "mcpName": "io.github.urbanmorph/bharatlas-mcp",
   "type": "module",
   "main": "index.js",
   "bin": {

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.urbanmorph/bharatlas-mcp",
-  "description": "Query India's open geo data: 77 layers from state to village, city wards, forests, hospitals, highways. Locate points, filter, group, download.",
-  "version": "1.0.0",
+  "description": "Query India's open geo data. Locate, filter, nearby search across layers.",
+  "version": "1.0.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "bharatlas-mcp",
+      "version": "1.0.2",
       "transport": { "type": "stdio" }
     }
   ]

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -55,3 +55,7 @@ User-agent: CCBot
 Allow: /
 
 Sitemap: https://bharatlas.com/sitemap.xml
+
+# LLM discovery
+# https://llmstxt.org
+LLMs: https://bharatlas.com/llms.txt


### PR DESCRIPTION
Required for MCP Registry. Also prevents token files from leaking into npm tarball.