### PR TITLE
fix: default include_centroid=true on query_layer

### DIFF
--- a/mcp/index.js
+++ b/mcp/index.js
@@ -138,7 +138,7 @@ const TOOLS = [
         limit: { type: "number", description: "Max rows (default 100, max 1000)" },
         include_centroid: {
           type: "boolean",
-          description: "Include _lat/_lng centroid coordinates in results (from bbox columns). Use for proximity/distance calculations.",
+          description: "Include _lat/_lng centroid coordinates (defaults to true). Set false to exclude.",
         },
       },
       required: ["layer_id"],

--- a/web/functions/api/v1/layers/[id]/query.ts
+++ b/web/functions/api/v1/layers/[id]/query.ts
@@ -36,7 +36,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   for (const [k, v] of url.searchParams.entries()) {
     if (!reserved.has(k) && v) where[k] = v;
   }
-  const includeCentroid = url.searchParams.get('include_centroid') === 'true';
+  const includeCentroid = url.searchParams.get('include_centroid') !== 'false';
 
   try {
     const start = Date.now();

--- a/web/scripts/shared-chrome.mjs
+++ b/web/scripts/shared-chrome.mjs
@@ -82,7 +82,6 @@ export const NAV_LINKS = [
   { k: 'docs', href: '/docs', label: 'docs' },
   { k: 'mcp', href: '/mcp', label: 'mcp' },
   { k: 'about', href: '/about', label: 'about' },
-  { k: 'github', href: 'https://github.com/urbanmorph/geodata', label: 'github' },
 ];
 
 export function renderNav(activeKey) {

--- a/web/tests/shared-chrome.test.ts
+++ b/web/tests/shared-chrome.test.ts
@@ -53,9 +53,9 @@ describe('renderNav', () => {
     }
   });
 
-  it('opens external github link in a new tab', () => {
+  it('does not include github in nav (moved to footer)', () => {
     const html = renderNav('catalog');
-    expect(html).toMatch(/href="https:\/\/github\.com\/urbanmorph\/geodata"[^>]*target="_blank"[^>]*rel="noopener"/);
+    expect(html).not.toContain('github.com');
   });
 
   it('keeps internal links target-less', () => {


### PR DESCRIPTION
LLMs weren't opting in to centroids for proximity questions. Make them on by default; opt out with `include_centroid=false`.