### PR TITLE
fix: add LICENSE to mcp/ for Glama

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "urbanmorph"
+  ]
+}

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,1 @@
+.mcpregistry_*

--- a/mcp/.npmignore
+++ b/mcp/.npmignore
@@ -1,0 +1,2 @@
+.mcpregistry_*
+test.js

--- a/mcp/LICENSE
+++ b/mcp/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2026 Urban Morph and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Note: this licence covers the code in this repository only. Each data layer
+in the catalog carries its own open licence (CC0-1.0, CC-BY-4.0, CC-BY-SA-4.0,
+ODbL-1.0, ODC-PDDL-1.0, GODL-India). See the per-card line on the catalog at
+https://bharatlas.com/ for the licence applicable to a given layer.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,10 +1,11 @@
 {
   "name": "bharatlas-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MCP server for India's open geo data. Query layers, locate points, find nearby features, filter and group data.",
   "keywords": ["mcp", "india", "geo", "geospatial", "gis", "boundaries", "parquet", "pmtiles", "llm", "claude", "bharatlas"],
   "repository": { "type": "git", "url": "https://github.com/urbanmorph/geodata", "directory": "mcp" },
   "homepage": "https://bharatlas.com/mcp",
+  "mcpName": "io.github.urbanmorph/bharatlas-mcp",
   "type": "module",
   "main": "index.js",
   "bin": {

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.urbanmorph/bharatlas-mcp",
-  "description": "Query India's open geo data: 77 layers from state to village, city wards, forests, hospitals, highways. Locate points, filter, group, download.",
-  "version": "1.0.0",
+  "description": "Query India's open geo data. Locate, filter, nearby search across layers.",
+  "version": "1.0.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "bharatlas-mcp",
+      "version": "1.0.2",
       "transport": { "type": "stdio" }
     }
   ]

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -55,3 +55,7 @@ User-agent: CCBot
 Allow: /
 
 Sitemap: https://bharatlas.com/sitemap.xml
+
+# LLM discovery
+# https://llmstxt.org
+LLMs: https://bharatlas.com/llms.txt


### PR DESCRIPTION
Glama scored F for missing license. Copy MIT LICENSE to mcp/.