### PR TITLE
fix(ci): community submissions disappeared from prod (op-precedence bug)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,13 @@ jobs:
         # just verifying the build doesn't break).
         env:
           TURNSTILE_SITEKEY: ${{ secrets.TURNSTILE_SITEKEY || '1x00000000000000000000AA' }}
-          COMMUNITY_FROM: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' && 'remote' || 'local' }}
+          # Operator precedence in GH expressions: && binds tighter than ||,
+          # so the obvious shape `A || B || C && 'remote' || 'local'` parses as
+          # `A || B || (C && 'remote') || 'local'` and short-circuits to the
+          # boolean `true` on push-to-main. wrangler then gets `--true` and the
+          # try/catch in prerender swallows the error → empty community list.
+          # Group all deploy events first, THEN AND with 'remote'.
+          COMMUNITY_FROM: ${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && 'remote' || 'local' }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: npm run build

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -694,10 +694,23 @@ for (const lvl of LEVEL_ORDER) {
   categoryCounts[cat] = (categoryCounts[cat] || 0) + 1;
 }
 
-// Community submissions: query D1 (local by default; --remote in prod build
-// once that's wired). Silently empty on failure so a missing wrangler /
-// missing DB doesn't break the build.
-const COMMUNITY_FROM = process.env.COMMUNITY_FROM || 'local'; // local | remote
+// Community submissions: query D1 (local for dev, --remote for the
+// deployed main build). Returns [] on failure so dev / PR builds don't
+// break when wrangler / D1 aren't reachable, but warns loudly to stderr
+// so CI logs surface a regression instead of shipping an empty grid.
+// Validate the env var up front: any value other than 'local' or 'remote'
+// (e.g. the literal string "true" produced by a botched workflow YAML
+// expression) gets caught here rather than handed to wrangler as a bogus
+// --flag that silently errors.
+const RAW_COMMUNITY_FROM = process.env.COMMUNITY_FROM || 'local';
+const COMMUNITY_FROM = ['local', 'remote'].includes(RAW_COMMUNITY_FROM) ? RAW_COMMUNITY_FROM : null;
+if (!COMMUNITY_FROM) {
+  console.warn(
+    `[prerender] COMMUNITY_FROM=${JSON.stringify(RAW_COMMUNITY_FROM)} is not 'local' or 'remote'. ` +
+    `Falling back to 'local'. Community submissions will NOT appear in this build.`,
+  );
+}
+const COMMUNITY_SCOPE = COMMUNITY_FROM ?? 'local';
 // Prefer a PATH-resolved wrangler (mise / homebrew) over npx, which has
 // hit a workerd arch mismatch on this machine's npx cache.
 import { execFileSync } from 'node:child_process';
@@ -709,7 +722,7 @@ const wranglerPrefix = WRANGLER_BIN || 'npx --yes wrangler';
 function fetchCommunitySubmissions() {
   try {
     const out = execSync(
-      `${wranglerPrefix} d1 execute geodata-submissions --${COMMUNITY_FROM} --json --command "${
+      `${wranglerPrefix} d1 execute geodata-submissions --${COMMUNITY_SCOPE} --json --command "${
         'SELECT s.id, s.name, s.description, s.category, s.attribution, s.is_original, ' +
         's.format, s.bytes, s.feature_count, s.r2_key, s.created_at, ' +
         "COALESCE(SUM(CASE WHEN r.vote = 1 THEN 1 ELSE 0 END), 0) AS up_count, " +
@@ -717,16 +730,27 @@ function fetchCommunitySubmissions() {
         'FROM submissions s LEFT JOIN submission_ratings r ON r.submission_id = s.id ' +
         "WHERE s.status='accepted' GROUP BY s.id ORDER BY s.created_at DESC LIMIT 200"
       }"`,
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
     );
     const data = JSON.parse(out);
-    return (data?.[0]?.results || []).map((r) => ({
+    const rows = (data?.[0]?.results || []).map((r) => ({
       ...r,
       up_count: Number(r.up_count) || 0,
       down_count: Number(r.down_count) || 0,
       score: (Number(r.up_count) || 0) - (Number(r.down_count) || 0),
     }));
-  } catch {
+    if (COMMUNITY_SCOPE === 'remote' && rows.length === 0) {
+      console.warn(
+        '[prerender] community fetch (remote) returned 0 rows. ' +
+        'If submissions exist in D1, this is a regression — check wrangler auth or the SQL.',
+      );
+    }
+    return rows;
+  } catch (err) {
+    console.warn(
+      `[prerender] community fetch (${COMMUNITY_SCOPE}) failed: ${err.message || err}. ` +
+      'Build continues with empty community grid.',
+    );
     return [];
   }
 }


### PR DESCRIPTION
## Summary

User reported that a community submission ("Goa Landuse Zone Change Applications", id `nL7zNStsW3`, status `accepted` in D1, submitted 2026-05-25) doesn't appear on the production home grid.

Root cause: a GitHub Actions expression precedence bug in `.github/workflows/ci.yml`. The shape

```yaml
COMMUNITY_FROM: ${{ A || B || C && 'remote' || 'local' }}
```

binds `&&` tighter than `||`, so it parses as `(A) || B || (C && 'remote') || 'local'`. On push-to-main, `A` is true and the first `||` short-circuits, yielding the boolean `true` (not the string `'remote'`). `prerender.mjs` then runs `wrangler d1 execute geodata-submissions --true ...`, that errors, and the bare `catch` swallows the failure and returns `[]`. Every main deploy since this expression landed has been shipping a community-less catalog.

## Two defences in this PR

**1. Workflow fix.** Group all "is this a deploy event?" conditions inside one set of parens, then AND with `'remote'`:

```yaml
# before
COMMUNITY_FROM: ${{ A || B || C && 'remote' || 'local' }}

# after
COMMUNITY_FROM: ${{ (A || B || C) && 'remote' || 'local' }}
```

**2. `prerender.mjs` hardening** — so the next YAML mistake doesn't silently disappear community again:

- Validate `COMMUNITY_FROM` up front. Anything other than `'local'` / `'remote'` falls back to `'local'` with a `console.warn` so CI logs scream when it happens.
- Replace the bare `catch` with one that prints the wrangler error message and the scope used. Capture stderr too (was discarded via `stdio: ['ignore', 'pipe', 'ignore']`) so the real cause is visible.
- On `'remote'` scope, log a warning if the query returns 0 rows. False positive is harmless during legitimate empty-D1 phases; false negative would be another silent disappearance.

## Test plan
- [x] `npm test` passes 509/509 locally
- [x] Workflow YAML parses; expression evaluates to `'remote'` for push-to-main and `'local'` for PR builds (verified by walking the precedence)
- [ ] Post-merge: confirm `catalog.json` ships with a community section and the Goa submission appears on the home grid
- [ ] Post-merge: confirm CI log shows no `[prerender] community fetch` warnings on the green deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)