### PR TITLE
security: PR-A defensive bundle + CI curl fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,23 +28,49 @@ jobs:
     outputs:
       has-new: ${{ steps.check.outputs.has-new }}
     steps:
-      - name: query D1 for recent accepted submissions
+      - name: query D1 for recent accepted submissions + housekeep rate_limits
         id: check
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # D1 binding-name → database-id mapping. Public identifier — same
+          # value lives in web/wrangler.toml (database_id).
+          D1_DATABASE_ID: c7c0c69e-02aa-482c-ac9a-541b36f21cc4
         run: |
           set -euo pipefail
-          npm install -g wrangler@4 >/dev/null 2>&1
-          RAW=$(wrangler d1 execute geodata-submissions --remote --json \
-            --command "SELECT COUNT(*) AS n FROM submissions WHERE status='accepted' AND created_at >= datetime('now', '-70 minutes')")
-          COUNT=$(echo "$RAW" | jq -r '.[0].results[0].n // 0')
+          # Direct REST call to the CF D1 query API — replaces the
+          # `npm install -g wrangler@4 && wrangler d1 execute` chain that
+          # cost 30+ seconds per cron tick AND occasionally hung for 2
+          # minutes before exiting non-zero. curl + jq are preinstalled on
+          # ubuntu-latest, so this step now runs in ~1 second and has no
+          # silent-install failure mode.
+          d1_query() {
+            curl -sS --fail-with-body --max-time 30 -X POST \
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/d1/database/$D1_DATABASE_ID/query" \
+              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              -H "content-type: application/json" \
+              -d "$1"
+          }
+
+          # 1. Count accepted submissions in the last 70 min (the cron-window
+          #    slack). If >0, trigger a deploy to rebake the home grid.
+          RAW=$(d1_query '{"sql":"SELECT COUNT(*) AS n FROM submissions WHERE status='\''accepted'\'' AND created_at >= datetime('\''now'\'', '\''-70 minutes'\'')"}')
+          COUNT=$(echo "$RAW" | jq -r '.result[0].results[0].n // 0')
           echo "Found $COUNT new submission(s) in the last 70 min"
           if [ "$COUNT" -gt 0 ]; then
             echo "has-new=true" >> "$GITHUB_OUTPUT"
           else
             echo "has-new=false" >> "$GITHUB_OUTPUT"
           fi
+
+          # 2. Housekeeping: the rate_limits table keys per (ip_hash, day);
+          #    each active IP adds a row daily. Without cleanup the table
+          #    grows unbounded — fine for D1 storage in the short term, but
+          #    eventually the index degrades. Hourly DELETE of rows older
+          #    than 2 days keeps it bounded to recent traffic.
+          PRUNED=$(d1_query '{"sql":"DELETE FROM rate_limits WHERE day_window_start < date('\''now'\'', '\''-2 days'\'')"}')
+          DEL_ROWS=$(echo "$PRUNED" | jq -r '.result[0].meta.changes // 0')
+          echo "Pruned $DEL_ROWS stale rate_limits rows"
 
   test-and-deploy:
     needs: [check-community-queue]

--- a/web/functions/api/r2/[[path]].ts
+++ b/web/functions/api/r2/[[path]].ts
@@ -11,10 +11,18 @@ import type { Env } from '../_middleware';
 
 type Params = { path: string[] };
 
+// Tight allowlist: this endpoint exists to serve community-submitted files
+// (see render-view.ts → /api/r2/community/<id>/<filename>). Curated layers
+// are served via the public R2 URL (pub-…r2.dev/…) directly, never through
+// here. Reject any other prefix so a future stray object can't be exfiltrated
+// via the bharatlas-branded same-origin path.
+const ALLOWED_PREFIX = /^community\//;
+
 export const onRequestGet: PagesFunction<Env, keyof Params> = async (ctx) => {
   const segs = (ctx.params.path as string[]) || [];
   const key = segs.join('/');
   if (!key) return new Response('missing key', { status: 400 });
+  if (!ALLOWED_PREFIX.test(key)) return new Response('not found', { status: 404 });
 
   const obj = await ctx.env.R2.get(key);
   if (!obj) return new Response('not found', { status: 404 });

--- a/web/functions/api/v1/_middleware.ts
+++ b/web/functions/api/v1/_middleware.ts
@@ -3,7 +3,9 @@ import { checkApiRateLimit } from '../../lib/api-ratelimit';
 
 export const onRequest: PagesFunction<Env> = async (ctx) => {
   const url = new URL(ctx.request.url);
-  const ip = ctx.request.headers.get('cf-connecting-ip') || ctx.request.headers.get('x-forwarded-for') || 'unknown';
+  // CF-Connecting-IP only — never trust X-Forwarded-For (attacker-controlled
+  // header; a rotating XFF would let one client mint fresh rate-limit buckets).
+  const ip = ctx.request.headers.get('cf-connecting-ip') || 'unknown';
   const ipHash = await sha256(ip);
 
   const isLocate = url.pathname.endsWith('/locate');

--- a/web/functions/c/[id].ts
+++ b/web/functions/c/[id].ts
@@ -5,6 +5,7 @@
 import { getSubmissionForView } from '../lib/submissions';
 import { countVotes } from '../lib/ratings';
 import { renderViewPage } from '../lib/render-view';
+import { SECURITY_HEADERS_HTML } from '../lib/security-headers';
 import type { Env as MiddlewareEnv } from '../api/_middleware';
 
 type Env = MiddlewareEnv;
@@ -18,7 +19,7 @@ export const onRequestGet: PagesFunction<Env, keyof Params> = async (ctx) => {
   if (!/^[A-Za-z0-9_-]{8,16}$/.test(id)) {
     return new Response(NOT_FOUND_HTML, {
       status: 404,
-      headers: { 'content-type': 'text/html; charset=utf-8' },
+      headers: { 'content-type': 'text/html; charset=utf-8', ...SECURITY_HEADERS_HTML },
     });
   }
 
@@ -36,6 +37,7 @@ export const onRequestGet: PagesFunction<Env, keyof Params> = async (ctx) => {
       headers: {
         'content-type': 'text/html; charset=utf-8',
         'cache-control': 'public, max-age=60',
+        ...SECURITY_HEADERS_HTML,
       },
     });
   }
@@ -53,6 +55,7 @@ export const onRequestGet: PagesFunction<Env, keyof Params> = async (ctx) => {
     headers: {
       'content-type': 'text/html; charset=utf-8',
       'cache-control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=86400',
+      ...SECURITY_HEADERS_HTML,
     },
   });
 };

