### PR TITLE
fix: remove github from nav bar

### DIFF
--- a/web/scripts/shared-chrome.mjs
+++ b/web/scripts/shared-chrome.mjs
@@ -82,7 +82,6 @@ export const NAV_LINKS = [
   { k: 'docs', href: '/docs', label: 'docs' },
   { k: 'mcp', href: '/mcp', label: 'mcp' },
   { k: 'about', href: '/about', label: 'about' },
-  { k: 'github', href: 'https://github.com/urbanmorph/geodata', label: 'github' },
 ];
 
 export function renderNav(activeKey) {

--- a/web/tests/shared-chrome.test.ts
+++ b/web/tests/shared-chrome.test.ts
@@ -53,9 +53,9 @@ describe('renderNav', () => {
     }
   });
 
-  it('opens external github link in a new tab', () => {
+  it('does not include github in nav (moved to footer)', () => {
     const html = renderNav('catalog');
-    expect(html).toMatch(/href="https:\/\/github\.com\/urbanmorph\/geodata"[^>]*target="_blank"[^>]*rel="noopener"/);
+    expect(html).not.toContain('github.com');
   });
 
   it('keeps internal links target-less', () => {


### PR DESCRIPTION
Already in footer and /about. Cleaner nav, especially on mobile.