### PR TITLE
docs: clarify centroid coords auto-included on /mcp

### DIFF
--- a/mcp/index.js
+++ b/mcp/index.js
@@ -138,7 +138,7 @@ const TOOLS = [
         limit: { type: "number", description: "Max rows (default 100, max 1000)" },
         include_centroid: {
           type: "boolean",
-          description: "Include _lat/_lng centroid coordinates in results (from bbox columns). Use for proximity/distance calculations.",
+          description: "Include _lat/_lng centroid coordinates (defaults to true). Set false to exclude.",
         },
       },
       required: ["layer_id"],

--- a/web/functions/api/v1/layers/[id]/query.ts
+++ b/web/functions/api/v1/layers/[id]/query.ts
@@ -36,7 +36,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   for (const [k, v] of url.searchParams.entries()) {
     if (!reserved.has(k) && v) where[k] = v;
   }
-  const includeCentroid = url.searchParams.get('include_centroid') === 'true';
+  const includeCentroid = url.searchParams.get('include_centroid') !== 'false';
 
   try {
     const start = Date.now();

--- a/web/mcp.template.html
+++ b/web/mcp.template.html
@@ -125,7 +125,7 @@
       <ul>
         <li><strong>list_layers</strong> -- discover layers by category, level, source, or text search</li>
         <li><strong>get_layer_schema</strong> -- column names, types, distinct values (call before querying)</li>
-        <li><strong>query_layer</strong> -- filter, select, group by any column, with optional centroid coordinates</li>
+        <li><strong>query_layer</strong> -- filter, select, group by any column; results include <code>_lat</code>/<code>_lng</code> for spatial layers</li>
         <li><strong>locate</strong> -- point-in-polygon across all admin layers + zones at once</li>
         <li><strong>nearby</strong> -- find features within a radius (works for points, polygons, and lines)</li>
         <li><strong>get_layer_detail</strong> -- download URLs in 5 formats (parquet, pmtiles, geojson, kml, shapefile)</li>

--- a/web/scripts/shared-chrome.mjs
+++ b/web/scripts/shared-chrome.mjs
@@ -82,7 +82,6 @@ export const NAV_LINKS = [
   { k: 'docs', href: '/docs', label: 'docs' },
   { k: 'mcp', href: '/mcp', label: 'mcp' },
   { k: 'about', href: '/about', label: 'about' },
-  { k: 'github', href: 'https://github.com/urbanmorph/geodata', label: 'github' },
 ];
 
 export function renderNav(activeKey) {

--- a/web/tests/shared-chrome.test.ts
+++ b/web/tests/shared-chrome.test.ts
@@ -53,9 +53,9 @@ describe('renderNav', () => {
     }
   });
 
-  it('opens external github link in a new tab', () => {
+  it('does not include github in nav (moved to footer)', () => {
     const html = renderNav('catalog');
-    expect(html).toMatch(/href="https:\/\/github\.com\/urbanmorph\/geodata"[^>]*target="_blank"[^>]*rel="noopener"/);
+    expect(html).not.toContain('github.com');
   });
 
   it('keeps internal links target-less', () => {


### PR DESCRIPTION
Follow-up to PR #94: API now defaults centroids on. Update /mcp wording.