--- a/web/functions/lib/security-headers.ts
+++ b/web/functions/lib/security-headers.ts
@@ -1,0 +1,47 @@
+// Shared security headers for Pages Function responses that don't inherit
+// the static-asset `_headers` policy (CF Pages applies `_headers` only to
+// static assets — Function responses override).
+//
+// Mirrors the CSP/HSTS/Permissions-Policy block in web/public/_headers so
+// the curated and edge-rendered pages have the same defense-in-depth posture.
+// `frame-ancestors 'self'` is the only addition vs `_headers` — it locks out
+// clickjacking on Pages Function pages without breaking the same-origin embed
+// mode (/c/<id>?embed=1).
+//
+// Apply by spreading into the Response init headers:
+//   return new Response(html, {
+//     headers: { ...SECURITY_HEADERS_HTML, 'content-type': 'text/html; ...' },
+//   });
+
+// Single source of truth for the CSP string — match _headers verbatim where
+// possible so /about, /c/<id>, /view/<id> all look identical to a browser.
+const CSP =
+  "default-src 'self'; " +
+  "script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com 'wasm-unsafe-eval'; " +
+  "worker-src 'self' blob:; " +
+  "connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com; " +
+  "img-src 'self' blob: data: https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://services.arcgisonline.com https://*.tile.opentopomap.org https://avatars.githubusercontent.com; " +
+  "style-src 'self' 'unsafe-inline'; " +
+  "font-src 'self'; " +
+  "frame-src https://challenges.cloudflare.com; " +
+  "frame-ancestors 'self'; " +
+  "object-src 'none'; " +
+  "base-uri 'self'";
+
+const SHARED = {
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  'x-content-type-options': 'nosniff',
+  'referrer-policy': 'strict-origin-when-cross-origin',
+  'permissions-policy':
+    'camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()',
+} as const;
+
+/** Full block for HTML-rendering Pages Functions (/c/<id>, /view/<id>). */
+export const SECURITY_HEADERS_HTML = {
+  ...SHARED,
+  'content-security-policy': CSP,
+} as const;
+
+/** Non-HTML responses (sitemap.xml, future XML/JSON) — CSP is irrelevant
+ *  but the cheap headers still tighten defense-in-depth. */
+export const SECURITY_HEADERS_NON_HTML = SHARED;

