### PR TITLE
seo: tier 1-3 audit fixes (FAQPage, breadcrumbs, single H1)

### DIFF
--- a/web/docs.template.html
+++ b/web/docs.template.html
@@ -224,6 +224,7 @@ curl https://bharatlas.com/api/v1/layers/wards_pcmc/counts?group_by=zone</code><
         <tr><td><code>shapefile</code></td><td>ArcGIS, legacy GIS tools</td></tr>
       </table>
 
+<!-- DOCS_FAQ_HTML -->
       <h2>For LLMs</h2>
       <p>Use the <a href="/mcp">bharatlas MCP server</a> (<code>npx bharatlas-mcp</code>) to connect Claude, GPT, Gemini, or any MCP-compatible LLM directly to this API. 8 tools with built-in instructions for schema-first querying, spatial joins, and multi-source awareness.</p>
 

--- a/web/functions/lib/render-view.ts
+++ b/web/functions/lib/render-view.ts
@@ -198,7 +198,7 @@ export function renderViewPage(opts: RenderOpts): string {
       .badge { display: inline-block; font-size: var(--fs-xs); font-weight: 600;
         padding: 2px 6px; border-radius: var(--radius-sm); letter-spacing: .04em; text-transform: uppercase;
         background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); }
-      h2 { font-size: var(--fs-2xl); line-height: 1.2; margin: 4px 0 var(--sp-2); }
+      h1 { font-size: var(--fs-2xl); line-height: 1.2; margin: 4px 0 var(--sp-2); font-weight: 700; }
       .desc { color: var(--muted); margin: 0 0 var(--sp-6); }
       .kv { display: grid; grid-template-columns: max-content 1fr; gap: 6px var(--sp-4); margin: var(--sp-4) 0 var(--sp-6); font-size: var(--fs-base); }
       .kv dt { color: var(--muted); }
