### PR TITLE
perf(edge): cache /catalog.json + /sitemap.xml + /llms.txt at the edge

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -19,8 +19,21 @@
   Cache-Control: public, max-age=3600
 
 # Catalog data — fresh-ish, but allow stale-while-revalidate so repeat visits feel instant.
+# CDN-Cache-Control is required for CF Pages to actually edge-cache JSON;
+# without it the response is served as cf-cache-status: DYNAMIC.
 /catalog.json
   Cache-Control: public, max-age=300, stale-while-revalidate=86400
+  CDN-Cache-Control: public, max-age=300, stale-while-revalidate=86400
+
+# Sitemap + LLM discovery file — both static, both safe to cache an hour
+# at the edge with stale-while-revalidate so submissions / docs changes
+# show up within a day at worst.
+/sitemap.xml
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+  CDN-Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+/llms.txt
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+  CDN-Cache-Control: public, max-age=3600, stale-while-revalidate=86400
 
 # India boundary overlay — hand-curated GeoJSON from osm-in. Source rarely
 # changes; safe to cache for a week with stale-while-revalidate so a future


### PR DESCRIPTION
## Summary

Three remaining surfaces were still `cf-cache-status: DYNAMIC` on production — origin trip on every hit despite being safe to edge-cache.

| Path | Before | Root cause | Fix |
|---|:-:|---|---|
| `/catalog.json` | DYNAMIC | Had `Cache-Control` but no `CDN-Cache-Control` (CF Pages requires the CDN directive specifically for JSON) | Add `CDN-Cache-Control: public, max-age=300, stale-while-revalidate=86400` |
| `/sitemap.xml` | DYNAMIC | Static `web/public/sitemap.xml` (written by `prerender.mjs`) shadows the edge Function that sets its own cache headers. No `_headers` rule for the static path. | Add new rule: 1 h edge TTL + SWR=86400 |
| `/llms.txt` | DYNAMIC | Flat static file, no `_headers` rule, got default `max-age=0, must-revalidate` | Add new rule: 1 h edge TTL + SWR=86400 |

Pairs with the Cloudflare dashboard Cache Rule update earlier today that put `/docs`, `/mcp`, `/view/*`, `/c/*` into the eligible-for-cache path set. That fixed the HTML surfaces; this fixes the remaining non-HTML ones.

## Test plan
- [x] `npm test` — 476/476 vitest pass
- [ ] **post-deploy** verify (one-liner):
  ```bash
  for u in /catalog.json /sitemap.xml /llms.txt; do
    curl -sI "https://bharatlas.com$u" | grep -i cf-cache-status
  done
  ```
  Expected: `MISS` first hit, `HIT` second.

## Notes
- `catalog.json` keeps a short 5-min edge TTL so the hourly cron + per-submission rebuilds still propagate fast.
- `sitemap.xml` + `llms.txt` are low-churn (per-deploy); 1 h edge + 24 h SWR is plenty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)