--- a/web/functions/lib/submit-helpers.ts
+++ b/web/functions/lib/submit-helpers.ts
@@ -43,10 +43,11 @@ export async function ipHashFor(
   salt: string,
   now: () => Date = () => new Date(),
 ): Promise<string> {
-  const ip =
-    request.headers.get('cf-connecting-ip') ||
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-    'unknown';
+  // CF-Connecting-IP only — never trust X-Forwarded-For. On Cloudflare Pages
+  // CF-Connecting-IP is always set; the missing case falls through to
+  // 'unknown' so a single shared bucket absorbs any anomaly rather than
+  // attackers minting fresh hashes via XFF rotation.
+  const ip = request.headers.get('cf-connecting-ip') || 'unknown';
   const material = `${ip}|${todayUTC(now)}|${salt}`;
   return sha256Hex(new TextEncoder().encode(material).buffer as ArrayBuffer);
 }

--- a/web/functions/sitemap.xml.ts
+++ b/web/functions/sitemap.xml.ts
@@ -6,6 +6,7 @@
 // CF Pages Functions take precedence over static files at the same path.
 
 import type { Env } from './api/_middleware';
+import { SECURITY_HEADERS_NON_HTML } from './lib/security-headers';
 
 const ORIGIN = 'https://bharatlas.com';
 
@@ -82,6 +83,7 @@ ${urls.join('\n')}
     headers: {
       'content-type': 'application/xml; charset=utf-8',
       'cache-control': 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+      ...SECURITY_HEADERS_NON_HTML,
     },
   });
 };

--- a/web/functions/view/[id].ts
+++ b/web/functions/view/[id].ts
@@ -6,6 +6,7 @@
 // bundle is the same; main.ts detects /view/<id> and opens that layer.
 
 import { buildViewDataset, buildViewContent, resolveLevelMeta, type CatalogLayer, type LevelMeta } from '../lib/view-dataset';
+import { SECURITY_HEADERS_HTML } from '../lib/security-headers';
 
 type Params = { id: string };
 
