### PR TITLE
fix(nearby): unblock Mumbai + Delhi Overture — 20k row groups

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -393,7 +393,7 @@
     "wards_bengaluru_gba": {
       "label": "Greater Bengaluru Wards (2025)",
       "unit": "wards",
-      "description": "Greater Bengaluru Authority — 369 final wards across 5 corporations, notified Nov 2025.",
+      "description": "Greater Bengaluru Authority \u2014 369 final wards across 5 corporations, notified Nov 2025.",
       "source_url": "https://data.opencity.in/dataset/gba-wards-delimitation-2025",
       "source_org": "Greater Bengaluru Authority",
       "notes": "Latest GBA delimitation. Pair with the 5-corp polygons for parent grouping."
@@ -409,7 +409,7 @@
     "wards_bengaluru_bbmp_2022": {
       "label": "BBMP Wards (2022, historical)",
       "unit": "wards",
-      "description": "Bruhat Bengaluru Mahanagara Palike — 243 wards from the 2022 draft delimitation. Historical reference; superseded by the 2025 GBA 369-ward scheme.",
+      "description": "Bruhat Bengaluru Mahanagara Palike \u2014 243 wards from the 2022 draft delimitation. Historical reference; superseded by the 2025 GBA 369-ward scheme.",
       "source_url": "https://data.opencity.in/dataset/bbmp-wards",
       "source_org": "BBMP",
       "notes": "Use the GBA 2025 layer for current ward boundaries."
@@ -433,7 +433,7 @@
     "wards_chennai": {
       "label": "Chennai (GCC) Wards",
       "unit": "wards",
-      "description": "Greater Chennai Corporation — 200 ward boundaries across the 15 zones.",
+      "description": "Greater Chennai Corporation \u2014 200 ward boundaries across the 15 zones.",
       "source_url": "https://data.opencity.in/dataset/gcc-ward-information",
       "source_org": "Greater Chennai Corporation",
       "notes": ""
@@ -441,7 +441,7 @@
     "wards_hyderabad": {
       "label": "Hyderabad (GHMC) Wards",
       "unit": "wards",
-      "description": "Greater Hyderabad Municipal Corporation — 145 wards across 6 zones.",
+      "description": "Greater Hyderabad Municipal Corporation \u2014 145 wards across 6 zones.",
       "source_url": "https://data.opencity.in/dataset/hyderabad-wards-info",
       "source_org": "Greater Hyderabad Municipal Corporation",
       "notes": ""
@@ -449,7 +449,7 @@
     "wards_mumbai": {
       "label": "Mumbai (BMC) Wards",
       "unit": "wards",
-      "description": "Brihanmumbai Municipal Corporation — 24 administrative wards (A–T plus the city-island spread).",
+      "description": "Brihanmumbai Municipal Corporation \u2014 24 administrative wards (A\u2013T plus the city-island spread).",
       "source_url": "https://data.opencity.in/dataset/mumbai-wards",
       "source_org": "Brihanmumbai Municipal Corporation",
       "notes": ""
@@ -465,7 +465,7 @@
     "wards_kolkata": {
       "label": "Kolkata (KMC) Wards",
       "unit": "wards",
-      "description": "Kolkata Municipal Corporation — 141 ward boundaries across the 16 boroughs.",
+      "description": "Kolkata Municipal Corporation \u2014 141 ward boundaries across the 16 boroughs.",
       "source_url": "https://data.opencity.in/dataset/kolkata-wards",
       "source_org": "Kolkata Municipal Corporation",
       "notes": ""
@@ -473,7 +473,7 @@
     "wards_pune": {
       "label": "Pune (PMC) Wards",
       "unit": "wards",
-      "description": "Pune Municipal Corporation — 58 administrative wards.",
+      "description": "Pune Municipal Corporation \u2014 58 administrative wards.",
       "source_url": "https://data.opencity.in/dataset/pune-wards",
       "source_org": "Pune Municipal Corporation",
       "notes": ""
@@ -481,7 +481,7 @@
     "wards_ahmedabad": {
       "label": "Ahmedabad (AMC) Wards",
       "unit": "wards",
-      "description": "Ahmedabad Municipal Corporation — 48 wards across the 7 zones.",
+      "description": "Ahmedabad Municipal Corporation \u2014 48 wards across the 7 zones.",
       "source_url": "https://data.opencity.in/dataset/ahmedabad-wards",
       "source_org": "Ahmedabad Municipal Corporation",
       "notes": ""
@@ -489,7 +489,7 @@
     "wards_jaipur": {
       "label": "Jaipur (JMC) Wards",
       "unit": "wards",
-      "description": "Jaipur Municipal Corporation — 150 ward boundaries.",
+      "description": "Jaipur Municipal Corporation \u2014 150 ward boundaries.",
       "source_url": "https://data.opencity.in/dataset/jaipur-wards",
       "source_org": "Jaipur Municipal Corporation",
       "notes": ""
@@ -497,7 +497,7 @@
     "wards_gurugram": {
       "label": "Gurugram (MCG) Wards",
       "unit": "wards",
-      "description": "Municipal Corporation of Gurugram — 35 ward boundaries.",
+      "description": "Municipal Corporation of Gurugram \u2014 35 ward boundaries.",
       "source_url": "https://data.opencity.in/dataset/gurugram-wards",
       "source_org": "Municipal Corporation of Gurugram",
       "notes": ""
@@ -505,7 +505,7 @@
     "wards_kochi": {
       "label": "Kochi (KMC) Wards",
       "unit": "wards",
-      "description": "Kochi Municipal Corporation ward boundaries — 74 administrative wards covering the city. Sourced from Oorvani Foundation's OpenCity data portal.",
+      "description": "Kochi Municipal Corporation ward boundaries \u2014 74 administrative wards covering the city. Sourced from Oorvani Foundation's OpenCity data portal.",
       "source_url": "https://data.opencity.in/dataset/kochi-wards",
       "source_org": "Kochi Municipal Corporation",
       "notes": ""
@@ -513,7 +513,7 @@
     "wards_bhubaneshwar": {
       "label": "Bhubaneshwar (BMC) Wards",
       "unit": "wards",
-      "description": "Bhubaneshwar Municipal Corporation ward boundaries — 67 wards covering Odisha's capital city. Sourced from Oorvani Foundation's OpenCity data portal.",
+      "description": "Bhubaneshwar Municipal Corporation ward boundaries \u2014 67 wards covering Odisha's capital city. Sourced from Oorvani Foundation's OpenCity data portal.",
       "source_url": "https://data.opencity.in/dataset/bhubaneshwar-wards",
       "source_org": "Bhubaneshwar Municipal Corporation",
       "notes": ""
@@ -521,7 +521,7 @@
     "wards_vizag": {
       "label": "Visakhapatnam (GVMC) Wards",
       "unit": "wards",
-      "description": "Greater Visakhapatnam Municipal Corporation — 98 wards.",
+      "description": "Greater Visakhapatnam Municipal Corporation \u2014 98 wards.",
       "source_url": "https://data.opencity.in/dataset/visakhapatnam-wards",
       "source_org": "Greater Visakhapatnam Municipal Corporation",
       "notes": ""
@@ -529,7 +529,7 @@
     "wards_thane": {
       "label": "Thane (TMC) Wards",
       "unit": "wards",
-      "description": "Thane Municipal Corporation — 47 wards across the city.",
+      "description": "Thane Municipal Corporation \u2014 47 wards across the city.",
       "source_url": "https://data.opencity.in/dataset/thane-wards",
       "source_org": "Thane Municipal Corporation",
       "notes": ""
@@ -545,7 +545,7 @@
     "wards_indore": {
       "label": "Indore (IMC) Wards (2024)",
       "unit": "wards",
-      "description": "Indore Municipal Corporation — 85 ward boundaries. 2024 delimitation.",
+      "description": "Indore Municipal Corporation \u2014 85 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/indore-wards-map",
       "source_org": "Indore Municipal Corporation",
       "notes": ""
@@ -553,7 +553,7 @@
     "wards_coimbatore": {
       "label": "Coimbatore (CCMC) Wards (2011)",
       "unit": "wards",
-      "description": "Coimbatore City Municipal Corporation — 100 ward boundaries. Census 2011 reorganization.",
+      "description": "Coimbatore City Municipal Corporation \u2014 100 ward boundaries. Census 2011 reorganization.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Coimbatore",
       "source_org": "DataMeet",
       "notes": ""
@@ -561,7 +561,7 @@
     "wards_madurai": {
       "label": "Madurai (MCM) Wards (2024)",
       "unit": "wards",
-      "description": "Madurai City Municipal Corporation — 100 ward boundaries. 2024 delimitation.",
+      "description": "Madurai City Municipal Corporation \u2014 100 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/madurai-wards-map",
       "source_org": "Madurai City Municipal Corporation",
       "notes": ""
@@ -569,7 +569,7 @@
     "wards_navi_mumbai": {
       "label": "Navi Mumbai (NMMC) Wards (2024)",
       "unit": "wards",
-      "description": "Navi Mumbai Municipal Corporation — 111 ward boundaries. 2024 delimitation.",
+      "description": "Navi Mumbai Municipal Corporation \u2014 111 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/navi-mumbai-wards-map",
       "source_org": "Navi Mumbai Municipal Corporation",
       "notes": ""
@@ -577,7 +577,7 @@
     "wards_guwahati": {
       "label": "Guwahati (GMC) Wards (2022)",
       "unit": "wards",
-      "description": "Guwahati Municipal Corporation — 60 ward boundaries. 2022 delimitation.",
+      "description": "Guwahati Municipal Corporation \u2014 60 ward boundaries. 2022 delimitation.",
       "source_url": "https://data.opencity.in/dataset/guwahati-wards-information",
       "source_org": "Guwahati Municipal Corporation",
       "notes": ""
@@ -585,7 +585,7 @@
     "wards_mysuru": {
       "label": "Mysuru (MCC) Wards",
       "unit": "wards",
-      "description": "Mysuru City Corporation — 65 ward boundaries.",
+      "description": "Mysuru City Corporation \u2014 65 ward boundaries.",
       "source_url": "https://data.opencity.in/dataset/mysuru-city-corporation-wards-info",
       "source_org": "Mysuru City Corporation",
       "notes": ""
@@ -593,7 +593,7 @@
     "wards_bhopal": {
       "label": "Bhopal (BMC) Wards (2024)",
       "unit": "wards",
-      "description": "Bhopal Municipal Corporation — 86 ward boundaries. 2024 delimitation.",
+      "description": "Bhopal Municipal Corporation \u2014 86 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/bhopal-wards-map",
       "source_org": "Bhopal Municipal Corporation",
       "notes": ""
@@ -601,7 +601,7 @@
     "wards_chandigarh": {
       "label": "Chandigarh (MC) Wards",
       "unit": "wards",
-      "description": "Municipal Corporation of Chandigarh — 28 ward boundaries.",
+      "description": "Municipal Corporation of Chandigarh \u2014 28 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Chandigarh",
       "source_org": "Municipal Corporation of Chandigarh",
       "notes": ""
@@ -609,7 +609,7 @@
     "wards_lucknow": {
       "label": "Lucknow (LMC) Wards",
       "unit": "wards",
-      "description": "Lucknow Municipal Corporation — 112 ward boundaries.",
+      "description": "Lucknow Municipal Corporation \u2014 112 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Lucknow",
       "source_org": "Lucknow Municipal Corporation",
       "notes": ""
@@ -617,7 +617,7 @@
     "wards_kanpur": {
       "label": "Kanpur (KMC) Wards",
       "unit": "wards",
-      "description": "Kanpur Municipal Corporation — 58 ward boundaries.",
+      "description": "Kanpur Municipal Corporation \u2014 58 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Kanpur",
       "source_org": "Kanpur Municipal Corporation",
       "notes": ""
@@ -625,7 +625,7 @@
     "wards_patna": {
       "label": "Patna (PMC) Wards (~2019)",
       "unit": "wards",
-      "description": "Patna Municipal Corporation — 75 wards (628 sub-ward polygons). Two naming schemes: numbered \"Ward N\" and spelled-out names.",
+      "description": "Patna Municipal Corporation \u2014 75 wards (628 sub-ward polygons). Two naming schemes: numbered \"Ward N\" and spelled-out names.",
       "source_url": "https://github.com/datta07/INDIAN-SHAPEFILES/tree/master/METROPOLITAN%20CITIES",
       "source_org": "datta07/INDIAN-SHAPEFILES",
       "notes": ""
@@ -633,7 +633,7 @@
     "wards_surat": {
       "label": "Surat (SMC) Wards (~2019)",
       "unit": "wards",
-      "description": "Surat Municipal Corporation — 30 ward boundaries with named wards.",
+      "description": "Surat Municipal Corporation \u2014 30 ward boundaries with named wards.",
       "source_url": "https://github.com/datta07/INDIAN-SHAPEFILES/tree/master/METROPOLITAN%20CITIES",
       "source_org": "datta07/INDIAN-SHAPEFILES",
       "notes": ""
@@ -641,7 +641,7 @@
     "wards_vadodara": {
       "label": "Vadodara (VMC) Wards",
       "unit": "wards",
-      "description": "Vadodara Municipal Corporation — 12 administrative ward boundaries.",
+      "description": "Vadodara Municipal Corporation \u2014 12 administrative ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Vadodara",
       "source_org": "DataMeet",
       "notes": ""
@@ -649,7 +649,7 @@
     "wards_faridabad": {
       "label": "Faridabad (MCF) Wards",
       "unit": "wards",
-      "description": "Municipal Corporation of Faridabad — 40 ward boundaries.",
+      "description": "Municipal Corporation of Faridabad \u2014 40 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Faridabad",
       "source_org": "DataMeet",
       "notes": ""
@@ -657,7 +657,7 @@
     "wards_pcmc": {
       "label": "Pimpri-Chinchwad (PCMC) Electoral Wards",
       "unit": "wards",
-      "description": "Pimpri-Chinchwad Municipal Corporation — 66 electoral ward boundaries across 6 zones.",
+      "description": "Pimpri-Chinchwad Municipal Corporation \u2014 66 electoral ward boundaries across 6 zones.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/PCMC",
       "source_org": "DataMeet",
       "notes": ""
@@ -665,7 +665,7 @@
     "wards_vijayawada": {
       "label": "Vijayawada (VMC) Wards",
       "unit": "wards",
-      "description": "Vijayawada Municipal Corporation — 77 ward boundaries.",
+      "description": "Vijayawada Municipal Corporation \u2014 77 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Vijayawada",
       "source_org": "DataMeet",
       "notes": ""
@@ -706,14 +706,14 @@
       "description": "Solar panel array polygon boundaries across India."
     },
     "vedas_solar_panels_ai_2023": {
-      "label": "Solar panels — AI-detected (VEDAS 2023)",
+      "label": "Solar panels \u2014 AI-detected (VEDAS 2023)",
       "unit": "solar panels",
       "description": "AI-derived solar panel footprints across India from VEDAS, 2023 snapshot. Complements the manually curated solar plants layer."
     },
     "vedas_transmission_lines": {
       "label": "Power transmission lines (VEDAS)",
       "unit": "transmission line segments",
-      "description": "High-voltage transmission line geometry across India. Licence differs from the rest of the VEDAS family — ODbL because the source is OSM-derived."
+      "description": "High-voltage transmission line geometry across India. Licence differs from the rest of the VEDAS family \u2014 ODbL because the source is OSM-derived."
     },
     "pmgsy_habitations": {
       "label": "Rural habitations (PMGSY 2024)",
@@ -728,12 +728,12 @@
     "wris_watersheds": {
       "label": "Watersheds (WRIS 2024)",
       "unit": "watersheds",
-      "description": "Watershed boundary polygons from CWC WRIS — the tier below sub-basin in the hydrology hierarchy."
+      "description": "Watershed boundary polygons from CWC WRIS \u2014 the tier below sub-basin in the hydrology hierarchy."
     },
     "wris_river_polygons": {
       "label": "River polygons (WRIS 2024)",
       "unit": "river polygons",
-      "description": "Rivers as polygon geometry from CWC WRIS — complements the existing line-geometry river network for area-based queries."
+      "description": "Rivers as polygon geometry from CWC WRIS \u2014 complements the existing line-geometry river network for area-based queries."
     },
     "slusi_soil_health": {
       "label": "Soil health (SLUSI 2020-23 snapshot)",
@@ -743,12 +743,12 @@
     "wris_waterbodies": {
       "label": "Waterbodies (WRIS 2024)",
       "unit": "waterbodies",
-      "description": "Surface waterbody polygons from CWC WRIS — covers ponds, tanks, reservoirs and natural waterbodies beyond named lakes."
+      "description": "Surface waterbody polygons from CWC WRIS \u2014 covers ponds, tanks, reservoirs and natural waterbodies beyond named lakes."
     },
     "slusi_micro_watersheds": {
       "label": "Micro-watersheds (SLUSI)",
       "unit": "micro-watersheds",
-      "description": "Micro-watershed boundary polygons across India from the Soil and Land Use Survey of India — the finest watershed delineation in the hydrology hierarchy."
+      "description": "Micro-watershed boundary polygons across India from the Soil and Land Use Survey of India \u2014 the finest watershed delineation in the hydrology hierarchy."
     },
     "pmgsy_roads": {
       "label": "Rural roads (PMGSY 2024)",
@@ -763,7 +763,7 @@
     "gsi_landslide_inventory": {
       "label": "Landslide inventory (GSI)",
       "unit": "landslides",
-      "description": "Geological Survey of India landslide inventory — pan-India catalogue of historical landslide occurrences with metadata."
+      "description": "Geological Survey of India landslide inventory \u2014 pan-India catalogue of historical landslide occurrences with metadata."
     },
     "ndem_landslide_hazard": {
       "label": "Landslide hazard zones (NDEM)",
@@ -781,7 +781,7 @@
       "description": "Historical cyclone track line geometries across the Indian Ocean basins, compiled by NDEM."
     },
     "overture_places_india": {
-      "label": "Places — Overture Maps (Dec 2023)",
+      "label": "Places \u2014 Overture Maps (Dec 2023)",
       "unit": "places",
       "description": "Pan-India points of interest from the Overture Maps Foundation December 2023 release. Names, categories, addresses, websites and confidence scores for restaurants, shops, ATMs, schools, transit, monuments and more."
     }
@@ -1489,7 +1489,7 @@
       "category": "people",
       "provenance": "curated",
       "fetched_at": "2026-05-21T10:31:10.501660+00:00",
-      "notes": "Lok Sabha constituencies — 543 polygons covering the entire country. Latest delimitation."
+      "notes": "Lok Sabha constituencies \u2014 543 polygons covering the entire country. Latest delimitation."
     },
     {
       "id": "lgd_assembly",
@@ -1606,7 +1606,7 @@
       "category": "infrastructure",
       "provenance": "curated",
       "fetched_at": "2026-05-23T17:18:45.854281+00:00",
-      "notes": "India Post pincode boundary polygons (simplified). 63,864 polygons. © 2025 Saket Choudhary, MIT-licensed via bharatviz.org. Source: bharatviz.org/India_pincodes_simplified.geojson; code repo github.com/saketlab/bharatviz."
+      "notes": "India Post pincode boundary polygons (simplified). 63,864 polygons. \u00a9 2025 Saket Choudhary, MIT-licensed via bharatviz.org. Source: bharatviz.org/India_pincodes_simplified.geojson; code repo github.com/saketlab/bharatviz."
     },
     {
       "id": "gs_wildlife",
@@ -1926,7 +1926,7 @@
       "category": "environment",
       "provenance": "curated",
       "fetched_at": "2026-05-24T14:09:37.777020+00:00",
-      "notes": "India's river network from CWC WRIS — line geometry for streams and rivers."
+      "notes": "India's river network from CWC WRIS \u2014 line geometry for streams and rivers."
     },
     {
       "id": "seismic_zones",
@@ -2206,7 +2206,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Greater Bengaluru Authority — 369 final wards across 5 corporations, notified Nov 2025."
+      "notes": "Greater Bengaluru Authority \u2014 369 final wards across 5 corporations, notified Nov 2025."
     },
     {
       "id": "corporation_bengaluru",
@@ -2283,7 +2283,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Bruhat Bengaluru Mahanagara Palike — 243 wards from the 2022 draft delimitation. Historical reference; superseded by the 2025 GBA 369-ward scheme."
+      "notes": "Bruhat Bengaluru Mahanagara Palike \u2014 243 wards from the 2022 draft delimitation. Historical reference; superseded by the 2025 GBA 369-ward scheme."
     },
     {
       "id": "bda_jurisdiction",
@@ -2400,7 +2400,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Greater Chennai Corporation — 200 ward boundaries across the 15 zones."
+      "notes": "Greater Chennai Corporation \u2014 200 ward boundaries across the 15 zones."
     },
     {
       "id": "wards_hyderabad",
@@ -2440,7 +2440,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Greater Hyderabad Municipal Corporation — 145 wards across 6 zones."
+      "notes": "Greater Hyderabad Municipal Corporation \u2014 145 wards across 6 zones."
     },
     {
       "id": "wards_mumbai",
@@ -2480,7 +2480,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Brihanmumbai Municipal Corporation — 24 administrative wards (A–T plus the city-island spread)."
+      "notes": "Brihanmumbai Municipal Corporation \u2014 24 administrative wards (A\u2013T plus the city-island spread)."
     },
     {
       "id": "electoral_wards_mumbai_2017",
@@ -2557,7 +2557,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Kolkata Municipal Corporation — 141 ward boundaries across the 16 boroughs."
+      "notes": "Kolkata Municipal Corporation \u2014 141 ward boundaries across the 16 boroughs."
     },
     {
       "id": "wards_pune",
@@ -2597,7 +2597,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Pune Municipal Corporation — 58 administrative wards."
+      "notes": "Pune Municipal Corporation \u2014 58 administrative wards."
     },
     {
       "id": "wards_ahmedabad",
@@ -2637,7 +2637,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Ahmedabad Municipal Corporation — 48 wards across the 7 zones."
+      "notes": "Ahmedabad Municipal Corporation \u2014 48 wards across the 7 zones."
     },
     {
       "id": "wards_jaipur",
@@ -2677,7 +2677,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Jaipur Municipal Corporation — 150 ward boundaries."
+      "notes": "Jaipur Municipal Corporation \u2014 150 ward boundaries."
     },
     {
       "id": "wards_gurugram",
@@ -2717,7 +2717,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Municipal Corporation of Gurugram — 35 ward boundaries."
+      "notes": "Municipal Corporation of Gurugram \u2014 35 ward boundaries."
     },
     {
       "id": "wards_kochi",
@@ -2757,7 +2757,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Kochi Municipal Corporation ward boundaries — 74 administrative wards covering the city. Sourced from Oorvani Foundation's OpenCity data portal."
+      "notes": "Kochi Municipal Corporation ward boundaries \u2014 74 administrative wards covering the city. Sourced from Oorvani Foundation's OpenCity data portal."
     },
     {
       "id": "wards_bhubaneshwar",
@@ -2794,7 +2794,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Bhubaneshwar Municipal Corporation ward boundaries — 67 wards covering Odisha's capital city. Sourced from Oorvani Foundation's OpenCity data portal."
+      "notes": "Bhubaneshwar Municipal Corporation ward boundaries \u2014 67 wards covering Odisha's capital city. Sourced from Oorvani Foundation's OpenCity data portal."
     },
     {
       "id": "wards_vizag",
@@ -2834,7 +2834,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Greater Visakhapatnam Municipal Corporation — 98 wards."
+      "notes": "Greater Visakhapatnam Municipal Corporation \u2014 98 wards."
     },
     {
       "id": "wards_thane",
@@ -2874,7 +2874,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Thane Municipal Corporation — 47 wards across the city."
+      "notes": "Thane Municipal Corporation \u2014 47 wards across the city."
     },
     {
       "id": "wards_delhi",
@@ -2954,7 +2954,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Indore Municipal Corporation — 85 ward boundaries. 2024 delimitation."
+      "notes": "Indore Municipal Corporation \u2014 85 ward boundaries. 2024 delimitation."
     },
     {
       "id": "wards_coimbatore",
@@ -2994,7 +2994,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Coimbatore City Municipal Corporation — 100 ward boundaries. Census 2011 reorganization."
+      "notes": "Coimbatore City Municipal Corporation \u2014 100 ward boundaries. Census 2011 reorganization."
     },
     {
       "id": "wards_madurai",
@@ -3034,7 +3034,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Madurai City Municipal Corporation — 100 ward boundaries. 2024 delimitation."
+      "notes": "Madurai City Municipal Corporation \u2014 100 ward boundaries. 2024 delimitation."
     },
     {
       "id": "wards_navi_mumbai",
@@ -3074,7 +3074,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Navi Mumbai Municipal Corporation — 111 ward boundaries. 2024 delimitation."
+      "notes": "Navi Mumbai Municipal Corporation \u2014 111 ward boundaries. 2024 delimitation."
     },
     {
       "id": "wards_guwahati",
@@ -3114,7 +3114,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Guwahati Municipal Corporation — 60 ward boundaries. 2022 delimitation."
+      "notes": "Guwahati Municipal Corporation \u2014 60 ward boundaries. 2022 delimitation."
     },
     {
       "id": "wards_mysuru",
@@ -3154,7 +3154,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Mysuru City Corporation — 65 ward boundaries."
+      "notes": "Mysuru City Corporation \u2014 65 ward boundaries."
     },
     {
       "id": "wards_bhopal",
@@ -3194,7 +3194,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Bhopal Municipal Corporation — 86 ward boundaries. 2024 delimitation."
+      "notes": "Bhopal Municipal Corporation \u2014 86 ward boundaries. 2024 delimitation."
     },
     {
       "id": "wards_chandigarh",
@@ -3234,7 +3234,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Municipal Corporation of Chandigarh — 28 ward boundaries."
+      "notes": "Municipal Corporation of Chandigarh \u2014 28 ward boundaries."
     },
     {
       "id": "wards_lucknow",
@@ -3274,7 +3274,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Lucknow Municipal Corporation — 112 ward boundaries."
+      "notes": "Lucknow Municipal Corporation \u2014 112 ward boundaries."
     },
     {
       "id": "wards_kanpur",
@@ -3314,7 +3314,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Kanpur Municipal Corporation — 58 ward boundaries."
+      "notes": "Kanpur Municipal Corporation \u2014 58 ward boundaries."
     },
     {
       "id": "wards_patna",
@@ -3354,7 +3354,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.109170+00:00",
-      "notes": "Patna Municipal Corporation — 75 wards (628 sub-ward polygons). Two naming schemes: numbered \"Ward N\" and spelled-out names."
+      "notes": "Patna Municipal Corporation \u2014 75 wards (628 sub-ward polygons). Two naming schemes: numbered \"Ward N\" and spelled-out names."
     },
     {
       "id": "wards_surat",
@@ -3394,7 +3394,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.110005+00:00",
-      "notes": "Surat Municipal Corporation — 30 ward boundaries with named wards."
+      "notes": "Surat Municipal Corporation \u2014 30 ward boundaries with named wards."
     },
     {
       "id": "wards_vadodara",
@@ -3434,7 +3434,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.110706+00:00",
-      "notes": "Vadodara Municipal Corporation — 12 administrative ward boundaries."
+      "notes": "Vadodara Municipal Corporation \u2014 12 administrative ward boundaries."
     },
     {
       "id": "wards_faridabad",
@@ -3474,7 +3474,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.111326+00:00",
-      "notes": "Municipal Corporation of Faridabad — 40 ward boundaries."
+      "notes": "Municipal Corporation of Faridabad \u2014 40 ward boundaries."
     },
     {
       "id": "wards_pcmc",
@@ -3514,7 +3514,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.112003+00:00",
-      "notes": "Pimpri-Chinchwad Municipal Corporation — 66 electoral ward boundaries across 6 zones."
+      "notes": "Pimpri-Chinchwad Municipal Corporation \u2014 66 electoral ward boundaries across 6 zones."
     },
     {
       "id": "wards_vijayawada",
@@ -3554,7 +3554,7 @@
       "category": "city-wards",
       "provenance": "curated",
       "fetched_at": "2026-05-26T14:44:38.112629+00:00",
-      "notes": "Vijayawada Municipal Corporation — 77 ward boundaries."
+      "notes": "Vijayawada Municipal Corporation \u2014 77 ward boundaries."
     },
     {
       "id": "india_boundary",
@@ -3586,7 +3586,7 @@
       "category": "boundaries",
       "provenance": "curated",
       "fetched_at": "2026-05-24T13:16:39.947047+00:00",
-      "notes": "India's national boundary as a single MultiPolygon, derived by dissolving the 36 LGD state + UT polygons. India-correct by construction (LGD is India's authoritative admin source — includes Aksai Chin via J&K/Ladakh and the full Arunachal Pradesh claim)."
+      "notes": "India's national boundary as a single MultiPolygon, derived by dissolving the 36 LGD state + UT polygons. India-correct by construction (LGD is India's authoritative admin source \u2014 includes Aksai Chin via J&K/Ladakh and the full Arunachal Pradesh claim)."
     },
     {
       "id": "india_flood_inventory",
@@ -3730,7 +3730,7 @@
       "category": "boundaries",
       "provenance": "curated",
       "fetched_at": "2026-05-19T07:50:55.916651+00:00",
-      "notes": "mislabeled in upstream — block-equivalent, not village"
+      "notes": "mislabeled in upstream \u2014 block-equivalent, not village"
     },
     {
       "id": "high_courts",
@@ -4315,7 +4315,7 @@
       "category": "infrastructure",
       "provenance": "curated",
       "fetched_at": null,
-      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from ISRO VEDAS energymap (transmission lines). OSM-derived per release body — ODbL applies."
+      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from ISRO VEDAS energymap (transmission lines). OSM-derived per release body \u2014 ODbL applies."
     },
     {
       "id": "pmgsy_habitations",
@@ -4582,7 +4582,7 @@
       },
       "category": "environment",
       "provenance": "curated",
-      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from NDEM cyclone track lines. Line geometry — see ndem_cyclones_ctp for the time-step point positions when needed.",
+      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from NDEM cyclone track lines. Line geometry \u2014 see ndem_cyclones_ctp for the time-step point positions when needed.",
       "geojson": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/environment/ndem-cyclone-tracks/NDEM_Cyclones_ctl.geojson",
         "bytes": 2234277
@@ -4595,37 +4595,6 @@
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/environment/ndem-cyclone-tracks/NDEM_Cyclones_ctl.shp.zip",
         "bytes": 186921
       },
-      "fetched_at": null
-    },
-    {
-      "id": "overture_places_india",
-      "level": "overture_places_india",
-      "source": "Overture",
-      "rows": 2744948,
-      "parquet": {
-        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/pois/overture-places/overture_places_india.parquet",
-        "upstream_url": "https://github.com/ramSeraph/indian_facilities/releases/download/pois/overture_places_india.parquet",
-        "bytes": 254030046
-      },
-      "pmtiles": {
-        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/pois/overture-places/overture_places_india.pmtiles",
-        "upstream_url": "https://github.com/ramSeraph/indian_facilities/releases/download/pois/overture_places_india.pmtiles",
-        "bytes": 1207239373
-      },
-      "licence": "CDLA-Permissive-2.0",
-      "attribution": {
-        "primary": {
-          "name": "Overture Maps Foundation",
-          "url": "https://overturemaps.org/overture-december-2023-release-notes/"
-        },
-        "publisher": null
-      },
-      "category": "infrastructure",
-      "provenance": "curated",
-      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from Overture Maps Foundation 2023-12-14-alpha.0 release. Dec 2023 snapshot — refresh tracks ramSeraph's republish cadence, not Overture's monthly upstream releases.",
-      "geojson": null,
-      "kml": null,
-      "shapefile": null,
       "fetched_at": null
     },
     {
@@ -4716,6 +4685,37 @@
       "category": "transport",
       "provenance": "curated",
       "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from PMGSY GeoSadak / OMMS.",
+      "geojson": null,
+      "kml": null,
+      "shapefile": null,
+      "fetched_at": null
+    },
+    {
+      "id": "overture_places_india",
+      "level": "overture_places_india",
+      "source": "Overture",
+      "rows": 2744948,
+      "parquet": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/pois/overture-places/overture_places_india.parquet",
+        "upstream_url": "https://github.com/ramSeraph/indian_facilities/releases/download/pois/overture_places_india.parquet",
+        "bytes": 259545561
+      },
+      "pmtiles": {
+        "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/pois/overture-places/overture_places_india.pmtiles",
+        "upstream_url": "https://github.com/ramSeraph/indian_facilities/releases/download/pois/overture_places_india.pmtiles",
+        "bytes": 1207239373
+      },
+      "licence": "CDLA-Permissive-2.0",
+      "attribution": {
+        "primary": {
+          "name": "Overture Maps Foundation",
+          "url": "https://overturemaps.org/overture-december-2023-release-notes/"
+        },
+        "publisher": null
+      },
+      "category": "infrastructure",
+      "provenance": "curated",
+      "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from Overture Maps Foundation 2023-12-14-alpha.0 release. Dec 2023 snapshot \u2014 refresh tracks ramSeraph's republish cadence, not Overture's monthly upstream releases.",
       "geojson": null,
       "kml": null,
       "shapefile": null,

--- a/scripts/external-ingested.json
+++ b/scripts/external-ingested.json
@@ -1026,25 +1026,6 @@
     "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps from NDEM cyclone track lines. Line geometry \u2014 see ndem_cyclones_ctp for the time-step point positions when needed."
   },
   {
-    "id": "overture_places_india",
-    "name": "Places \u2014 Overture Maps (Dec 2023)",
-    "level": "overture_places_india",
-    "category": "infrastructure",
-    "source": "Overture",
-    "description": "Pan-India points of interest from the Overture Maps Foundation December 2023 release. Names, categories, addresses, websites and confidence scores for restaurants, shops, ATMs, schools, transit, monuments and more.",
-    "unit": "places",
-    "features": 2744948,
-    "license": "CDLA-Permissive-2.0",
-    "r2_prefix": "pois/overture-places",
-    "parquet_file": "overture_places_india.parquet",
-    "parquet_bytes": 254030046,
-    "pmtiles_file": "overture_places_india.pmtiles",
-    "pmtiles_bytes": 1207239373,
-    "source_url": "https://overturemaps.org/overture-december-2023-release-notes/",
-    "source_org": "Overture Maps Foundation",
-    "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from Overture Maps Foundation 2023-12-14-alpha.0 release. Dec 2023 snapshot \u2014 refresh tracks ramSeraph's republish cadence, not Overture's monthly upstream releases."
-  },
-  {
     "id": "wris_waterbodies",
     "name": "Waterbodies (WRIS 2024)",
     "level": "wris_waterbodies",
@@ -1100,5 +1081,24 @@
     "source_url": "https://omms.nic.in/",
     "source_org": "PMGSY GeoSadak (Ministry of Rural Development)",
     "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from PMGSY GeoSadak / OMMS."
+  },
+  {
+    "id": "overture_places_india",
+    "name": "Places \u2014 Overture Maps (Dec 2023)",
+    "level": "overture_places_india",
+    "category": "infrastructure",
+    "source": "Overture",
+    "description": "Pan-India points of interest from the Overture Maps Foundation December 2023 release. Names, categories, addresses, websites and confidence scores for restaurants, shops, ATMs, schools, transit, monuments and more.",
+    "unit": "places",
+    "features": 2744948,
+    "license": "CDLA-Permissive-2.0",
+    "r2_prefix": "pois/overture-places",
+    "parquet_file": "overture_places_india.parquet",
+    "parquet_bytes": 259545561,
+    "pmtiles_file": "overture_places_india.pmtiles",
+    "pmtiles_bytes": 1207239373,
+    "source_url": "https://overturemaps.org/overture-december-2023-release-notes/",
+    "source_org": "Overture Maps Foundation",
+    "notes": "Pre-baked parquet + pmtiles compiled by ramSeraph/indianopenmaps (DataMeet community) from Overture Maps Foundation 2023-12-14-alpha.0 release. Dec 2023 snapshot \u2014 refresh tracks ramSeraph's republish cadence, not Overture's monthly upstream releases."
   }
 ]

--- a/scripts/ingest_ramseraph.py
+++ b/scripts/ingest_ramseraph.py
@@ -519,13 +519,18 @@ def row_group_size_for(feature_count: int) -> int | None:
     /api/v1/nearby pruning. Default (122880) wastes pruning on dense layers
     because a single group still covers a meaningful chunk of India even
     after Hilbert sort. Bucket by feature count so each layer ends up with
-    roughly 10-100 groups.
+    enough groups that even Hilbert curve discontinuities (zigzag points
+    that span large bboxes) only pull in ~120k rows post-prune.
+
     Returns None for tiny layers where a single group is fine.
+
+    Cap at 20k: a 50k tier was tried for >1M-row layers and left Mumbai
+    and Delhi Overture queries 503-ing because 5-6 row groups matched
+    their bbox including a Hilbert outlier spanning half of west India.
     """
     if feature_count < 10_000:    return None
     if feature_count < 100_000:   return 5_000
-    if feature_count < 1_000_000: return 20_000
-    return 50_000
+    return 20_000
 
 
 def rebake_flatten_bbox(src: Path, dst: Path) -> tuple[int, list[str]]:

--- a/scripts/test_hilbert_sort.py
+++ b/scripts/test_hilbert_sort.py
@@ -134,7 +134,13 @@ def test_rebake_handles_geometry_typed_column(tmp_path: Path) -> None:
 
 def test_row_group_size_for_scales_with_density() -> None:
     """Dense layers want many small groups (tight Hilbert chunks per group);
-    sparse layers want one or two big groups. Spec the buckets."""
+    sparse layers want one or two big groups. Spec the buckets.
+
+    Cap at 20k for everything >100k: the 50k tier was tried for >1M-row layers
+    but left Mumbai/Delhi Overture queries hitting 5-6 row groups (including a
+    Hilbert curve outlier spanning half of west India), exhausting the Workers
+    CPU budget. 20k keeps every metro under ~120k post-prune rows.
+    """
     from ingest_ramseraph import row_group_size_for
     assert row_group_size_for(100) is None         # single group is fine
     assert row_group_size_for(9_999) is None
@@ -142,8 +148,8 @@ def test_row_group_size_for_scales_with_density() -> None:
     assert row_group_size_for(99_999) == 5_000
     assert row_group_size_for(500_000) == 20_000   # ~25 groups
     assert row_group_size_for(999_999) == 20_000
-    assert row_group_size_for(2_700_000) == 50_000  # Overture: ~54 groups
-    assert row_group_size_for(5_000_000) == 50_000
+    assert row_group_size_for(2_700_000) == 20_000  # Overture: ~135 groups
+    assert row_group_size_for(5_000_000) == 20_000
 
 
 def test_rebake_uses_tight_row_groups_for_dense_layers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

After #105 fixed Bangalore-Overture, sampling 12 major Indian metros revealed Mumbai and Delhi still 503'd. Root cause: the 50k `ROW_GROUP_SIZE` for >1M-row layers let Hilbert curve zigzags produce row groups with very wide bboxes. Mumbai's query touched 5 such groups (256k post-prune rows); Delhi touched 6 (307k rows). Both exhausted the Worker budget.

Cap at 20k for everything above 100k features. Smaller groups → tighter per-group bboxes → even the curve discontinuities only contribute ~20k rows each.

## Before / after

10 km radius via `/api/v1/nearby?layer=overture_places_india&...`:

| City | Before (50k) | After (20k) |
|---|---|---|
| **Mumbai** | **503** (256k rows) | **200, 6.3s, 66k rows** |
| **Delhi** | **503** (307k rows) | **200, 5.5s, 89k rows** |
| Bangalore | 4.2s (100k rows) | 4.4s (100k rows) — unchanged |
| Kolkata | 3.6s (72k rows) | 3.5s (72k rows) — unchanged |
| Leh | (sparse) | 0.8s (1k rows) — unchanged |

Mumbai's post-prune row count dropped 4× (256k → 66k). Delhi 3.4× (307k → 89k). Both now fit Workers' CPU budget with margin to spare.

## What changed

```python
def row_group_size_for(feature_count):
    if feature_count < 10_000:    return None
    if feature_count < 100_000:   return 5_000
    return 20_000                              # was: 20_000 for <1M, 50_000 for >=1M
```

Plus a re-ingest of `overture_places_india` so the new parquet ships with 135 row groups instead of 54.

## Trade-offs
- Parquet size: 254 MB → 259.5 MB (+2% metadata overhead). Acceptable in exchange for Mumbai/Delhi working at all.
- Sparse-area queries (Leh) unchanged because they only touch 1-2 groups regardless of group size.
- `pmgsy_roads` (1.1M, currently on 50k from #106) and `slusi_soil_health` (5.2M, not yet rebaked) still on the old 50k. They don't have a megacity timeout symptom, but a re-bake would tighten them too. Queued, not in this PR.

## Test plan
- [x] vitest 509/509 pass
- [x] pytest 30/30 pass (1 updated test asserts 20k for >1M)
- [x] Overture re-baked + uploaded; Mumbai, Delhi, Bangalore, Kolkata, Leh verified via MCP
- [ ] Post-merge: re-sweep the 12-metro list to confirm no other city regresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)