### PR TITLE
fix(nearby): Overture timeout — Hilbert sort + tight row groups + top-K cap

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -393,7 +393,7 @@
     "wards_bengaluru_gba": {
       "label": "Greater Bengaluru Wards (2025)",
       "unit": "wards",
-      "description": "Greater Bengaluru Authority — 369 final wards across 5 corporations, notified Nov 2025.",
+      "description": "Greater Bengaluru Authority \u2014 369 final wards across 5 corporations, notified Nov 2025.",
       "source_url": "https://data.opencity.in/dataset/gba-wards-delimitation-2025",
       "source_org": "Greater Bengaluru Authority",
       "notes": "Latest GBA delimitation. Pair with the 5-corp polygons for parent grouping."
@@ -409,7 +409,7 @@
     "wards_bengaluru_bbmp_2022": {
       "label": "BBMP Wards (2022, historical)",
       "unit": "wards",
-      "description": "Bruhat Bengaluru Mahanagara Palike — 243 wards from the 2022 draft delimitation. Historical reference; superseded by the 2025 GBA 369-ward scheme.",
+      "description": "Bruhat Bengaluru Mahanagara Palike \u2014 243 wards from the 2022 draft delimitation. Historical reference; superseded by the 2025 GBA 369-ward scheme.",
       "source_url": "https://data.opencity.in/dataset/bbmp-wards",
       "source_org": "BBMP",
       "notes": "Use the GBA 2025 layer for current ward boundaries."
@@ -433,7 +433,7 @@
     "wards_chennai": {
       "label": "Chennai (GCC) Wards",
       "unit": "wards",
-      "description": "Greater Chennai Corporation — 200 ward boundaries across the 15 zones.",
+      "description": "Greater Chennai Corporation \u2014 200 ward boundaries across the 15 zones.",
       "source_url": "https://data.opencity.in/dataset/gcc-ward-information",
       "source_org": "Greater Chennai Corporation",
       "notes": ""
@@ -441,7 +441,7 @@
     "wards_hyderabad": {
       "label": "Hyderabad (GHMC) Wards",
       "unit": "wards",
-      "description": "Greater Hyderabad Municipal Corporation — 145 wards across 6 zones.",
+      "description": "Greater Hyderabad Municipal Corporation \u2014 145 wards across 6 zones.",
       "source_url": "https://data.opencity.in/dataset/hyderabad-wards-info",
       "source_org": "Greater Hyderabad Municipal Corporation",
       "notes": ""
@@ -449,7 +449,7 @@
     "wards_mumbai": {
       "label": "Mumbai (BMC) Wards",
       "unit": "wards",
-      "description": "Brihanmumbai Municipal Corporation — 24 administrative wards (A–T plus the city-island spread).",
+      "description": "Brihanmumbai Municipal Corporation \u2014 24 administrative wards (A\u2013T plus the city-island spread).",
       "source_url": "https://data.opencity.in/dataset/mumbai-wards",
       "source_org": "Brihanmumbai Municipal Corporation",
       "notes": ""
@@ -465,7 +465,7 @@
     "wards_kolkata": {
       "label": "Kolkata (KMC) Wards",
       "unit": "wards",
-      "description": "Kolkata Municipal Corporation — 141 ward boundaries across the 16 boroughs.",
+      "description": "Kolkata Municipal Corporation \u2014 141 ward boundaries across the 16 boroughs.",
       "source_url": "https://data.opencity.in/dataset/kolkata-wards",
       "source_org": "Kolkata Municipal Corporation",
       "notes": ""
@@ -473,7 +473,7 @@
     "wards_pune": {
       "label": "Pune (PMC) Wards",
       "unit": "wards",
-      "description": "Pune Municipal Corporation — 58 administrative wards.",
+      "description": "Pune Municipal Corporation \u2014 58 administrative wards.",
       "source_url": "https://data.opencity.in/dataset/pune-wards",
       "source_org": "Pune Municipal Corporation",
       "notes": ""
@@ -481,7 +481,7 @@
     "wards_ahmedabad": {
       "label": "Ahmedabad (AMC) Wards",
       "unit": "wards",
-      "description": "Ahmedabad Municipal Corporation — 48 wards across the 7 zones.",
+      "description": "Ahmedabad Municipal Corporation \u2014 48 wards across the 7 zones.",
       "source_url": "https://data.opencity.in/dataset/ahmedabad-wards",
       "source_org": "Ahmedabad Municipal Corporation",
       "notes": ""
@@ -489,7 +489,7 @@
     "wards_jaipur": {
       "label": "Jaipur (JMC) Wards",
       "unit": "wards",
-      "description": "Jaipur Municipal Corporation — 150 ward boundaries.",
+      "description": "Jaipur Municipal Corporation \u2014 150 ward boundaries.",
       "source_url": "https://data.opencity.in/dataset/jaipur-wards",
       "source_org": "Jaipur Municipal Corporation",
       "notes": ""
@@ -497,7 +497,7 @@
     "wards_gurugram": {
       "label": "Gurugram (MCG) Wards",
       "unit": "wards",
-      "description": "Municipal Corporation of Gurugram — 35 ward boundaries.",
+      "description": "Municipal Corporation of Gurugram \u2014 35 ward boundaries.",
       "source_url": "https://data.opencity.in/dataset/gurugram-wards",
       "source_org": "Municipal Corporation of Gurugram",
       "notes": ""
@@ -505,7 +505,7 @@
     "wards_kochi": {
       "label": "Kochi (KMC) Wards",
       "unit": "wards",
-      "description": "Kochi Municipal Corporation ward boundaries — 74 administrative wards covering the city. Sourced from Oorvani Foundation's OpenCity data portal.",
+      "description": "Kochi Municipal Corporation ward boundaries \u2014 74 administrative wards covering the city. Sourced from Oorvani Foundation's OpenCity data portal.",
       "source_url": "https://data.opencity.in/dataset/kochi-wards",
       "source_org": "Kochi Municipal Corporation",
       "notes": ""
@@ -513,7 +513,7 @@
     "wards_bhubaneshwar": {
       "label": "Bhubaneshwar (BMC) Wards",
       "unit": "wards",
-      "description": "Bhubaneshwar Municipal Corporation ward boundaries — 67 wards covering Odisha's capital city. Sourced from Oorvani Foundation's OpenCity data portal.",
+      "description": "Bhubaneshwar Municipal Corporation ward boundaries \u2014 67 wards covering Odisha's capital city. Sourced from Oorvani Foundation's OpenCity data portal.",
       "source_url": "https://data.opencity.in/dataset/bhubaneshwar-wards",
       "source_org": "Bhubaneshwar Municipal Corporation",
       "notes": ""
@@ -521,7 +521,7 @@
     "wards_vizag": {
       "label": "Visakhapatnam (GVMC) Wards",
       "unit": "wards",
-      "description": "Greater Visakhapatnam Municipal Corporation — 98 wards.",
+      "description": "Greater Visakhapatnam Municipal Corporation \u2014 98 wards.",
       "source_url": "https://data.opencity.in/dataset/visakhapatnam-wards",
       "source_org": "Greater Visakhapatnam Municipal Corporation",
       "notes": ""
@@ -529,7 +529,7 @@
     "wards_thane": {
       "label": "Thane (TMC) Wards",
       "unit": "wards",
-      "description": "Thane Municipal Corporation — 47 wards across the city.",
+      "description": "Thane Municipal Corporation \u2014 47 wards across the city.",
       "source_url": "https://data.opencity.in/dataset/thane-wards",
       "source_org": "Thane Municipal Corporation",
       "notes": ""
@@ -545,7 +545,7 @@
     "wards_indore": {
       "label": "Indore (IMC) Wards (2024)",
       "unit": "wards",
-      "description": "Indore Municipal Corporation — 85 ward boundaries. 2024 delimitation.",
+      "description": "Indore Municipal Corporation \u2014 85 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/indore-wards-map",
       "source_org": "Indore Municipal Corporation",
       "notes": ""
@@ -553,7 +553,7 @@
     "wards_coimbatore": {
       "label": "Coimbatore (CCMC) Wards (2011)",
       "unit": "wards",
-      "description": "Coimbatore City Municipal Corporation — 100 ward boundaries. Census 2011 reorganization.",
+      "description": "Coimbatore City Municipal Corporation \u2014 100 ward boundaries. Census 2011 reorganization.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Coimbatore",
       "source_org": "DataMeet",
       "notes": ""
@@ -561,7 +561,7 @@
     "wards_madurai": {
       "label": "Madurai (MCM) Wards (2024)",
       "unit": "wards",
-      "description": "Madurai City Municipal Corporation — 100 ward boundaries. 2024 delimitation.",
+      "description": "Madurai City Municipal Corporation \u2014 100 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/madurai-wards-map",
       "source_org": "Madurai City Municipal Corporation",
       "notes": ""
@@ -569,7 +569,7 @@
     "wards_navi_mumbai": {
       "label": "Navi Mumbai (NMMC) Wards (2024)",
       "unit": "wards",
-      "description": "Navi Mumbai Municipal Corporation — 111 ward boundaries. 2024 delimitation.",
+      "description": "Navi Mumbai Municipal Corporation \u2014 111 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/navi-mumbai-wards-map",
       "source_org": "Navi Mumbai Municipal Corporation",
       "notes": ""
@@ -577,7 +577,7 @@
     "wards_guwahati": {
       "label": "Guwahati (GMC) Wards (2022)",
       "unit": "wards",
-      "description": "Guwahati Municipal Corporation — 60 ward boundaries. 2022 delimitation.",
+      "description": "Guwahati Municipal Corporation \u2014 60 ward boundaries. 2022 delimitation.",
       "source_url": "https://data.opencity.in/dataset/guwahati-wards-information",
       "source_org": "Guwahati Municipal Corporation",
       "notes": ""
@@ -585,7 +585,7 @@
     "wards_mysuru": {
       "label": "Mysuru (MCC) Wards",
       "unit": "wards",
-      "description": "Mysuru City Corporation — 65 ward boundaries.",
+      "description": "Mysuru City Corporation \u2014 65 ward boundaries.",
       "source_url": "https://data.opencity.in/dataset/mysuru-city-corporation-wards-info",
       "source_org": "Mysuru City Corporation",
       "notes": ""
@@ -593,7 +593,7 @@
     "wards_bhopal": {
       "label": "Bhopal (BMC) Wards (2024)",
       "unit": "wards",
-      "description": "Bhopal Municipal Corporation — 86 ward boundaries. 2024 delimitation.",
+      "description": "Bhopal Municipal Corporation \u2014 86 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/bhopal-wards-map",
       "source_org": "Bhopal Municipal Corporation",
       "notes": ""
@@ -601,7 +601,7 @@
     "wards_chandigarh": {
       "label": "Chandigarh (MC) Wards",
       "unit": "wards",
-      "description": "Municipal Corporation of Chandigarh — 28 ward boundaries.",
+      "description": "Municipal Corporation of Chandigarh \u2014 28 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Chandigarh",
       "source_org": "Municipal Corporation of Chandigarh",
       "notes": ""
@@ -609,7 +609,7 @@
     "wards_lucknow": {
       "label": "Lucknow (LMC) Wards",
       "unit": "wards",
-      "description": "Lucknow Municipal Corporation — 112 ward boundaries.",
+      "description": "Lucknow Municipal Corporation \u2014 112 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Lucknow",
       "source_org": "Lucknow Municipal Corporation",
       "notes": ""
@@ -617,7 +617,7 @@
     "wards_kanpur": {
       "label": "Kanpur (KMC) Wards",
       "unit": "wards",
-      "description": "Kanpur Municipal Corporation — 58 ward boundaries.",
+      "description": "Kanpur Municipal Corporation \u2014 58 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Kanpur",
       "source_org": "Kanpur Municipal Corporation",
       "notes": ""
@@ -625,7 +625,7 @@
     "wards_patna": {
       "label": "Patna (PMC) Wards (~2019)",
       "unit": "wards",
-      "description": "Patna Municipal Corporation — 75 wards (628 sub-ward polygons). Two naming schemes: numbered \"Ward N\" and spelled-out names.",
+      "description": "Patna Municipal Corporation \u2014 75 wards (628 sub-ward polygons). Two naming schemes: numbered \"Ward N\" and spelled-out names.",
       "source_url": "https://github.com/datta07/INDIAN-SHAPEFILES/tree/master/METROPOLITAN%20CITIES",
       "source_org": "datta07/INDIAN-SHAPEFILES",
       "notes": ""
@@ -633,7 +633,7 @@
     "wards_surat": {
       "label": "Surat (SMC) Wards (~2019)",
       "unit": "wards",
-      "description": "Surat Municipal Corporation — 30 ward boundaries with named wards.",
+      "description": "Surat Municipal Corporation \u2014 30 ward boundaries with named wards.",
       "source_url": "https://github.com/datta07/INDIAN-SHAPEFILES/tree/master/METROPOLITAN%20CITIES",
       "source_org": "datta07/INDIAN-SHAPEFILES",
       "notes": ""
@@ -641,7 +641,7 @@
     "wards_vadodara": {
       "label": "Vadodara (VMC) Wards",
       "unit": "wards",
-      "description": "Vadodara Municipal Corporation — 12 administrative ward boundaries.",
+      "description": "Vadodara Municipal Corporation \u2014 12 administrative ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Vadodara",
       "source_org": "DataMeet",
       "notes": ""
@@ -649,7 +649,7 @@
     "wards_faridabad": {
       "label": "Faridabad (MCF) Wards",
       "unit": "wards",
-      "description": "Municipal Corporation of Faridabad — 40 ward boundaries.",
+      "description": "Municipal Corporation of Faridabad \u2014 40 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Faridabad",
       "source_org": "DataMeet",
       "notes": ""
@@ -657,7 +657,7 @@
     "wards_pcmc": {
       "label": "Pimpri-Chinchwad (PCMC) Electoral Wards",
       "unit": "wards",
-      "description": "Pimpri-Chinchwad Municipal Corporation — 66 electoral ward boundaries across 6 zones.",
+      "description": "Pimpri-Chinchwad Municipal Corporation \u2014 66 electoral ward boundaries across 6 zones.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/PCMC",
       "source_org": "DataMeet",
       "notes": ""
@@ -665,7 +665,7 @@
     "wards_vijayawada": {
       "label": "Vijayawada (VMC) Wards",
       "unit": "wards",
-      "description": "Vijayawada Municipal Corporation — 77 ward boundaries.",
+      "description": "Vijayawada Municipal Corporation \u2014 77 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Vijayawada",
       "source_org": "DataMeet",
       "notes": ""
@@ -706,14 +706,14 @@
       "description": "Solar panel array polygon boundaries across India."
     },
     "vedas_solar_panels_ai_2023": {
-      "label": "Solar panels — AI-detected (VEDAS 2023)",
+      "label": "Solar panels \u2014 AI-detected (VEDAS 2023)",
       "unit": "solar panels",
       "description": "AI-derived solar panel footprints across India from VEDAS, 2023 snapshot. Complements the manually curated solar plants layer."
     },
     "vedas_transmission_lines": {
       "label": "Power transmission lines (VEDAS)",
       "unit": "transmission line segments",
-      "description": "High-voltage transmission line geometry across India. Licence differs from the rest of the VEDAS family — ODbL because the source is OSM-derived."
+      "description": "High-voltage transmission line geometry across India. Licence differs from the rest of the VEDAS family \u2014 ODbL because the source is OSM-derived."
     },
     "pmgsy_habitations": {
       "label": "Rural habitations (PMGSY 2024)",
@@ -728,12 +728,12 @@
     "wris_watersheds": {
       "label": "Watersheds (WRIS 2024)",
       "unit": "watersheds",
-      "description": "Watershed boundary polygons from CWC WRIS — the tier below sub-basin in the hydrology hierarchy."
+      "description": "Watershed boundary polygons from CWC WRIS \u2014 the tier below sub-basin in the hydrology hierarchy."
     },
     "wris_river_polygons": {
       "label": "River polygons (WRIS 2024)",
       "unit": "river polygons",
-      "description": "Rivers as polygon geometry from CWC WRIS — complements the existing line-geometry river network for area-based queries."
+      "description": "Rivers as polygon geometry from CWC WRIS \u2014 complements the existing line-geometry river network for area-based queries."
     },
     "slusi_soil_health": {
       "label": "Soil health (SLUSI 2020-23 snapshot)",
@@ -743,12 +743,12 @@
     "wris_waterbodies": {
       "label": "Waterbodies (WRIS 2024)",
       "unit": "waterbodies",
-      "description": "Surface waterbody polygons from CWC WRIS — covers ponds, tanks, reservoirs and natural waterbodies beyond named lakes."
+      "description": "Surface waterbody polygons from CWC WRIS \u2014 covers ponds, tanks, reservoirs and natural waterbodies beyond named lakes."
     },
     "slusi_micro_watersheds": {
       "label": "Micro-watersheds (SLUSI)",
       "unit": "micro-watersheds",
-      "description": "Micro-watershed boundary polygons across India from the Soil and Land Use Survey of India — the finest watershed delineation in the hydrology hierarchy."
+      "description": "Micro-watershed boundary polygons across India from the Soil and Land Use Survey of India \u2014 the finest watershed delineation in the hydrology hierarchy."
     },
     "pmgsy_roads": {
       "label": "Rural roads (PMGSY 2024)",
@@ -763,7 +763,7 @@
     "gsi_landslide_inventory": {
       "label": "Landslide inventory (GSI)",
       "unit": "landslides",
-      "description": "Geological Survey of India landslide inventory — pan-India catalogue of historical landslide occurrences with metadata."
+      "description": "Geological Survey of India landslide inventory \u2014 pan-India catalogue of historical landslide occurrences with metadata."
     },
     "ndem_landslide_hazard": {
       "label": "Landslide hazard zones (NDEM)",
@@ -781,7 +781,7 @@
       "description": "Historical cyclone track line geometries across the Indian Ocean basins, compiled by NDEM."
     },
     "overture_places_india": {
-      "label": "Places — Overture Maps (Dec 2023)",
+      "label": "Places \u2014 Overture Maps (Dec 2023)",
       "unit": "places",
       "description": "Pan-India points of interest from the Overture Maps Foundation December 2023 release. Names, categories, addresses, websites and confidence scores for restaurants, shops, ATMs, schools, transit, monuments and more."
     }
@@ -1489,7 +1489,7 @@
       "category": "people",
       "provenance": "curated",
       "fetched_at": "2026-05-21T10:31:10.501660+00:00",
-      "notes": "Lok Sabha constituencies — 543 polygons covering the entire country. Latest delimitation."
+      "notes": "Lok Sabha constituencies \u2014 543 polygons covering the entire country. Latest delimitation."
     },
     {
       "id": "lgd_assembly",
@@ -1606,7 +1606,7 @@
       "category": "infrastructure",
       "provenance": "curated",
       "fetched_at": "2026-05-23T17:18:45.854281+00:00",
-      "notes": "India Post pincode boundary polygons (simplified). 63,864 polygons. © 2025 Saket Choudhary, MIT-licensed via bharatviz.org. Source: bharatviz.org/India_pincodes_simplified.geojson; code repo github.com/saketlab/bharatviz."
+      "notes": "India Post pincode boundary polygons (simplified). 63,864 polygons. \u00a9 2025 Saket Choudhary, MIT-licensed via bharatviz.org. Source: bharatviz.org/India_pincodes_simplified.geojson; code repo github.com/saketlab/bharatviz."
     },
     {
       "id": "gs_wildlife",
@@ -1926,7 +1926,7 @@
       "category": "environment",
       "provenance": "curated",
       "fetched_at": "2026-05-24T14:09:37.777020+00:00",
-      "notes": "India's river network from CWC WRIS — line geometry for streams and rivers."
+      "notes": "India's river network from CWC WRIS \u2014 line geometry for streams and rivers."
     },
     {
       "id": "seismic_zones",
@@ -2206,7 +2206,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Greater Bengaluru Authority — 369 final wards across 5 corporations, notified Nov 2025."
+      "notes": "Greater Bengaluru Authority \u2014 369 final wards across 5 corporations, notified Nov 2025."
     },
     {
       "id": "corporation_bengaluru",
@@ -2283,7 +2283,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Bruhat Bengaluru Mahanagara Palike — 243 wards from the 2022 draft delimitation. Historical reference; superseded by the 2025 GBA 369-ward scheme."
+      "notes": "Bruhat Bengaluru Mahanagara Palike \u2014 243 wards from the 2022 draft delimitation. Historical reference; superseded by the 2025 GBA 369-ward scheme."
     },
     {
       "id": "bda_jurisdiction",
@@ -2400,7 +2400,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Greater Chennai Corporation — 200 ward boundaries across the 15 zones."
+      "notes": "Greater Chennai Corporation \u2014 200 ward boundaries across the 15 zones."
     },
     {
       "id": "wards_hyderabad",
@@ -2440,7 +2440,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Greater Hyderabad Municipal Corporation — 145 wards across 6 zones."
+      "notes": "Greater Hyderabad Municipal Corporation \u2014 145 wards across 6 zones."
     },
     {
       "id": "wards_mumbai",
@@ -2480,7 +2480,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Brihanmumbai Municipal Corporation — 24 administrative wards (A–T plus the city-island spread)."
+      "notes": "Brihanmumbai Municipal Corporation \u2014 24 administrative wards (A\u2013T plus the city-island spread)."
     },
     {
       "id": "electoral_wards_mumbai_2017",
@@ -2557,7 +2557,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Kolkata Municipal Corporation — 141 ward boundaries across the 16 boroughs."
+      "notes": "Kolkata Municipal Corporation \u2014 141 ward boundaries across the 16 boroughs."
     },
     {
       "id": "wards_pune",
@@ -2597,7 +2597,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Pune Municipal Corporation — 58 administrative wards."
+      "notes": "Pune Municipal Corporation \u2014 58 administrative wards."
     },
     {
       "id": "wards_ahmedabad",
@@ -2637,7 +2637,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Ahmedabad Municipal Corporation — 48 wards across the 7 zones."
+      "notes": "Ahmedabad Municipal Corporation \u2014 48 wards across the 7 zones."
     },
     {
       "id": "wards_jaipur",
@@ -2677,7 +2677,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Jaipur Municipal Corporation — 150 ward boundaries."
+      "notes": "Jaipur Municipal Corporation \u2014 150 ward boundaries."
     },
     {
       "id": "wards_gurugram",
@@ -2717,7 +2717,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Municipal Corporation of Gurugram — 35 ward boundaries."
+      "notes": "Municipal Corporation of Gurugram \u2014 35 ward boundaries."
     },
     {
       "id": "wards_kochi",
@@ -2757,7 +2757,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Kochi Municipal Corporation ward boundaries — 74 administrative wards covering the city. Sourced from Oorvani Foundation's OpenCity data portal."
+      "notes": "Kochi Municipal Corporation ward boundaries \u2014 74 administrative wards covering the city. Sourced from Oorvani Foundation's OpenCity data portal."
     },
     {
       "id": "wards_bhubaneshwar",
@@ -2794,7 +2794,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Bhubaneshwar Municipal Corporation ward boundaries — 67 wards covering Odisha's capital city. Sourced from Oorvani Foundation's OpenCity data portal."
+      "notes": "Bhubaneshwar Municipal Corporation ward boundaries \u2014 67 wards covering Odisha's capital city. Sourced from Oorvani Foundation's OpenCity data portal."
     },
     {
       "id": "wards_vizag",
@@ -2834,7 +2834,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Greater Visakhapatnam Municipal Corporation — 98 wards."
+      "notes": "Greater Visakhapatnam Municipal Corporation \u2014 98 wards."
     },
     {
       "id": "wards_thane",
@@ -2874,7 +2874,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Thane Municipal Corporation — 47 wards across the city."
+      "notes": "Thane Municipal Corporation \u2014 47 wards across the city."
     },
     {
       "id": "wards_delhi",
@@ -2954,7 +2954,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Indore Municipal Corporation — 85 ward boundaries. 2024 delimitation."
+      "notes": "Indore Municipal Corporation \u2014 85 ward boundaries. 2024 delimitation."
     },
     {
       "id": "wards_coimbatore",
@@ -2994,7 +2994,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Coimbatore City Municipal Corporation — 100 ward boundaries. Census 2011 reorganization."
+      "notes": "Coimbatore City Municipal Corporation \u2014 100 ward boundaries. Census 2011 reorganization."
     },
     {
       "id": "wards_madurai",
@@ -3034,7 +3034,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Madurai City Municipal Corporation — 100 ward boundaries. 2024 delimitation."
+      "notes": "Madurai City Municipal Corporation \u2014 100 ward boundaries. 2024 delimitation."
     },
     {
       "id": "wards_navi_mumbai",
@@ -3074,7 +3074,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Navi Mumbai Municipal Corporation — 111 ward boundaries. 2024 delimitation."
+      "notes": "Navi Mumbai Municipal Corporation \u2014 111 ward boundaries. 2024 delimitation."
     },
     {
       "id": "wards_guwahati",
@@ -3114,7 +3114,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Guwahati Municipal Corporation — 60 ward boundaries. 2022 delimitation."
+      "notes": "Guwahati Municipal Corporation \u2014 60 ward boundaries. 2022 delimitation."
     },
     {
       "id": "wards_mysuru",
@@ -3154,7 +3154,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Mysuru City Corporation — 65 ward boundaries."
+      "notes": "Mysuru City Corporation \u2014 65 ward boundaries."
     },
     {
       "id": "wards_bhopal",
@@ -3194,7 +3194,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Bhopal Municipal Corporation — 86 ward boundaries. 2024 delimitation."
+      "notes": "Bhopal Municipal Corporation \u2014 86 ward boundaries. 2024 delimitation."
     },
     {
       "id": "wards_chandigarh",
@@ -3234,7 +3234,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Municipal Corporation of Chandigarh — 28 ward boundaries."
+      "notes": "Municipal Corporation of Chandigarh \u2014 28 ward boundaries."
     },
     {
       "id": "wards_lucknow",
@@ -3274,7 +3274,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Lucknow Municipal Corporation — 112 ward boundaries."
+      "notes": "Lucknow Municipal Corporation \u2014 112 ward boundaries."
     },
     {
       "id": "wards_kanpur",
@@ -3314,7 +3314,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Kanpur Municipal Corporation — 58 ward boundaries."
+      "notes": "Kanpur Municipal Corporation \u2014 58 ward boundaries."
     },
     {
       "id": "wards_patna",
@@ -3354,7 +3354,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.109170+00:00",
-      "notes": "Patna Municipal Corporation — 75 wards (628 sub-ward polygons). Two naming schemes: numbered \"Ward N\" and spelled-out names."
+      "notes": "Patna Municipal Corporation \u2014 75 wards (628 sub-ward polygons). Two naming schemes: numbered \"Ward N\" and spelled-out names."
     },
     {
       "id": "wards_surat",
@@ -3394,7 +3394,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.110005+00:00",
-      "notes": "Surat Municipal Corporation — 30 ward boundaries with named wards."
+      "notes": "Surat Municipal Corporation \u2014 30 ward boundaries with named wards."
     },
     {
       "id": "wards_vadodara",
@@ -3434,7 +3434,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.110706+00:00",
-      "notes": "Vadodara Municipal Corporation — 12 administrative ward boundaries."
+      "notes": "Vadodara Municipal Corporation \u2014 12 administrative ward boundaries."
     },
     {
       "id": "wards_faridabad",
@@ -3474,7 +3474,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.111326+00:00",
-      "notes": "Municipal Corporation of Faridabad — 40 ward boundaries."
+      "notes": "Municipal Corporation of Faridabad \u2014 40 ward boundaries."
     },
     {
       "id": "wards_pcmc",
@@ -3514,7 +3514,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.112003+00:00",
-      "notes": "Pimpri-Chinchwad Municipal Corporation — 66 electoral ward boundaries across 6 zones."
+      "notes": "Pimpri-Chinchwad Municipal Corporation \u2014 66 electoral ward boundaries across 6 zones."
     },
     {
       "id": "wards_vijayawada",
@@ -3554,7 +3554,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.112629+00:00",
-      "notes": "Vijayawada Municipal Corporation — 77 ward boundaries."
+      "notes": "Vijayawada Municipal Corporation \u2014 77 ward boundaries."
     },
     {
       "id": "india_boundary",
@@ -3586,7 +3586,7 @@
       "category": "boundaries",
       "provenance": "curated",
       "fetched_at": "2026-05-24T13:16:39.947047+00:00",
-      "notes": "India's national boundary as a single MultiPolygon, derived by dissolving the 36 LGD state + UT polygons. India-correct by construction (LGD is India's authoritative admin source — includes Aksai Chin via J&K/Ladakh and the full Arunachal Pradesh claim)."
+      "notes": "India's national boundary as a single MultiPolygon, derived by dissolving the 36 LGD state + UT polygons. India-correct by construction (LGD is India's authoritative admin source \u2014 includes Aksai Chin via J&K/Ladakh and the full Arunachal Pradesh claim)."
     },
     {
       "id": "india_flood_inventory",
@@ -3730,7 +3730,7 @@
       "category": "boundaries",
       "provenance": "curated",
       "fetched_at": "2026-05-19T07:50:55.916651+00:00",
-      "notes": "mislabeled in upstream — block-equivalent, not village"
+      "notes": "mislabeled in upstream \u2014 block-equivalent, not village"
     },
     {
       "id": "high_courts",
@@ -4408,7 +4408,7 @@
       "category": "infrastructure",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from ISRO VEDAS energymap (transmission lines). OSM-derived per release body — ODbL applies."
+      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from ISRO VEDAS energymap (transmission lines). OSM-derived per release body \u2014 ODbL applies."
     },
     {
       "id": "pmgsy_habitations",
@@ -4675,7 +4675,7 @@
       },
       "category": "environment",
       "provenance": "curated",
-      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from NDEM cyclone track lines. Line geometry — see ndem_cyclones_ctp for the time-step point positions when needed.",
+      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from NDEM cyclone track lines. Line geometry \u2014 see ndem_cyclones_ctp for the time-step point positions when needed.",
       "geojson": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/environment/ndem-cyclone-tracks/NDEM_Cyclones_ctl.geojson",
         "bytes": 2234277
@@ -4698,7 +4698,7 @@
       "parquet": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/pois/overture-places/overture_places_india.parquet",
         "upstream_url": "https://github.com/ramSeraph/indian_facilities/releases/download/pois/overture_places_india.parquet",
-        "bytes": 289738241
+        "bytes": 254030046
       },
       "pmtiles": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/pois/overture-places/overture_places_india.pmtiles",
@@ -4715,7 +4715,7 @@
       },
       "category": "infrastructure",
       "provenance": "curated",
-      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from Overture Maps Foundation 2023-12-14-alpha.0 release. Dec 2023 snapshot — refresh tracks ramSeraph's republish cadence, not Overture's monthly upstream releases.",
+      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from Overture Maps Foundation 2023-12-14-alpha.0 release. Dec 2023 snapshot \u2014 refresh tracks ramSeraph's republish cadence, not Overture's monthly upstream releases.",
       "geojson": null,
       "kml": null,
       "shapefile": null,
@@ -4860,7 +4860,7 @@
           "type": "float",
           "distinct": 115,
           "null_frac": 0.0,
-          "min": 9.77917883249722E-7,
+          "min": 9.77917883249722e-07,
           "max": 0.000867317553441183
         },
         {
@@ -6493,11 +6493,11 @@
           "type": "float",
           "distinct": 40,
           "null_frac": 0.0,
-          "min": 0.0000739312032324,
+          "min": 7.39312032324e-05,
           "max": 0.0038809564025,
           "top_values": [
             {
-              "v": 0.000088107787503,
+              "v": 8.8107787503e-05,
               "n": 1
             },
             {
@@ -6613,7 +6613,7 @@
               "n": 1
             },
             {
-              "v": 0.0000739312032324,
+              "v": 7.39312032324e-05,
               "n": 1
             },
             {
@@ -6637,7 +6637,7 @@
               "n": 1
             },
             {
-              "v": 0.0000838053795906,
+              "v": 8.38053795906e-05,
               "n": 1
             },
             {
@@ -6649,7 +6649,7 @@
               "n": 1
             },
             {
-              "v": 0.0000864973505915,
+              "v": 8.64973505915e-05,
               "n": 1
             },
             {
@@ -6929,7 +6929,7 @@
           "type": "float",
           "distinct": 76,
           "null_frac": 0.0,
-          "min": 6.96794667375E-7,
+          "min": 6.96794667375e-07,
           "max": 0.00046029591055
         },
         {

--- a/scripts/external-ingested.json
+++ b/scripts/external-ingested.json
@@ -1094,11 +1094,11 @@
     "license": "CDLA-Permissive-2.0",
     "r2_prefix": "pois/overture-places",
     "parquet_file": "overture_places_india.parquet",
-    "parquet_bytes": 289738241,
+    "parquet_bytes": 254030046,
     "pmtiles_file": "overture_places_india.pmtiles",
     "pmtiles_bytes": 1207239373,
     "source_url": "https://overturemaps.org/overture-december-2023-release-notes/",
     "source_org": "Overture Maps Foundation",
-    "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps from Overture Maps Foundation 2023-12-14-alpha.0 release. Dec 2023 snapshot \u2014 refresh tracks ramSeraph's republish cadence, not Overture's monthly upstream releases."
+    "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from Overture Maps Foundation 2023-12-14-alpha.0 release. Dec 2023 snapshot \u2014 refresh tracks ramSeraph's republish cadence, not Overture's monthly upstream releases."
   }
 ]

--- a/scripts/ingest_ramseraph.py
+++ b/scripts/ingest_ramseraph.py
@@ -514,33 +514,73 @@ def http_download(url: str, dest: Path) -> int:
     return n
 
 
+def row_group_size_for(feature_count: int) -> int | None:
+    """Tighter row groups → tighter per-group bbox stats → more effective
+    /api/v1/nearby pruning. Default (122880) wastes pruning on dense layers
+    because a single group still covers a meaningful chunk of India even
+    after Hilbert sort. Bucket by feature count so each layer ends up with
+    roughly 10-100 groups.
+    Returns None for tiny layers where a single group is fine.
+    """
+    if feature_count < 10_000:    return None
+    if feature_count < 100_000:   return 5_000
+    if feature_count < 1_000_000: return 20_000
+    return 50_000
+
+
 def rebake_flatten_bbox(src: Path, dst: Path) -> tuple[int, list[str]]:
-    """Re-emit parquet with the bbox STRUCT flattened to top-level xmin/ymin/
-    xmax/ymax columns (so parquet-query's centroid logic works unchanged).
+    """Re-emit parquet so /api/v1/nearby can prune efficiently:
+      1. Top-level flat xmin/ymin/xmax/ymax columns — either flattened from
+         an existing `bbox` STRUCT (ramSeraph shape) or synthesised from the
+         geometry's extent when neither is present (own-bake LGD shape).
+      2. Rows ordered along a Hilbert curve over India's bbox so row-group
+         bbox stats are tight enough for hyparquet to skip entire groups.
+
+    Without (1) /nearby falls through to a full WKB scan that's capped at
+    200 MB; without (2) the row-group bbox stats span all of India and no
+    pruning happens regardless of how good the filter is.
+
     Returns (feature_count, non-geom column names).
     """
     con = duckdb.connect()
     con.execute('INSTALL spatial; LOAD spatial;')
-    # Discover the column structure
     cols = con.execute(f"DESCRIBE SELECT * FROM read_parquet('{src}')").fetchall()
     col_names = [c[0] for c in cols]
-    has_bbox = 'bbox' in col_names
+    has_bbox_struct = 'bbox' in col_names
+    has_flat_bbox = all(c in col_names for c in ('xmin', 'ymin', 'xmax', 'ymax'))
+    # ramSeraph parquet stores `geometry` already typed as GEOMETRY; a few
+    # older / simpler files store it as raw BLOB (WKB). Detect which.
+    geom_type = next((c[1] for c in cols if c[0] == 'geometry'), 'BLOB')
+    geom_expr = 'geometry' if 'GEOMETRY' in geom_type else 'ST_GeomFromWKB(geometry)'
+    # India bbox; ST_Hilbert uses this as the curve's domain so the 32-bit
+    # index has max resolution over the country instead of the whole world.
+    india_bbox = "ST_Extent(ST_MakeEnvelope(68, 6, 98, 38))"
 
-    if not has_bbox:
-        # Nothing to flatten — copy through with zstd recompression.
-        con.execute(
-            f"COPY (SELECT * FROM read_parquet('{src}')) TO '{dst}' "
-            "(FORMAT PARQUET, COMPRESSION ZSTD)"
-        )
-    else:
-        # Flatten bbox struct. Drop the struct column; add flat fields.
-        con.execute(
-            f"COPY (SELECT * EXCLUDE (bbox), "
+    if has_bbox_struct:
+        # Flatten the struct into top-level cols, drop the struct itself.
+        bbox_clause = (
+            f"SELECT * EXCLUDE (bbox), "
             f"bbox.xmin AS xmin, bbox.ymin AS ymin, "
-            f"bbox.xmax AS xmax, bbox.ymax AS ymax "
-            f"FROM read_parquet('{src}')) TO '{dst}' "
-            "(FORMAT PARQUET, COMPRESSION ZSTD)"
+            f"bbox.xmax AS xmax, bbox.ymax AS ymax"
         )
+    elif has_flat_bbox:
+        bbox_clause = "SELECT *"
+    else:
+        # No bbox in source; compute from the geometry's extent per row.
+        bbox_clause = (
+            f"SELECT *, "
+            f"ST_XMin({geom_expr}) AS xmin, ST_YMin({geom_expr}) AS ymin, "
+            f"ST_XMax({geom_expr}) AS xmax, ST_YMax({geom_expr}) AS ymax"
+        )
+
+    row_count = con.execute(f"SELECT COUNT(*) FROM read_parquet('{src}')").fetchone()[0]
+    rgs = row_group_size_for(row_count)
+    rgs_clause = f", ROW_GROUP_SIZE {rgs}" if rgs is not None else ""
+    con.execute(
+        f"COPY ({bbox_clause} FROM read_parquet('{src}') "
+        f"ORDER BY ST_Hilbert({geom_expr}, {india_bbox})) TO '{dst}' "
+        f"(FORMAT PARQUET, COMPRESSION ZSTD, COMPRESSION_LEVEL 9{rgs_clause})"
+    )
 
     n = con.execute(f"SELECT COUNT(*) FROM read_parquet('{dst}')").fetchone()[0]
     final_cols = con.execute(f"DESCRIBE SELECT * FROM read_parquet('{dst}')").fetchall()

--- a/scripts/test_hilbert_sort.py
+++ b/scripts/test_hilbert_sort.py
@@ -1,0 +1,198 @@
+"""Test that rebake_flatten_bbox spatially sorts rows so parquet row-group
+bbox statistics are useful for /api/v1/nearby pruning.
+
+Spec: rows in the output parquet should be spatially clustered — consecutive
+rows are geographically close to each other, not in upstream order. The
+metric we use is the ratio of mean-consecutive-distance to mean-random-pair
+distance. A Hilbert-sorted file should have a ratio well under 0.3; random
+order is ~1.0.
+
+Run: python3 -m pytest scripts/test_hilbert_sort.py -v"""
+import sys
+from pathlib import Path
+
+import duckdb
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / 'scripts'))
+
+
+def make_test_parquet(path: Path, n_rows: int = 2000) -> None:
+    """Write a parquet with n_rows random points across India bbox, with a
+    bbox STRUCT mimicking ramSeraph's release format. Deliberately not
+    spatially ordered so the rebake has something to fix."""
+    con = duckdb.connect()
+    con.execute('INSTALL spatial; LOAD spatial;')
+    con.execute(f"""
+        COPY (
+          WITH pts AS (
+            SELECT
+              i AS id,
+              68.0 + ((i * 2654435761) % 1000) / 1000.0 * 30 AS x,
+              6.0  + ((i * 1597334677) % 1000) / 1000.0 * 32 AS y
+            FROM range({n_rows}) t(i)
+          )
+          SELECT
+            id,
+            ST_AsWKB(ST_Point(x, y))::BLOB AS geometry,
+            {{xmin: x, ymin: y, xmax: x, ymax: y}} AS bbox
+          FROM pts
+        ) TO '{path}' (FORMAT PARQUET)
+    """)
+
+
+def mean_consecutive_distance(path: Path) -> float:
+    con = duckdb.connect()
+    con.execute('INSTALL spatial; LOAD spatial;')
+    row = con.execute(f"""
+        WITH ordered AS (
+          SELECT row_number() OVER () AS rn, xmin AS x, ymin AS y
+          FROM read_parquet('{path}')
+        ),
+        pairs AS (
+          SELECT a.x AS ax, a.y AS ay, b.x AS bx, b.y AS byy
+          FROM ordered a JOIN ordered b ON b.rn = a.rn + 1
+        )
+        SELECT avg(sqrt((ax - bx) * (ax - bx) + (ay - byy) * (ay - byy))) FROM pairs
+    """).fetchone()
+    return float(row[0])
+
+
+def mean_random_pair_distance(path: Path, sample: int = 500) -> float:
+    con = duckdb.connect()
+    con.execute('INSTALL spatial; LOAD spatial;')
+    row = con.execute(f"""
+        WITH pts AS (SELECT xmin AS x, ymin AS y FROM read_parquet('{path}') USING SAMPLE {sample} ROWS),
+             pairs AS (SELECT a.x AS ax, a.y AS ay, b.x AS bx, b.y AS byy FROM pts a CROSS JOIN pts b WHERE a.x <> b.x OR a.y <> b.y)
+        SELECT avg(sqrt((ax - bx) * (ax - bx) + (ay - byy) * (ay - byy))) FROM pairs
+    """).fetchone()
+    return float(row[0])
+
+
+def test_rebake_flatten_bbox_spatially_clusters_rows(tmp_path: Path) -> None:
+    """The acceptance test: after rebake, consecutive rows are geographically
+    much closer than random pairs. Without spatial sort this would be ~1.0."""
+    from ingest_ramseraph import rebake_flatten_bbox
+
+    src = tmp_path / 'src.parquet'
+    dst = tmp_path / 'dst.parquet'
+    make_test_parquet(src, n_rows=2000)
+
+    n, cols = rebake_flatten_bbox(src, dst)
+    assert n == 2000
+    assert set(['xmin', 'ymin', 'xmax', 'ymax']).issubset(cols)
+
+    consecutive = mean_consecutive_distance(dst)
+    random_pair = mean_random_pair_distance(dst)
+    ratio = consecutive / random_pair
+    assert ratio < 0.3, (
+        f'rebake should spatially cluster rows. consecutive={consecutive:.3f}, '
+        f'random_pair={random_pair:.3f}, ratio={ratio:.3f} (expected < 0.3)'
+    )
+
+
+def test_rebake_preserves_row_count(tmp_path: Path) -> None:
+    from ingest_ramseraph import rebake_flatten_bbox
+
+    src = tmp_path / 'src.parquet'
+    dst = tmp_path / 'dst.parquet'
+    make_test_parquet(src, n_rows=500)
+
+    n, _ = rebake_flatten_bbox(src, dst)
+    assert n == 500
+
+
+def test_rebake_handles_geometry_typed_column(tmp_path: Path) -> None:
+    """ramSeraph parquet stores `geometry` as the GEOMETRY logical type, not
+    raw BLOB. Earlier impl wrapped it in ST_GeomFromWKB which broke on the
+    real file shape. Regression test for that."""
+    from ingest_ramseraph import rebake_flatten_bbox
+
+    src = tmp_path / 'src.parquet'
+    dst = tmp_path / 'dst.parquet'
+    con = duckdb.connect()
+    con.execute('INSTALL spatial; LOAD spatial;')
+    # No ::BLOB cast — geometry is stored with the spatial logical type.
+    con.execute(f"""
+        COPY (
+          WITH pts AS (
+            SELECT
+              i AS id,
+              68.0 + ((i * 2654435761) % 1000) / 1000.0 * 30 AS x,
+              6.0  + ((i * 1597334677) % 1000) / 1000.0 * 32 AS y
+            FROM range(500) t(i)
+          )
+          SELECT id, ST_Point(x, y) AS geometry, {{xmin: x, ymin: y, xmax: x, ymax: y}} AS bbox
+          FROM pts
+        ) TO '{src}' (FORMAT PARQUET)
+    """)
+    n, cols = rebake_flatten_bbox(src, dst)
+    assert n == 500
+    assert set(['xmin', 'ymin', 'xmax', 'ymax']).issubset(cols)
+
+
+def test_row_group_size_for_scales_with_density() -> None:
+    """Dense layers want many small groups (tight Hilbert chunks per group);
+    sparse layers want one or two big groups. Spec the buckets."""
+    from ingest_ramseraph import row_group_size_for
+    assert row_group_size_for(100) is None         # single group is fine
+    assert row_group_size_for(9_999) is None
+    assert row_group_size_for(50_000) == 5_000     # ~10 groups
+    assert row_group_size_for(99_999) == 5_000
+    assert row_group_size_for(500_000) == 20_000   # ~25 groups
+    assert row_group_size_for(999_999) == 20_000
+    assert row_group_size_for(2_700_000) == 50_000  # Overture: ~54 groups
+    assert row_group_size_for(5_000_000) == 50_000
+
+
+def test_rebake_uses_tight_row_groups_for_dense_layers(tmp_path: Path) -> None:
+    """End-to-end: a dense layer should end up with many small row groups
+    after rebake, so /api/v1/nearby's bbox prune can be effective."""
+    from ingest_ramseraph import rebake_flatten_bbox
+    import pyarrow.parquet as pq
+
+    src = tmp_path / 'src.parquet'
+    dst = tmp_path / 'dst.parquet'
+    con = duckdb.connect()
+    con.execute('INSTALL spatial; LOAD spatial;')
+    # 60k random points across India — dense enough to trigger the 5k bucket
+    con.execute(f"""
+        COPY (
+          WITH pts AS (
+            SELECT
+              i AS id,
+              68.0 + ((i * 2654435761) % 10000) / 10000.0 * 30 AS x,
+              6.0  + ((i * 1597334677) % 10000) / 10000.0 * 32 AS y
+            FROM range(60000) t(i)
+          )
+          SELECT id, ST_Point(x, y) AS geometry FROM pts
+        ) TO '{src}' (FORMAT PARQUET)
+    """)
+    rebake_flatten_bbox(src, dst)
+    pf = pq.ParquetFile(dst)
+    # 60k rows / 5k per group = 12 groups expected
+    assert pf.num_row_groups >= 8, f'expected dense layer to be split into many groups, got {pf.num_row_groups}'
+
+
+def test_rebake_synthesizes_bbox_cols_when_absent(tmp_path: Path) -> None:
+    """Own-bake layers (LGD villages/panchayats etc.) ship without any bbox
+    representation. rebake should synthesise flat xmin/ymin/xmax/ymax from
+    the geometry so /api/v1/nearby's bbox-prune path can work on them."""
+    from ingest_ramseraph import rebake_flatten_bbox
+
+    src = tmp_path / 'src.parquet'
+    dst = tmp_path / 'dst.parquet'
+    con = duckdb.connect()
+    con.execute('INSTALL spatial; LOAD spatial;')
+    # GEOMETRY-typed column (matches LGD parquet shape), NO bbox struct, NO flat cols
+    con.execute(f"""
+        COPY (SELECT i AS id, ST_Point(68 + (i % 30), 6 + (i % 32)) AS geometry FROM range(500) t(i))
+        TO '{src}' (FORMAT PARQUET)
+    """)
+
+    n, cols = rebake_flatten_bbox(src, dst)
+    assert n == 500
+    assert set(['xmin', 'ymin', 'xmax', 'ymax']).issubset(cols), (
+        f'rebake should add flat bbox cols when source has neither struct nor flat. Got: {cols}'
+    )

--- a/web/functions/lib/nearby.ts
+++ b/web/functions/lib/nearby.ts
@@ -34,6 +34,7 @@ export interface NearbyResult {
   timing_ms: number;
   _source: 'parquet-bbox' | 'parquet-scan';
   rows_scanned: number;
+  _truncated?: boolean;
 }
 
 const KM_PER_DEG_LAT = 111.32;
@@ -80,6 +81,40 @@ function round4(n: number): number {
   return Math.round(n * 10000) / 10000;
 }
 
+// Top-K-by-distance over bbox-pruned rows. Returns winners + total count of
+// rows inside the radius. Kept separate so the caller can defer the
+// expensive cleanProps() to just the K winners — without this, dense metros
+// like Bangalore Overture allocate 100k+ output objects and blow the
+// Workers CPU budget. `total` is the true within-radius count, not just
+// winners.length.
+export interface BboxWinner {
+  row: Record<string, unknown>;
+  cLat: number; cLng: number; d: number;
+}
+
+function topKByDistance(winners: BboxWinner[], limit: number): BboxWinner[] {
+  winners.sort((a, b) => a.d - b.d);
+  if (winners.length > limit) winners.length = limit;
+  return winners;
+}
+
+export function pickNearestBboxRows(
+  rows: Array<Record<string, unknown>>,
+  lat: number, lng: number, radiusKm: number, limit: number,
+): { winners: BboxWinner[]; total: number } {
+  let total = 0;
+  const winners: BboxWinner[] = [];
+  for (const row of rows) {
+    const cLat = (Number(row.ymin) + Number(row.ymax)) / 2;
+    const cLng = (Number(row.xmin) + Number(row.xmax)) / 2;
+    const d = haversineKm(lat, lng, cLat, cLng);
+    if (d > radiusKm) continue;
+    total++;
+    winners.push({ row, cLat, cLng, d });
+  }
+  return { winners: topKByDistance(winners, limit), total };
+}
+
 export async function nearby(
   lat: number, lng: number, radiusKm: number,
   layerId: string, catalog: CatalogData, r2: R2Bucket,
@@ -106,9 +141,10 @@ export async function nearby(
 
   const hasBboxCols = BBOX_COLS.every((c) => allCols.includes(c));
   const qbbox = queryBbox(lat, lng, radiusKm);
-  const hits: NearbyHit[] = [];
   let rows: Record<string, unknown>[];
   let skip: Set<string>;
+  let total: number;
+  let winners: BboxWinner[];
 
   if (hasBboxCols) {
     rows = await parquetQuery({
@@ -127,18 +163,9 @@ export async function nearby(
       },
     }) as Record<string, unknown>[];
     skip = new Set([geomCol, 'xmin', 'ymin', 'xmax', 'ymax', 'bbox']);
-    for (const row of rows) {
-      const cLat = (Number(row.ymin) + Number(row.ymax)) / 2;
-      const cLng = (Number(row.xmin) + Number(row.xmax)) / 2;
-      const d = haversineKm(lat, lng, cLat, cLng);
-      if (d > radiusKm) continue;
-      hits.push({
-        properties: cleanProps(row, skip),
-        _lat: round4(cLat),
-        _lng: round4(cLng),
-        _distance_km: Math.round(d * 10) / 10,
-      });
-    }
+    const r = pickNearestBboxRows(rows, lat, lng, radiusKm, limit);
+    winners = r.winners;
+    total = r.total;
   } else {
     const bytes = layer.parquet.bytes ?? 0;
     if (bytes > MAX_FULLSCAN_BYTES) {
@@ -155,30 +182,37 @@ export async function nearby(
       geoparquet: false,
     }) as Record<string, unknown>[];
     skip = new Set([geomCol]);
+    // Scan path computes the centroid from WKB per row (no bbox cols).
+    // Same top-K shape as the bbox path; just a different distance source.
+    total = 0;
+    const allWinners: BboxWinner[] = [];
     for (const row of rows) {
       const c = extractCentroid(row[geomCol]);
       if (!c) continue;
       const [cLng, cLat] = c;
       const d = haversineKm(lat, lng, cLat, cLng);
       if (d > radiusKm) continue;
-      hits.push({
-        properties: cleanProps(row, skip),
-        _lat: round4(cLat),
-        _lng: round4(cLng),
-        _distance_km: Math.round(d * 10) / 10,
-      });
+      total++;
+      allWinners.push({ row, cLat, cLng, d });
     }
+    winners = topKByDistance(allWinners, limit);
   }
 
-  hits.sort((a, b) => a._distance_km - b._distance_km);
+  const features: NearbyHit[] = winners.map((w) => ({
+    properties: cleanProps(w.row, skip),
+    _lat: round4(w.cLat),
+    _lng: round4(w.cLng),
+    _distance_km: Math.round(w.d * 10) / 10,
+  }));
 
   return {
     center: { lat, lng },
     radius_km: radiusKm,
-    total: hits.length,
-    features: hits.slice(0, limit),
+    total,
+    features,
     timing_ms: Date.now() - start,
     _source: hasBboxCols ? 'parquet-bbox' : 'parquet-scan',
     rows_scanned: rows.length,
+    _truncated: total > features.length,
   };
 }

--- a/web/scripts/bench-cap.mjs
+++ b/web/scripts/bench-cap.mjs
@@ -1,0 +1,129 @@
+// Bench the Overture nearby path with and without the top-K cap optimisation.
+// Mirrors the prod Worker code path: parquet read → bbox row prune → centroid
+// haversine → cleanProps + output object. Reports timing for both shapes so
+// we can see whether the optimisation actually helps before pushing.
+
+import { parquetMetadataAsync, parquetQuery, parquetSchema } from 'hyparquet';
+import { compressors } from 'hyparquet-compressors';
+
+const URL = 'https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/pois/overture-places/overture_places_india.parquet';
+const CENTER = { lat: 12.9716, lng: 77.5946 };
+const RADIUS_KM = 10;
+const LIMIT = 20;
+
+const JUNK_PROPS = new Set([
+  'shape_leng', 'shape_area', 'shape_length', 'shape.starea()', 'shape.stlength()',
+  'shape_le_1', 'st_area(shape)', 'st_perimeter(shape)',
+  'inpoly_fid', 'simpgnflag', 'maxsimptol', 'minsimptol', 'ogc_fid',
+]);
+
+const round4 = (n) => Math.round(n * 10000) / 10000;
+
+function haversineKm(lat1, lng1, lat2, lng2) {
+  const R = 6371;
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLng = (lng2 - lng1) * Math.PI / 180;
+  const a = Math.sin(dLat/2)**2 + Math.cos(lat1*Math.PI/180)*Math.cos(lat2*Math.PI/180)*Math.sin(dLng/2)**2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+}
+
+function queryBbox(lat, lng, r) {
+  const dLat = r / 111.32;
+  const dLng = r / (111.32 * Math.cos(lat * Math.PI / 180));
+  return { xmin: lng - dLng, ymin: lat - dLat, xmax: lng + dLng, ymax: lat + dLat };
+}
+
+function cleanProps(row, skip) {
+  const out = {};
+  for (const k of Object.keys(row)) {
+    if (skip.has(k) || JUNK_PROPS.has(k.toLowerCase())) continue;
+    out[k] = row[k];
+  }
+  return out;
+}
+
+async function httpAsyncBuffer(url) {
+  const head = await fetch(url, { method: 'HEAD' });
+  const sz = +head.headers.get('content-length');
+  return {
+    byteLength: sz,
+    async slice(s, e) {
+      const r = await fetch(url, { headers: { Range: `bytes=${s}-${(e ?? sz) - 1}` } });
+      return r.arrayBuffer();
+    },
+  };
+}
+
+async function readMatchingRows() {
+  const file = await httpAsyncBuffer(URL);
+  const meta = await parquetMetadataAsync(file);
+  const cols = parquetSchema(meta).children.map((c) => c.element.name);
+  const qb = queryBbox(CENTER.lat, CENTER.lng, RADIUS_KM);
+  const t0 = Date.now();
+  const rows = await parquetQuery({
+    compressors, file,
+    columns: cols.filter((c) => c !== 'geometry'),
+    rowFormat: 'object',
+    geoparquet: false,
+    filter: {
+      $and: [
+        { xmin: { $lte: qb.xmax } }, { xmax: { $gte: qb.xmin } },
+        { ymin: { $lte: qb.ymax } }, { ymax: { $gte: qb.ymin } },
+      ],
+    },
+  });
+  return { rows, readMs: Date.now() - t0 };
+}
+
+// OLD: allocate per-row hit (full cleanProps), sort all, slice
+function processOld(rows) {
+  const t0 = Date.now();
+  const skip = new Set(['geometry', 'xmin', 'ymin', 'xmax', 'ymax', 'bbox']);
+  const hits = [];
+  for (const row of rows) {
+    const cLat = (Number(row.ymin) + Number(row.ymax)) / 2;
+    const cLng = (Number(row.xmin) + Number(row.xmax)) / 2;
+    const d = haversineKm(CENTER.lat, CENTER.lng, cLat, cLng);
+    if (d > RADIUS_KM) continue;
+    hits.push({
+      properties: cleanProps(row, skip),
+      _lat: round4(cLat), _lng: round4(cLng),
+      _distance_km: Math.round(d * 10) / 10,
+    });
+  }
+  hits.sort((a, b) => a._distance_km - b._distance_km);
+  return { total: hits.length, features: hits.slice(0, LIMIT), ms: Date.now() - t0 };
+}
+
+// NEW: top-K first, cleanProps only on winners
+function processNew(rows) {
+  const t0 = Date.now();
+  const skip = new Set(['geometry', 'xmin', 'ymin', 'xmax', 'ymax', 'bbox']);
+  let total = 0;
+  const winners = [];
+  for (const row of rows) {
+    const cLat = (Number(row.ymin) + Number(row.ymax)) / 2;
+    const cLng = (Number(row.xmin) + Number(row.xmax)) / 2;
+    const d = haversineKm(CENTER.lat, CENTER.lng, cLat, cLng);
+    if (d > RADIUS_KM) continue;
+    total++;
+    winners.push({ row, cLat, cLng, d });
+  }
+  winners.sort((a, b) => a.d - b.d);
+  if (winners.length > LIMIT) winners.length = LIMIT;
+  const features = winners.map((w) => ({
+    properties: cleanProps(w.row, skip),
+    _lat: round4(w.cLat), _lng: round4(w.cLng),
+    _distance_km: Math.round(w.d * 10) / 10,
+  }));
+  return { total, features, ms: Date.now() - t0 };
+}
+
+const { rows, readMs } = await readMatchingRows();
+console.log(`parquet read+filter: ${rows.length} rows / ${readMs} ms`);
+
+const oldR = processOld(rows);
+console.log(`OLD (cleanProps per row):  total=${oldR.total} returned=${oldR.features.length} process_ms=${oldR.ms}`);
+
+const newR = processNew(rows);
+console.log(`NEW (cleanProps on top-K): total=${newR.total} returned=${newR.features.length} process_ms=${newR.ms} ratio=${(newR.ms / oldR.ms).toFixed(2)}x`);

--- a/web/tests/nearby.test.ts
+++ b/web/tests/nearby.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { queryBbox, haversineKm } from '../functions/lib/nearby';
+import { queryBbox, haversineKm, pickNearestBboxRows } from '../functions/lib/nearby';
 import { wkbCentroid, geoJSONCentroid, extractCentroid } from '../functions/lib/wkb-centroid';
 
 describe('queryBbox', () => {
@@ -138,6 +138,62 @@ describe('geoJSONCentroid', () => {
   it('returns null for null/empty geometry', () => {
     expect(geoJSONCentroid(null)).toBeNull();
     expect(geoJSONCentroid({})).toBeNull();
+  });
+});
+
+describe('pickNearestBboxRows (top-K + cap)', () => {
+  // Build N rows scattered between two latitudes. row[0] is closest to (lat0, lng0).
+  function scatter(n: number, lat0: number, lng0: number): Array<Record<string, unknown>> {
+    const rows = [];
+    for (let i = 0; i < n; i++) {
+      const dy = (i / n) * 1.0;  // up to 1 deg north
+      rows.push({ xmin: lng0, xmax: lng0, ymin: lat0 + dy, ymax: lat0 + dy, _id: i });
+    }
+    return rows;
+  }
+
+  it('returns at most `limit` winners ordered by distance', () => {
+    const rows = scatter(50, 12.97, 77.59);
+    const r = pickNearestBboxRows(rows, 12.97, 77.59, 200, 5);
+    expect(r.winners.length).toBe(5);
+    expect(r.winners[0].d).toBeLessThan(r.winners[4].d);
+    expect(r.total).toBe(50);
+  });
+
+  it('drops rows outside the radius from total', () => {
+    const rows = [
+      { xmin: 77.59, xmax: 77.59, ymin: 12.97, ymax: 12.97 },  // exact center
+      { xmin: 77.59, xmax: 77.59, ymin: 14.00, ymax: 14.00 },  // ~115 km north
+    ];
+    const r = pickNearestBboxRows(rows, 12.97, 77.59, 50, 10);
+    expect(r.total).toBe(1);
+    expect(r.winners.length).toBe(1);
+  });
+
+  it('does NOT materialise props on losing rows (allocation-bounded)', () => {
+    // The whole point of extracting this helper: when 100k rows are in the
+    // bbox prune but we only return `limit`, only `limit` row objects should
+    // appear in winners — the rest must be discarded so the caller can keep
+    // its expensive cleanProps work bounded by `limit`.
+    const rows = scatter(10_000, 12.97, 77.59);
+    const r = pickNearestBboxRows(rows, 12.97, 77.59, 500, 20);
+    expect(r.winners.length).toBe(20);
+    expect(r.total).toBe(10_000);
+    // every winner carries its row reference so caller can hydrate props
+    for (const w of r.winners) expect(w.row).toBeDefined();
+  });
+
+  it('reports total accurately even when far above limit', () => {
+    const rows = scatter(5000, 12.97, 77.59);
+    const r = pickNearestBboxRows(rows, 12.97, 77.59, 1000, 10);
+    expect(r.total).toBe(5000);
+    expect(r.winners.length).toBe(10);
+  });
+
+  it('empty input → empty winners', () => {
+    const r = pickNearestBboxRows([], 12.97, 77.59, 10, 5);
+    expect(r.winners).toEqual([]);
+    expect(r.total).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Overture nearby was 503-ing in prod after PR #104 swapped from pmtiles to parquet — the Worker hit its resource limit decoding 100k+ POIs within Bangalore's 10km bbox. Three changes stack to fix it:

1. **Hilbert sort** in `rebake_flatten_bbox()` — `ORDER BY ST_Hilbert(geometry, india_bbox)` so row group min/max bbox stats actually prune. Before: every row group spanned ~all of India. After: e.g. Overture row group 2 covers exactly the Bangalore window.

2. **Density-aware ROW_GROUP_SIZE** — 5k rows for 10k-100k layers, 20k for 100k-1M, 50k for 1M+. Tighter groups → tighter per-group bbox → smaller post-prune working set in dense queries.

3. **Lazy cleanProps + top-K cap** in `nearby.ts` — extract `pickNearestBboxRows()` and defer the expensive `cleanProps()` to just the K winners. Without this, 100k JS objects allocate even when we return 20.

Also added: synthesises flat `xmin/ymin/xmax/ymax` from geometry when source has neither STRUCT nor flat cols (unlocks /nearby on own-bake LGD layers once rebaked). `COMPRESSION_LEVEL 9` keeps file sizes near source. License attribution fix from #104 also lands here (DataMeet → datameet.org).

## Before / after

Bangalore (12.9716, 77.5946) 10km radius on `overture_places_india`:

| Metric | Before | After |
|---|---|---|
| Prod HTTP | 503 (error 1102, Worker resource limit) | **200 OK** |
| Server `timing_ms` | timeout | **4,406 ms** |
| Local bbox-filter | 100,633 rows / 19,107 ms | 100,620 rows / 4,046 ms (**~4.7x**) |
| Parquet file size | 289 MB | 254 MB (**12% smaller** — Hilbert clusters WKB patterns) |
| Row groups | 23 (~120k each) | 54 (~50k each) |
| `total` returned | (none) | 92,502 (real Bangalore Overture POI density within 10km) |

The Overture parquet on R2 has already been re-baked + uploaded as part of verifying this PR. No additional ops needed for Overture at merge time.

## Trade-offs
- Response gains a `_truncated?: boolean` field. Contract fields (`center`, `radius_km`, `total`, `features`, `timing_ms`) unchanged.
- Hilbert sort + tight row groups slightly increase parquet metadata overhead. Negligible.
- For sparse queries (e.g. Leh 10km), a tighter row group split touches a few more groups instead of one big group — measured impact is well under 1s.

## Queued follow-up rebakes (separate ops, not this PR)

| Layer | Why queued |
|---|---|
| `pmgsy_roads` (1.2 GB) | ramSeraph — `ingest_ramseraph.py pmgsy_roads` |
| `slusi_micro_watersheds` (496 MB) | ramSeraph |
| `wris_waterbodies` (413 MB) | ramSeraph |
| `lgd_villages` (474 MB) | own-bake — needs upstream fetch + `rebake_flatten_bbox` |
| `lgd_panchayats` (368 MB) | own-bake |
| `bp_wetlands` (413 MB) | bbox stats missing on existing parquet — investigate |

The code is ready for all of these; just rebake & reupload when convenient.

## Test plan
- [x] vitest 509/509 pass (5 new pickNearestBboxRows tests)
- [x] pytest 23/23 pass (3 new rebake_flatten_bbox tests + 2 row-group-size tests)
- [x] tsc zero errors on changed files
- [x] Real Overture rebake + upload verified end-to-end
- [x] Prod smoke-test — 200 OK with full result
- [ ] Post-deploy: re-run smoke against `/api/v1/nearby?layer=overture_places_india&...` from MCP client to confirm response shape
- [ ] Post-deploy: kick off queued rebakes one at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)