### PR TITLE
fix(home): search overrides active category pill

### DIFF
--- a/web/src/catalog-filter.ts
+++ b/web/src/catalog-filter.ts
@@ -35,6 +35,31 @@ export type FilterResult = {
   totalMatches: number;
 };
 
+/**
+ * Decide per-card visibility on the home grid.
+ *
+ * Earlier behaviour was `matches AND inActiveCategory` for every card. That
+ * made search results depend on whether the matched layer happened to be
+ * categorised into the currently-selected pill — invisible context to the
+ * user. Typing `over` with `Environment` selected returned "No matches",
+ * even though Overture Places (in `infrastructure`) clearly matched.
+ *
+ * New rule: when the user is searching (query non-empty), the active pill
+ * is ignored — search intent ("find me this thing") overrides scoping
+ * intent ("show me only this category"). When the query is empty, the
+ * pill scopes the catalog as before. Pill counts continue to show
+ * filtered/total in both modes so the distribution stays visible.
+ */
+export function cardVisibility(
+  matches: boolean[],
+  categories: string[],
+  activeCat: string,
+  query: string,
+): boolean[] {
+  const searching = query.trim().length > 0;
+  return matches.map((m, i) => m && (searching || activeCat === 'all' || categories[i] === activeCat));
+}
+
 export function filterCards(cards: CardLike[], query: string): FilterResult {
   const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
 

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,7 +1,7 @@
 // Tiny entry: hash-based map routing + hover-prefetch of the map chunk.
 // Map code is in a separate chunk; only loaded when the user opens a map.
 import { isEmbedPath, isViewPath, nextStateOnClose } from './embed-snippet';
-import { filterCards, type CardLike } from './catalog-filter';
+import { filterCards, cardVisibility, type CardLike } from './catalog-filter';
 
 document.querySelector('.view-seo')?.remove();
 
@@ -126,17 +126,19 @@ if (searchInput && grid) {
     // every section so the row--collapsed cap doesn't hide matches.
     const forceExpand = !!query || activeCat !== 'all';
 
-    // Per-card visibility = matches query AND in active category.
-    // Track per-section + total visible for section hide + meta line.
+    // Per-card visibility: search query intent overrides category-pill scope
+    // (see cardVisibility doc-comment in catalog-filter.ts). When the user
+    // is typing in the search box, every match across every category renders
+    // — regardless of which pill is active — so cross-category results
+    // ("over" → Overture in Infrastructure with Environment selected) don't
+    // silently get hidden behind "No matches".
+    const visible = cardVisibility(result.matches, cardLikes.map((c) => c.category), activeCat, query);
     const visiblePerSection = new Map<HTMLElement, number>();
     let totalVisible = 0;
     for (let i = 0; i < cardEls.length; i++) {
       const el = cardEls[i];
-      const cat = cardLikes[i].category;
-      const inCat = activeCat === 'all' || cat === activeCat;
-      const visible = result.matches[i] && inCat;
-      el.classList.toggle('hidden', !visible);
-      if (visible) {
+      el.classList.toggle('hidden', !visible[i]);
+      if (visible[i]) {
         totalVisible++;
         const sec = el.closest<HTMLElement>('.category-section');
         if (sec) visiblePerSection.set(sec, (visiblePerSection.get(sec) || 0) + 1);
@@ -146,7 +148,10 @@ if (searchInput && grid) {
       section.classList.toggle('expanded', forceExpand);
       const cat = section.dataset.category || '';
       const sectionVisible = visiblePerSection.get(section) || 0;
-      const catFiltered = activeCat !== 'all' && cat !== activeCat;
+      // Hide a section only when (a) the user has scoped to a different pill
+      // AND isn't searching, OR (b) it has no visible cards. While searching,
+      // sections appear for every category that has matches.
+      const catFiltered = !query && activeCat !== 'all' && cat !== activeCat;
       section.classList.toggle('hidden', catFiltered || sectionVisible === 0);
     }
 

--- a/web/tests/catalog-filter.test.ts
+++ b/web/tests/catalog-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { filterCards, type CardLike } from '../src/catalog-filter';
+import { filterCards, cardVisibility, type CardLike } from '../src/catalog-filter';
 
 // Fixture mirrors real prerender shape: each card carries a high-signal
 // "primary" haystack (title + level + aliases) and a low-signal "body"
@@ -74,5 +74,51 @@ describe('catalog-filter — filterCards', () => {
     expect(r.totalMatches).toBe(1);
     expect(r.countsByCategory.get('environment')).toBe(1);
     expect(r.countsByCategory.get('administrative')).toBeUndefined();
+  });
+});
+
+describe('catalog-filter — cardVisibility (search × active-pill interaction)', () => {
+  // Mirrors the home-grid bug from PR #99 follow-up: typing "over" with
+  // Environment active returned "No matches" because the Overture match
+  // lives in Infrastructure. New rule: when a query is active, the pill
+  // scope is bypassed so search results are never silently hidden.
+  const cats = cards.map((c) => c.category);
+
+  it('empty query, no active pill: respects matches as-is', () => {
+    const matches = cards.map(() => true);
+    const v = cardVisibility(matches, cats, 'all', '');
+    expect(v.every((x: boolean) => x)).toBe(true);
+  });
+
+  it('empty query, active pill: scopes to that category', () => {
+    const matches = cards.map(() => true);
+    const v = cardVisibility(matches, cats, 'people', '');
+    expect(v.filter(Boolean).length).toBe(1); // only the pincode card
+    expect(v[6]).toBe(true);
+  });
+
+  it('non-empty query: ignores active pill, returns every match', () => {
+    // Simulate searching "over" — only the env card matches by index.
+    // With active pill = 'people', earlier behaviour would have returned
+    // 0 visible; new behaviour returns the env card regardless.
+    const matches = cards.map((c, i) => i === 7); // wildlife is index 7
+    const v = cardVisibility(matches, cats, 'people', 'wild');
+    expect(v[7]).toBe(true);
+    expect(v.filter(Boolean).length).toBe(1);
+  });
+
+  it('non-empty query with whitespace only: treated as empty (pill still scopes)', () => {
+    const matches = cards.map(() => true);
+    const v = cardVisibility(matches, cats, 'people', '   ');
+    expect(v.filter(Boolean).length).toBe(1);
+  });
+
+  it('respects matches: cards that did not match the query stay hidden', () => {
+    // Only 2 cards "match" the simulated query.
+    const matches = cards.map((c, i) => i === 0 || i === 7);
+    const v = cardVisibility(matches, cats, 'all', 'whatever');
+    expect(v.filter(Boolean).length).toBe(2);
+    expect(v[0]).toBe(true);
+    expect(v[7]).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Typing in the search box on bharatlas.com home grid no longer hides matches that happen to be filed under a different category pill than the one currently active.

**Reported repro** (PR #99 deploy, user-reported):
- Click the **Environment** pill
- Type `over` in the search box
- See `0 matches for "over"` and `No matches. Contribute the first →`
- **But** pill counts already say `All 1/86` and `Infrastructure 1/11` — the Overture Places match exists, it's just been filed under Infrastructure and the renderer was AND-ing search results with the active pill.

The bug made search results depend on invisible context (catalog taxonomy ↔ pill), so the same UI action (`type in search`) produced inconsistent outcomes. `water` "worked" because all `water*` layers happen to be in Environment; `over` "broke" because Overture happens to be in Infrastructure.

## Fix

Per-card visibility on the home grid is now:

```
matches[i] && (query ? true : inActiveCategory)
```

— a query in the search box bypasses the pill scope. When the search clears, the pill scope returns. Pill counts continue to show `filtered/total` so the distribution stays visible.

Standard catalog-search UX (npmjs, GitHub advanced search, etc.).

## Implementation

- New pure helper `cardVisibility(matches, categories, activeCat, query)` in `web/src/catalog-filter.ts`. Doc-comment explains the rationale + carries the symptom for future archeology.
- `web/src/main.ts` swaps the inline `matches[i] && inCat` for the helper and updates the section-hide rule (`catFiltered = !query && …`).
- 5 new vitest tests under `catalog-filter — cardVisibility`:
  - empty query, no active pill: respects matches as-is
  - empty query, active pill: scopes to that category
  - non-empty query: ignores active pill, returns every match (the headline test)
  - whitespace-only query treated as empty
  - matches[i] still respected — non-matching cards stay hidden

## Test plan

- [x] `npm test` — 476/476 vitest pass (was 471, +5 new)
- [x] Locally rebuilt + spot-checked: search `over` with Environment active → Overture renders under Infrastructure
- [x] `water` with Environment active still shows 3 env layers (unchanged behaviour)
- [x] Clearing the search restores pill scope
- [ ] **post-deploy**: production reproduction of the `over` query returns the Overture card

## Out of scope (filed as separate)

- Catalog `download_counts` is **stale by 300 downloads** (catalog says 948, D1 says 1,248) because `build_catalog.py` isn't part of the deploy pipeline. Same root pattern (deploy refreshes the wrong things), different field. Suggested follow-up: either run `build_catalog.py` in CI before prerender, or have `ingest_ramseraph.py` refresh `download_counts` from D1 alongside its other catalog patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)