@@ -19,7 +20,7 @@ const NOT_FOUND_HTML = `<!doctype html><html><head><meta charset="utf-8"><title>
 export const onRequestGet: PagesFunction<unknown, keyof Params> = async (ctx) => {
   const id = (ctx.params.id as string) || '';
   if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
-    return new Response(NOT_FOUND_HTML, { status: 404, headers: { 'content-type': 'text/html; charset=utf-8' } });
+    return new Response(NOT_FOUND_HTML, { status: 404, headers: { 'content-type': 'text/html; charset=utf-8', ...SECURITY_HEADERS_HTML } });
   }
   const origin = new URL(ctx.request.url).origin;
 
@@ -33,7 +34,7 @@ export const onRequestGet: PagesFunction<unknown, keyof Params> = async (ctx) =>
   const catalog = (await catalogResp.json()) as Catalog;
   const layer = catalog.layers?.find((l) => l.id === id);
   if (!layer) {
-    return new Response(NOT_FOUND_HTML, { status: 404, headers: { 'content-type': 'text/html; charset=utf-8' } });
+    return new Response(NOT_FOUND_HTML, { status: 404, headers: { 'content-type': 'text/html; charset=utf-8', ...SECURITY_HEADERS_HTML } });
   }
 
   const levelMeta = resolveLevelMeta(layer, catalog.level_meta);
@@ -84,6 +85,7 @@ export const onRequestGet: PagesFunction<unknown, keyof Params> = async (ctx) =>
       headers: {
         'content-type': 'text/html; charset=utf-8',
         'cache-control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=86400',
+        ...SECURITY_HEADERS_HTML,
       },
     }));
 };

--- a/web/public/.well-known/security.txt
+++ b/web/public/.well-known/security.txt
@@ -1,0 +1,9 @@
+# bharatlas security disclosure
+# https://www.rfc-editor.org/rfc/rfc9116
+
+Contact: mailto:sathya@urbanmorph.com
+Expires: 2027-05-29T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://bharatlas.com/.well-known/security.txt
+Acknowledgments: https://github.com/urbanmorph/geodata
+Policy: https://github.com/urbanmorph/geodata/security/policy

--- a/web/tests/security-headers.test.ts
+++ b/web/tests/security-headers.test.ts
@@ -80,3 +80,70 @@ describe('Security headers — Cloudflare Pages _headers file', () => {
     expect(headersFile).toMatch(/Referrer-Policy:\s*strict-origin-when-cross-origin/i);
   });
 });
+
+import { SECURITY_HEADERS_HTML, SECURITY_HEADERS_NON_HTML } from '../functions/lib/security-headers';
+
+describe('Security headers — SECURITY_HEADERS_HTML (Pages Function responses)', () => {
+  // CF Pages applies `_headers` only to static assets, not to Pages Function
+  // responses. The HTML-rendering Pages Functions (/c/<id>, /view/<id>)
+  // explicitly spread SECURITY_HEADERS_HTML so they get the same
+  // defense-in-depth posture as prerendered HTML.
+
+  it('sets Strict-Transport-Security', () => {
+    expect(SECURITY_HEADERS_HTML['strict-transport-security']).toMatch(/^max-age=\d+/);
+    expect(SECURITY_HEADERS_HTML['strict-transport-security']).toMatch(/includeSubDomains/);
+  });
+
+  it('sets X-Content-Type-Options: nosniff', () => {
+    expect(SECURITY_HEADERS_HTML['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('sets Referrer-Policy', () => {
+    expect(SECURITY_HEADERS_HTML['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  });
+
+  it('sets Permissions-Policy denying sensitive capabilities', () => {
+    const pp = SECURITY_HEADERS_HTML['permissions-policy'];
+    expect(pp).toMatch(/camera=\(\)/);
+    expect(pp).toMatch(/microphone=\(\)/);
+    expect(pp).toMatch(/geolocation=\(\)/);
+  });
+
+  it('CSP includes frame-ancestors to block clickjacking', () => {
+    // Mirrors `_headers` CSP but adds `frame-ancestors 'self'` so iframe
+    // embeds outside bharatlas are blocked.
+    expect(SECURITY_HEADERS_HTML['content-security-policy']).toMatch(/frame-ancestors\s+'self'/);
+  });
+
+  it("CSP keeps default-src to 'self' and locks object-src", () => {
+    const csp = SECURITY_HEADERS_HTML['content-security-policy'];
+    expect(csp).toMatch(/default-src\s+'self'/);
+    expect(csp).toMatch(/object-src\s+'none'/);
+    expect(csp).toMatch(/base-uri\s+'self'/);
+  });
+
+  it('CSP whitelists the same runtime origins as static _headers', () => {
+    const csp = SECURITY_HEADERS_HTML['content-security-policy'];
+    // Cloudflare Turnstile widget
+    expect(csp).toMatch(/https:\/\/challenges\.cloudflare\.com/);
+    // MapLibre + DuckDB-WASM lazy load
+    expect(csp).toMatch(/https:\/\/cdn\.jsdelivr\.net/);
+    // R2 public reads for layer downloads
+    expect(csp).toMatch(/https:\/\/pub-0429b8e3b5a946e69ea007df844a6f1c\.r2\.dev/);
+  });
+});
+
+describe('Security headers — SECURITY_HEADERS_NON_HTML (sitemap.xml etc.)', () => {
+  // Non-HTML responses don't need CSP but do benefit from HSTS + nosniff.
+
+  it('sets the cheap headers (HSTS, nosniff, RP, PP)', () => {
+    expect(SECURITY_HEADERS_NON_HTML['strict-transport-security']).toBeDefined();
+    expect(SECURITY_HEADERS_NON_HTML['x-content-type-options']).toBe('nosniff');
+    expect(SECURITY_HEADERS_NON_HTML['referrer-policy']).toBeDefined();
+    expect(SECURITY_HEADERS_NON_HTML['permissions-policy']).toBeDefined();
+  });
+
+  it('does NOT set Content-Security-Policy (irrelevant for non-HTML)', () => {
+    expect((SECURITY_HEADERS_NON_HTML as Record<string, string>)['content-security-policy']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Bundles the cheap defense-in-depth wins from yesterday's security audit + the curl-replaces-wrangler fix from the failed scheduled cron. No behaviour change for users; tighter posture against opportunistic abuse and one CI step that no longer hangs for 2 minutes before failing.

## What's in scope

### Security hardenings (audit "cheap wins" only)

- **New `web/functions/lib/security-headers.ts`** — exports `SECURITY_HEADERS_HTML` (full CSP + HSTS + Permissions-Policy + Referrer-Policy + X-Content-Type-Options) and `SECURITY_HEADERS_NON_HTML`. CSP mirrors `web/public/_headers` verbatim **and** adds `frame-ancestors 'self'` to lock out clickjacking.
- **Spread the headers into the three HTML-emitting Pages Functions** — `web/functions/c/[id].ts`, `web/functions/view/[id].ts`, `web/functions/sitemap.xml.ts`. CF Pages applies `_headers` only to static assets, so before this commit `curl -sI https://bharatlas.com/c/<id>` returned zero security headers.
- **R2 prefix allowlist** in `web/functions/api/r2/[[path]].ts` — restricted to `^community/`. This endpoint exists exclusively to serve community-submitted files (per its own header comment); curated R2 objects are reached via the public `pub-…r2.dev/…` URL directly. Anything outside `community/` now 404s before R2 touch, so a future stray object can't be exfiltrated via the bharatlas-branded same-origin path.
- **Drop X-Forwarded-For fallback** in `web/functions/lib/submit-helpers.ts` + `web/functions/api/v1/_middleware.ts`. CF Pages always sets `cf-connecting-ip`; the XFF fallback was latent on prod but a free rate-limit-bypass primitive if CF is ever bypassed.
- **`web/public/.well-known/security.txt`** — RFC 9116 disclosure pointer (sathya@urbanmorph.com + GitHub security policy URL).