@@ -227,7 +227,7 @@ export function renderViewPage(opts: RenderOpts): string {
     ${header}
 
     <span class="badge">community</span>
-    <h2>${esc(s.name)}</h2>
+    <h1>${esc(s.name)}</h1>
     <p class="desc">${esc(description)}</p>
 
     <dl class="kv">

--- a/web/functions/sitemap.xml.ts
+++ b/web/functions/sitemap.xml.ts
@@ -13,6 +13,8 @@ const STATIC: Array<{ loc: string; changefreq: string; priority: string }> = [
   { loc: ORIGIN + '/', changefreq: 'weekly', priority: '1.0' },
   { loc: ORIGIN + '/about', changefreq: 'monthly', priority: '0.8' },
   { loc: ORIGIN + '/preview', changefreq: 'monthly', priority: '0.8' },
+  { loc: ORIGIN + '/docs', changefreq: 'monthly', priority: '0.7' },
+  { loc: ORIGIN + '/mcp', changefreq: 'monthly', priority: '0.7' },
   { loc: ORIGIN + '/privacy', changefreq: 'yearly', priority: '0.3' },
   { loc: ORIGIN + '/terms', changefreq: 'yearly', priority: '0.3' },
 ];

--- a/web/functions/view/[id].ts
+++ b/web/functions/view/[id].ts
@@ -67,6 +67,18 @@ export const onRequestGet: PagesFunction<unknown, keyof Params> = async (ctx) =>
     .on('body', {
       element(el) { el.prepend(contentHtml, { html: true }); },
     })
+    // Home hero h1 is left in DOM by index.html so it's there after JS hydrates
+    // and the user closes the map overlay. On /view/<id> the only h1 a crawler
+    // should see is the layer title in <article class="view-seo">. Demote to
+    // <div> (same .hero__title CSS) so styling is preserved when the user
+    // returns to / via the in-page close button.
+    .on('h1.hero__title', {
+      element(el) {
+        el.before('<div class="hero__title">', { html: true });
+        el.after('</div>', { html: true });
+        el.removeAndKeepContent();
+      },
+    })
     .transform(new Response(indexResp.body, {
       status: 200,
       headers: {

--- a/web/mcp.template.html
+++ b/web/mcp.template.html
@@ -121,7 +121,7 @@
       <p class="question">How many hospitals are in flood-prone areas of Assam?</p>
       <p class="answer">3,909 health facilities in Assam (narrowed by state). For precise flood-zone overlap, the MCP tests hospital points against the India Flood Inventory layer.</p>
 
-      <h2>7 tools</h2>
+      <h2>8 tools</h2>
       <ul>
         <li><strong>list_layers</strong> -- discover layers by category, level, source, or text search</li>
         <li><strong>get_layer_schema</strong> -- column names, types, distinct values (call before querying)</li>

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -57,6 +57,12 @@
 /preview
   Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=86400
   CDN-Cache-Control: public, max-age=300, stale-while-revalidate=86400
+/docs
+  Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=86400
+  CDN-Cache-Control: public, max-age=300, stale-while-revalidate=86400
+/mcp
+  Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=86400
+  CDN-Cache-Control: public, max-age=300, stale-while-revalidate=86400
 # Legal pages — edits are rare and can wait a day to propagate.
 /privacy
   Cache-Control: public, max-age=300, s-maxage=86400, stale-while-revalidate=86400

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -114,6 +114,8 @@ function seoHead(o) {
     `<meta property="og:description" content="${esc(o.description)}" />`,
     `<meta property="og:url" content="${esc(o.url)}" />`,
     `<meta property="og:image" content="${esc(image)}" />`,
+    `<meta property="og:image:width" content="1200" />`,
+    `<meta property="og:image:height" content="630" />`,
     `<meta property="og:site_name" content="bharatlas" />`,
     `<meta property="og:locale" content="en_IN" />`,
     `<meta name="twitter:card" content="summary_large_image" />`,
@@ -998,6 +1000,43 @@ await renderPage('terms', {
   image: ORIGIN + '/og-default.png',
 });
 
+// /docs FAQ — mirrors the visible "Common questions" section emitted into
+// docs.template.html. Targets queries an LLM (or a human) is likely to ask
+// before reading the full reference. Keep answers tight and curl-shaped so
+// they're directly copy-pastable.
+const DOCS_FAQ = [
+  {
+    q: 'Do I need an API key to use the bharatlas API?',
+    a: 'No. The API is public, read-only and CORS-enabled. No auth, no signup, no API key. Rate limit is 120 requests per minute per IP for most endpoints, 60/min for /locate and /nearby.',
+  },
+  {
+    q: 'How do I list all geo layers via the API?',
+    a: 'GET https://bharatlas.com/api/v1/layers returns every curated layer with pagination. Optional filters: ?category=, ?level=, ?source=, ?q= for full-text search.',
+  },
+  {
+    q: 'How do I find what state or district a coordinate is in?',
+    a: 'GET https://bharatlas.com/api/v1/locate?lat=12.97&lng=77.59 runs point-in-polygon across 12 admin and zone layers in a single call. Returns state, district, ward, pincode, seismic zone, eco-zone and more.',
+  },
+  {
+    q: 'How do I find features near a point?',
+    a: 'GET https://bharatlas.com/api/v1/nearby?lat=12.97&lng=77.59&layer=wris_reservoirs&radius_km=50 finds features from any layer within a radius. Works for points, polygons and lines via Haversine distance to computed centroids.',
+  },
+  {
+    q: 'How do I query a layer with column filters?',
+    a: 'GET https://bharatlas.com/api/v1/layers/:id/query?where=col=val&select=col1,col2&group_by=col. Reads parquet directly from R2 at runtime. Call /schema first to discover column names.',
+  },
+  {
+    q: 'What download formats does bharatlas support?',
+    a: 'Up to 5 formats per layer: parquet (DuckDB, Pandas, R, Spark), pmtiles (web maps), geojson (QGIS, D3), kml (Google Earth) and shapefile (ArcGIS). Use /api/v1/layers/:id to get direct download URLs.',
+  },
+  {
+    q: 'How do I connect an LLM to the bharatlas API?',
+    a: 'Use the bharatlas MCP server: add bharatlas-mcp to your MCP client config and run npx -y bharatlas-mcp. Connects Claude, GPT, Gemini or any MCP-compatible LLM with 8 tools and built-in instructions for spatial joins and schema-first querying.',
+  },
+];
+
+const docsFaqHtml = `      <h2>Common questions</h2>\n${DOCS_FAQ.map(({ q, a }) => `      <h3>${q}</h3>\n      <p>${a}</p>`).join('\n')}\n`;
+
 await renderPage('docs', {
   title: 'API v1',
   description:
@@ -1006,14 +1045,76 @@ await renderPage('docs', {
   image: ORIGIN + '/og-default.png',
   structuredData: {
     '@context': 'https://schema.org',
-    '@type': 'WebAPI',
-    name: 'bharatlas API v1',
-    description: "Public JSON API for India's open geo layers. 13 endpoints: list, query, filter, locate, nearby, schema, categories, levels, counts, downloads, submissions.",
-    url: ORIGIN + '/docs',
-    provider: { '@type': 'Organization', name: 'Urban Morph', url: 'https://urbanmorph.com' },
-    documentation: ORIGIN + '/docs',
+    '@graph': [
+      {
+        '@type': 'WebAPI',
+        name: 'bharatlas API v1',
+        description: "Public JSON API for India's open geo layers. 13 endpoints: list, query, filter, locate, nearby, schema, categories, levels, counts, downloads, submissions.",
+        url: ORIGIN + '/docs',
+        provider: { '@type': 'Organization', name: 'Urban Morph', url: 'https://urbanmorph.com' },
+        documentation: ORIGIN + '/docs',
+      },
+      {
+        '@type': 'FAQPage',
+        mainEntity: DOCS_FAQ.map(({ q, a }) => ({
+          '@type': 'Question',
+          name: q,
+          acceptedAnswer: { '@type': 'Answer', text: a },
+        })),
+      },
+    ],
   },
-});
+}, { DOCS_FAQ_HTML: docsFaqHtml });
+
+// /mcp FAQ — kept in sync with the visible <p class="question"> / <p class="answer">
+// pairs in mcp.template.html. FAQPage JSON-LD lights up Google rich results
+// and lets LLM crawlers ingest the Q&A surface cleanly.
+const MCP_FAQ = [
+  {
+    q: 'How many national parks vs wildlife sanctuaries are in India?',
+    a: '101 national parks and 560 wildlife sanctuaries, from the gs_wildlife layer grouped by category. The bharatlas MCP server returns this from a single group-by query against the curated GatiShakti wildlife layer.',
+  },
+  {
+    q: 'How many villages are in Bengaluru Urban district?',
+    a: '949 villages. The lgd_villages layer filtered by dtname=BENGALURU URBAN. Schema-first pattern: get_layer_schema first, then query_layer with the right column name.',
+  },
+  {
+    q: 'How many health facilities are in Bihar?',
+    a: '8,363 facilities: 3,232 sub-centres, 591 PHCs, 74 CHCs and others. From the nic_health layer filtered by state. Sub-typing via the category column gives the breakdown.',
+  },
+  {
+    q: 'How many wards does Chennai have vs Pune?',
+    a: 'Chennai has 200 wards, Pune has 58. From the wards_chennai and wards_pune layers respectively. Each Indian city has its own ward layer because authoritative ward maps come from city corporations, not a central registry.',
+  },
+  {
+    q: 'What state, district, and seismic zone is Bengaluru in?',
+    a: 'Karnataka, Bengaluru Urban district, Seismic Zone II. The MCP locate endpoint runs point-in-polygon against 12 layers in a single call: state, district, ward, pincode, forest, eco-zone, seismic zone and more.',
+  },
+  {
+    q: 'Which blocks are in district 571?',
+    a: '10 community-development blocks including Kunigal, Tumakuru, Gubbi, Turuvekere and Tiptur. From the lgd_blocks layer filtered by dtcode11=571 (Tumakuru district in Karnataka).',
+  },
+  {
+    q: 'How many airports are in Bengaluru district and what types?',
+    a: '3 airports: HAL (Domestic), Yelahanka AFB (Civil Enclave), Kempegowda International. The MCP locates the district from a name, then filters the airports layer by state and district.',
+  },
+  {
+    q: 'Which airports in Karnataka are near water bodies?',
+    a: 'Hubballi Airport (~3 km from Unkal Lake), Mangalore Airport (between Netravathi and Gurupura rivers) and Jindal Vijaynagar (~7 km from JSW Reservoir). The MCP cross-references the airports and reservoirs layers via spatial proximity.',
+  },
+  {
+    q: 'Which villages in Madhya Pradesh are in eco-sensitive zones?',
+    a: 'MP has 4 eco-sensitive zones: Kharmor, Chambal, Orchha and Kheoni. The MCP narrows 47,571 MP villages by district, then tests each candidate against the eco-zone boundaries via point-in-polygon.',
+  },
+  {
+    q: 'Which districts does NH-44 pass through?',
+    a: 'NH-44 runs through Delhi, Uttar Pradesh, Madhya Pradesh, Telangana and Karnataka. The MCP samples points along the route line geometry and runs locate at each sample to assemble the district list.',
+  },
+  {
+    q: 'How many hospitals are in flood-prone areas of Assam?',
+    a: 'Assam has 3,909 health facilities, narrowed by state from the nic_health layer. For precise flood-zone overlap, the MCP tests hospital points against the India Flood Inventory polygons via point-in-polygon.',
+  },
+];
 
 await renderPage('mcp', {
   title: 'MCP Server',
@@ -1023,14 +1124,26 @@ await renderPage('mcp', {
   image: ORIGIN + '/og-default.png',
   structuredData: {
     '@context': 'https://schema.org',
-    '@type': 'SoftwareApplication',
-    name: 'bharatlas-mcp',
-    description: "MCP server for India's open geo data. 8 tools for LLMs: list, schema, query, locate, nearby, categories, submissions, downloads.",
-    url: ORIGIN + '/mcp',
-    applicationCategory: 'DeveloperApplication',
-    operatingSystem: 'Any',
-    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-    softwareRequirements: 'Node.js, any MCP-compatible LLM client',
+    '@graph': [
+      {
+        '@type': 'SoftwareApplication',
+        name: 'bharatlas-mcp',
+        description: "MCP server for India's open geo data. 8 tools for LLMs: list, schema, query, locate, nearby, categories, submissions, downloads.",
+        url: ORIGIN + '/mcp',
+        applicationCategory: 'DeveloperApplication',
+        operatingSystem: 'Any',
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        softwareRequirements: 'Node.js, any MCP-compatible LLM client',
+      },
+      {
+        '@type': 'FAQPage',
+        mainEntity: MCP_FAQ.map(({ q, a }) => ({
+          '@type': 'Question',
+          name: q,
+          acceptedAnswer: { '@type': 'Answer', text: a },
+        })),
+      },
+    ],
   },
 });
 

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -934,6 +934,13 @@ await renderPage('about', {
     '@context': 'https://schema.org',
     '@graph': [
       {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: ORIGIN + '/' },
+          { '@type': 'ListItem', position: 2, name: 'About', item: ORIGIN + '/about' },
+        ],
+      },
+      {
         '@type': 'AboutPage',
         name: 'About bharatlas',
         url: ORIGIN + '/about',
@@ -945,7 +952,10 @@ await renderPage('about', {
         '@id': ORIGIN + '/about#sathya',
         name: 'Sathya Sankaran',
         url: 'https://www.sathyasankaran.com',
-        sameAs: ['https://linkedin.com/in/sathyasankaran'],
+        sameAs: [
+          'https://linkedin.com/in/sathyasankaran',
+          'https://github.com/urbanmorph',
+        ],
         worksFor: { '@type': 'Organization', name: 'Urban Morph', url: 'https://urbanmorph.com' },
       },
       {
@@ -974,15 +984,29 @@ await renderPage(
     image: ORIGIN + '/og-preview.png',
     structuredData: {
       '@context': 'https://schema.org',
-      '@type': 'WebApplication',
-      name: 'bharatlas · preview',
-      url: ORIGIN + '/preview',
-      applicationCategory: 'UtilityApplication',
-      operatingSystem: 'Web',
+      '@graph': [
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: ORIGIN + '/' },
+            { '@type': 'ListItem', position: 2, name: 'Preview', item: ORIGIN + '/preview' },
+          ],
+        },
+        {
+          '@type': 'WebApplication',
+          name: 'bharatlas · preview',
+          url: ORIGIN + '/preview',
+          applicationCategory: 'UtilityApplication',
+          operatingSystem: 'Web',
+        },
+      ],
     },
   },
   { TURNSTILE_SITEKEY },
 );
+
+// Shared minimal WebSite ref for legal pages' isPartOf.
+const WEBSITE_REF = { '@type': 'WebSite', name: 'bharatlas', url: ORIGIN + '/' };
 
 await renderPage('privacy', {
   title: 'Privacy',
@@ -990,6 +1014,25 @@ await renderPage('privacy', {
     "Bharatlas runs without accounts, third-party analytics or tracking cookies. This page explains what we store (very little) and what we don't.",
   url: ORIGIN + '/privacy',
   image: ORIGIN + '/og-default.png',
+  structuredData: {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: ORIGIN + '/' },
+          { '@type': 'ListItem', position: 2, name: 'Privacy', item: ORIGIN + '/privacy' },
+        ],
+      },
+      {
+        '@type': 'WebPage',
+        name: 'Privacy',
+        url: ORIGIN + '/privacy',
+        isPartOf: WEBSITE_REF,
+        about: 'Privacy practices for bharatlas: no accounts, no third-party analytics, no tracking cookies.',
+      },
+    ],
+  },
 });
 
 await renderPage('terms', {
@@ -998,6 +1041,25 @@ await renderPage('terms', {
     "Terms for using bharatlas: open-licence content only, no warranty of accuracy, contributor attests right to share. Short and plain-English.",
   url: ORIGIN + '/terms',
   image: ORIGIN + '/og-default.png',
+  structuredData: {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: ORIGIN + '/' },
+          { '@type': 'ListItem', position: 2, name: 'Terms', item: ORIGIN + '/terms' },
+        ],
+      },
+      {
+        '@type': 'WebPage',
+        name: 'Terms',
+        url: ORIGIN + '/terms',
+        isPartOf: WEBSITE_REF,
+        about: 'Terms of use for bharatlas: open-licence content only, no warranty of accuracy, contributor attests right to share.',
+      },
+    ],
+  },
 });
 
 // /docs FAQ — mirrors the visible "Common questions" section emitted into
@@ -1046,6 +1108,13 @@ await renderPage('docs', {
   structuredData: {
     '@context': 'https://schema.org',
     '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: ORIGIN + '/' },
+          { '@type': 'ListItem', position: 2, name: 'API v1', item: ORIGIN + '/docs' },
+        ],
+      },
       {
         '@type': 'WebAPI',
         name: 'bharatlas API v1',
@@ -1125,6 +1194,13 @@ await renderPage('mcp', {
   structuredData: {
     '@context': 'https://schema.org',
     '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: ORIGIN + '/' },
+          { '@type': 'ListItem', position: 2, name: 'MCP Server', item: ORIGIN + '/mcp' },
+        ],
+      },
       {
         '@type': 'SoftwareApplication',
         name: 'bharatlas-mcp',

--- a/web/tests/render-view.test.ts
+++ b/web/tests/render-view.test.ts
@@ -32,6 +32,13 @@ describe('renderViewPage', () => {
     expect(html).toMatch(/<title>Mumbai bike lanes · bharatlas<\/title>/);
   });
 
+  it('renders the submission name as a single H1 (SEO)', () => {
+    const html = renderViewPage({ submission: row(), origin: ORIGIN, ratingsCount: 0, alreadyRated: false });
+    const h1s = html.match(/<h1\b/g) || [];
+    expect(h1s.length).toBe(1);
+    expect(html).toMatch(/<h1[^>]*>Mumbai bike lanes<\/h1>/);
+  });
+
   it('emits a canonical URL pinned to bharatlas.com (not the request origin)', () => {
     const html = renderViewPage({ submission: row(), origin: ORIGIN, ratingsCount: 0, alreadyRated: false });
     // Canonical must be the public origin regardless of where the request

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -213,6 +213,69 @@ describe('SEO — /docs FAQPage + structured-data', () => {
   });
 });
 
+describe('SEO — BreadcrumbList on every prerendered page', () => {
+  // Breadcrumbs reinforce site structure for Google (sitelinks breadcrumb
+  // trail in SERPs) and give LLM crawlers a navigable hierarchy.
+  const PAGES = [
+    { file: 'index.html', last: 'Catalog' },
+    { file: 'about.html', last: 'About' },
+    { file: 'preview.html', last: 'Preview' },
+    { file: 'docs.html', last: 'API v1' },
+    { file: 'mcp.html', last: 'MCP Server' },
+    { file: 'privacy.html', last: 'Privacy' },
+    { file: 'terms.html', last: 'Terms' },
+  ];
+
+  for (const { file, last } of PAGES) {
+    it(`${file} emits a BreadcrumbList ending in "${last}"`, () => {
+      const html = readFileSync(resolve(__dirname, '..', file), 'utf8');
+      const m = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+      expect(m, `${file} no JSON-LD`).not.toBeNull();
+      const data = JSON.parse(m![1].replace(/\\u003c/g, '<'));
+      const graph = data['@graph'] || [data];
+      const bc = graph.find((n: any) => n['@type'] === 'BreadcrumbList');
+      expect(bc, `${file} missing BreadcrumbList`).toBeTruthy();
+      expect(bc.itemListElement?.length, 'breadcrumb needs ≥2 items').toBeGreaterThanOrEqual(2);
+      const tail = bc.itemListElement[bc.itemListElement.length - 1];
+      expect(tail.name).toBe(last);
+    });
+  }
+});
+
+describe('SEO — legal pages carry WebPage JSON-LD', () => {
+  // /privacy and /terms were shipping zero structured data. WebPage with
+  // isPartOf reinforces they belong to the bharatlas WebSite, lifting
+  // entity association in Google's knowledge graph.
+  for (const file of ['privacy.html', 'terms.html']) {
+    it(`${file} emits a WebPage with isPartOf the bharatlas WebSite`, () => {
+      const html = readFileSync(resolve(__dirname, '..', file), 'utf8');
+      const m = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+      expect(m, `${file} no JSON-LD`).not.toBeNull();
+      const data = JSON.parse(m![1].replace(/\\u003c/g, '<'));
+      const graph = data['@graph'] || [data];
+      const wp = graph.find((n: any) => n['@type'] === 'WebPage');
+      expect(wp, `${file} missing WebPage`).toBeTruthy();
+      expect(wp.isPartOf?.['@type']).toBe('WebSite');
+      expect(wp.isPartOf?.url).toMatch(/^https:\/\/bharatlas\.com/);
+    });
+  }
+});
+
+describe('SEO — /about Person.sameAs includes GitHub for entity disambiguation', () => {
+  it('/about Person sameAs contains both linkedin and github', () => {
+    const html = readFileSync(resolve(__dirname, '..', 'about.html'), 'utf8');
+    const m = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+    expect(m).not.toBeNull();
+    const data = JSON.parse(m![1].replace(/\\u003c/g, '<'));
+    const graph = data['@graph'] || [data];
+    const person = graph.find((n: any) => n['@type'] === 'Person');
+    expect(person?.sameAs).toEqual(expect.arrayContaining([
+      expect.stringMatching(/linkedin\.com/),
+      expect.stringMatching(/github\.com/),
+    ]));
+  });
+});
+
 describe('SEO — OG image dimensions on prerendered pages', () => {
   // Twitter/Slack/iMessage cards render correctly without dims, but Facebook
   // and LinkedIn need explicit width/height to skip a re-fetch + show the

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -153,6 +153,81 @@ describe('SEO — /about FAQPage', () => {
   });
 });
 
+describe('SEO — /mcp FAQPage + structured-data', () => {
+  function loadMcpGraph(): any[] {
+    const html = readFileSync(resolve(__dirname, '..', 'mcp.html'), 'utf8');
+    const m = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+    if (!m) throw new Error('no JSON-LD on /mcp');
+    const data = JSON.parse(m[1].replace(/\\u003c/g, '<'));
+    return data['@graph'] || [data];
+  }
+
+  it('/mcp emits a FAQPage with ≥8 questions', () => {
+    // The page already shows 11 visible <p class="question">…</p> /
+    // <p class="answer">…</p> pairs under "What you can ask". Mirroring
+    // them as FAQPage JSON-LD lights up Google rich results AND gives
+    // LLM crawlers (ChatGPT/Claude/Perplexity) a clean Q&A ingest.
+    const faq = loadMcpGraph().find((n) => n['@type'] === 'FAQPage');
+    expect(faq, '/mcp missing FAQPage').toBeTruthy();
+    expect(faq.mainEntity?.length, 'FAQPage needs ≥8 questions').toBeGreaterThanOrEqual(8);
+    for (const q of faq.mainEntity) {
+      expect(q['@type']).toBe('Question');
+      expect(q.acceptedAnswer?.['@type']).toBe('Answer');
+      expect(q.acceptedAnswer?.text?.length, 'Answer empty').toBeGreaterThan(20);
+    }
+  });
+
+  it('/mcp still emits SoftwareApplication', () => {
+    expect(loadMcpGraph().find((n) => n['@type'] === 'SoftwareApplication'), 'lost SoftwareApplication')
+      .toBeTruthy();
+  });
+});
+
+describe('SEO — /docs FAQPage + structured-data', () => {
+  function loadDocsGraph(): any[] {
+    const html = readFileSync(resolve(__dirname, '..', 'docs.html'), 'utf8');
+    const m = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+    if (!m) throw new Error('no JSON-LD on /docs');
+    const data = JSON.parse(m[1].replace(/\\u003c/g, '<'));
+    return data['@graph'] || [data];
+  }
+
+  it('/docs emits a FAQPage with ≥4 questions', () => {
+    const faq = loadDocsGraph().find((n) => n['@type'] === 'FAQPage');
+    expect(faq, '/docs missing FAQPage').toBeTruthy();
+    expect(faq.mainEntity?.length, 'FAQPage needs ≥4 questions').toBeGreaterThanOrEqual(4);
+    for (const q of faq.mainEntity) {
+      expect(q['@type']).toBe('Question');
+      expect(q.acceptedAnswer?.['@type']).toBe('Answer');
+      expect(q.acceptedAnswer?.text?.length, 'Answer empty').toBeGreaterThan(20);
+    }
+  });
+
+  it('/docs still emits WebAPI', () => {
+    expect(loadDocsGraph().find((n) => n['@type'] === 'WebAPI'), 'lost WebAPI').toBeTruthy();
+  });
+
+  it('/docs has a visible Common questions section (Google needs visible Q&A to match FAQPage markup)', () => {
+    const html = readFileSync(resolve(__dirname, '..', 'docs.html'), 'utf8');
+    expect(html).toMatch(/<h2[^>]*>\s*Common questions\s*<\/h2>/i);
+  });
+});
+
+describe('SEO — OG image dimensions on prerendered pages', () => {
+  // Twitter/Slack/iMessage cards render correctly without dims, but Facebook
+  // and LinkedIn need explicit width/height to skip a re-fetch + show the
+  // card on first scrape. All bharatlas OG cards are 1200×630.
+  const PAGES = ['index.html', 'about.html', 'preview.html', 'docs.html', 'mcp.html', 'privacy.html', 'terms.html'];
+
+  for (const page of PAGES) {
+    it(`${page} declares og:image:width=1200 and og:image:height=630`, () => {
+      const html = readFileSync(resolve(__dirname, '..', page), 'utf8');
+      expect(html, `${page} missing og:image:width`).toMatch(/property="og:image:width" content="1200"/);
+      expect(html, `${page} missing og:image:height`).toMatch(/property="og:image:height" content="630"/);
+    });
+  }
+});
+
 describe('SEO — per-page OG images differentiated', () => {
   function og(page: string): string {
     const html = readFileSync(resolve(__dirname, '..', page), 'utf8');


### PR DESCRIPTION
## Summary

End-to-end SEO/AEO audit pass on bharatlas.com. Three tiers, three commits, +23 tests.

**Tier 1** — content/structural bugs visible to crawlers:
- `/view/*` rendered two H1s (view-seo article + home hero). HTMLRewriter now demotes the hero H1 to `<div class="hero__title">` so styling survives the SPA's close-map transition.
- `/mcp` said "7 tools" but listed 8.

**Tier 2** — structured-data + infra wins:
- FAQPage JSON-LD on `/mcp` (11 Q&As from the visible "What you can ask" pairs) and `/docs` (7 Q&As, plus a new visible "Common questions" section so the markup matches visible content per Google's policy).
- `/c/<id>` rendered the submission name as H2; promoted to H1.
- `og:image:width=1200` + `og:image:height=630` sitewide via `seoHead` — Facebook/LinkedIn render cards on first scrape without re-fetch.
- Edge `sitemap.xml.ts` was shadowing the static sitemap without `/docs` and `/mcp`; both added.
- `/docs` and `/mcp` hit origin on every request (cf-cache-status: DYNAMIC); added the same edge cache stanzas as `/about` + `/preview`.

**Tier 3** — entity + hierarchy polish:
- `BreadcrumbList` JSON-LD on `/about`, `/preview`, `/docs`, `/mcp`, `/privacy`, `/terms` (home already had one).
- `WebPage` JSON-LD on `/privacy` + `/terms` (previously zero structured data).
- `/about` `Person.sameAs` now includes GitHub in addition to LinkedIn.

## Why now

Lighthouse SEO was already 100/100 across the site, but the audit surfaced gaps Lighthouse doesn't measure: FAQPage absence on /mcp and /docs, missing breadcrumbs on inner pages, zero JSON-LD on legal pages, duplicate H1s on `/view/*`, OG image dims missing.

Baseline snapshots (Lighthouse + structured-data inventory) saved under `supporting-docs/seo-*-2026-05-28-before.md` (gitignored, local only). After-snapshot can be diffed once deployed.

## Test plan
- [x] `npm test` — 470 passed (was 447, +23 new)
- [x] `npm run build` — clean
- [x] `dist/{mcp,docs,index,about,preview,privacy,terms}.html` all carry `og:image:width=1200` + `og:image:height=630`
- [x] `dist/mcp.html` has `SoftwareApplication` + `FAQPage` + `BreadcrumbList` in `@graph`
- [x] `dist/docs.html` has `WebAPI` + `FAQPage` + `BreadcrumbList` in `@graph` + visible `<h2>Common questions</h2>` block
- [x] `dist/{privacy,terms}.html` each carry `WebPage` + `BreadcrumbList`
- [x] `dist/about.html` `Person.sameAs` contains both LinkedIn and GitHub
- [ ] **post-deploy:** `curl -sL https://bharatlas.com/view/lgd_states | grep -c '<h1' ` returns `1`
- [ ] **post-deploy:** `curl -sL https://bharatlas.com/c/<id> | grep -c '<h1'` returns `1`
- [ ] **post-deploy:** `curl -sL https://bharatlas.com/sitemap.xml | grep -E '/(docs|mcp)$'` shows both
- [ ] **post-deploy:** `curl -sI https://bharatlas.com/mcp | grep cache-control` shows the new stanza
- [ ] **post-deploy:** Google Rich Results Test on `/mcp` + `/docs` lists FAQPage eligibility

## Deferred (not blocking)
- Tier 2 #7 (`/verify`, `/submit` 301 → `/preview`): user decision — leaving the 2-line legacy redirects in `_redirects` per discussion.
- DEF-04: next MCP npm release (`bharatlas-mcp@1.0.3`) bundling UA header + centroid SERVER_INSTRUCTIONS hint. Unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)