### Tier 1.5 housekeeping

- **`rate_limits` cleanup** in the hourly cron — `DELETE FROM rate_limits WHERE day_window_start < date('now','-2 days')` so the table stays bounded to recent traffic. Costs ~3ms more per cron tick.

### CI: curl replaces wrangler for the D1 cron probe

- The `check-community-queue` step's `npm install -g wrangler@4 && wrangler d1 execute --remote` chain cost 30+s per cron tick and occasionally hung for 2 minutes before exiting non-zero (see the 2026-05-29T13:30 failure on commit `75d6ca9` — `wrangler@4.95.0` EBADENGINEs on the runner's default Node 20, install silently fails, then the command crashes).
- Replaced with a direct REST call to the CF D1 query API gated by `curl --max-time 30 --fail-with-body`. `curl` + `jq` are preinstalled on `ubuntu-latest`, so the step now runs in ~1s and surfaces errors instead of swallowing them. Same SQL, no functional change.
- `D1_DATABASE_ID` is hardcoded in the workflow (same value as `web/wrangler.toml`'s `database_id` — public identifier, not a secret).

## Verified locally

Built `dist/`, restarted `wrangler pages dev dist --port 8788`, then:

| probe | result |
|---|---|
| `GET /c/<id>` (local D1 empty) | 404 + full security headers ✓ |
| `GET /view/lgd_states` | 200 + full security headers ✓ |
| `GET /sitemap.xml` | 200 + non-HTML security headers ✓ |
| `GET /.well-known/security.txt` | 200 + RFC 9116 body ✓ |
| `GET /api/r2/community/abc/test` | routed to R2 (404, empty local) ✓ |
| `GET /api/r2/secret/file` | 404 (allowlist blocks before R2 touch) ✓ |

## Test plan

- [x] `npm test` — 485/485 vitest pass (was 476, +9 security-headers tests)
- [x] `npm run build` — clean
- [x] Functional probes via `wrangler pages dev` (above)
- [ ] **post-deploy** — re-verify CSP/HSTS on `/c/<id>` and `/view/<id>` against prod
- [ ] **post-deploy** — `curl -sI https://bharatlas.com/api/r2/admin/states/file` returns 404
- [ ] **next scheduled cron** at minute 17 — the new curl step succeeds in <5s (vs the 2-minute hang on the prior failure)

## Deferred (named in the audit, NOT in this bundle)

- T1.2 — vote-farming via IP rotation. Needs design once community grows past 1 submission.
- T1.3 — server-side re-parse of uploaded bytes in `/api/submit`. Per-format engineering (parquet via hyparquet, KML via sandboxed XML parser).
- T1.4 — `/api/v1/layers/:id/query` parquet OOM/CPU exhaustion. Predicate-pushdown rewrite + tighter per-IP-per-min on `/query` specifically.

Each of those wants its own PR with thought-through design. They're tracked in conversation memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)