### PR TITLE
feat(home): community pill + community-keyword search; fix(preview): use Bharatlas Minimal basemap

### DIFF
--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -763,10 +763,13 @@ function renderCommunityCard(s, opts = {}) {
   const cat = s.category || 'other';
   const collapsed = opts.collapsed ? ' row--collapsed' : '';
   // Two-tier haystack (matches curated cards). Title is the only field
-  // we trust as "this card is about X"; the rest is body.
-  const primaryHaystack = expandAliases(s.name || '').toLowerCase();
+  // we trust as "this card is about X"; the rest is body. We also lift
+  // 'community' and 'submission' into primary so searching either word
+  // surfaces community-provenance cards alongside any curated card with
+  // 'community' in its title (e.g. Community-development Blocks).
+  const primaryHaystack = expandAliases([s.name || '', 'community submission'].join(' ')).toLowerCase();
   const bodyHaystack = expandAliases(
-    [s.description || '', s.attribution || '', cat, s.format || '', 'community'].join(' '),
+    [s.description || '', s.attribution || '', cat, s.format || ''].join(' '),
   ).toLowerCase();
   const dataAttrs = [
     `data-id="${esc(s.id)}"`,
@@ -819,8 +822,16 @@ const chips = [
     ([id, name]) => `<button class="catalog-chip" data-cat="${esc(id)}" data-count="${categoryCounts[id]}" data-total="${categoryCounts[id]}">${esc(name)} <span class="count">${categoryCounts[id]}</span></button>`,
   ),
 ];
+// Community pill: appears only when there's at least one community submission.
+// It filters on provenance, not category — cardVisibility special-cases the
+// activeCat='community' lookup so cards from any content category surface.
+if (community.length > 0) {
+  chips.push(
+    `<button class="catalog-chip" data-cat="community" data-count="${community.length}" data-total="${community.length}">Community <span class="count">${community.length}</span></button>`,
+  );
+}
 // Only render chips when there's more than one category to switch between.
-const chipsHtml = activeCats.length > 1 ? chips.join('') : '';
+const chipsHtml = activeCats.length > 1 || community.length > 0 ? chips.join('') : '';
 
 // Render one section per non-empty category. Inside each: curated level rows
 // first (in LEVEL_ORDER), then community cards (newest first). Both are

--- a/web/src/catalog-filter.ts
+++ b/web/src/catalog-filter.ts
@@ -27,6 +27,10 @@ export type CardLike = {
   category: string;
   primary: string;
   body: string;
+  /** 'curated' | 'community'. The community pill filters on this instead
+   *  of category because community submissions inherit a content category
+   *  (environment, infrastructure, etc.) for the section they render in. */
+  provenance?: string;
 };
 
 export type FilterResult = {
@@ -38,26 +42,39 @@ export type FilterResult = {
 /**
  * Decide per-card visibility on the home grid.
  *
- * Earlier behaviour was `matches AND inActiveCategory` for every card. That
- * made search results depend on whether the matched layer happened to be
- * categorised into the currently-selected pill — invisible context to the
- * user. Typing `over` with `Environment` selected returned "No matches",
- * even though Overture Places (in `infrastructure`) clearly matched.
+ * Rules:
+ *   - When the user is searching (query non-empty), the active pill is
+ *     ignored — search intent overrides scoping so cross-category matches
+ *     don't get silently hidden (e.g. typing "over" with Environment
+ *     selected must still surface Overture in Infrastructure).
+ *   - When activeCat === 'community', filter by provenance instead of
+ *     content category; community submissions inherit a content category
+ *     for sectioning, so the pill would otherwise match nothing.
+ *   - Otherwise, scope by content category as before.
  *
- * New rule: when the user is searching (query non-empty), the active pill
- * is ignored — search intent ("find me this thing") overrides scoping
- * intent ("show me only this category"). When the query is empty, the
- * pill scopes the catalog as before. Pill counts continue to show
- * filtered/total in both modes so the distribution stays visible.
+ * Second arg accepts either a string[] (legacy: category per card) or a
+ * CardLike[] (richer: category + provenance). The provenance lookup needs
+ * the richer shape; string[] is kept for callers that don't need it.
  */
 export function cardVisibility(
   matches: boolean[],
-  categories: string[],
+  cards: string[] | CardLike[],
   activeCat: string,
   query: string,
 ): boolean[] {
   const searching = query.trim().length > 0;
-  return matches.map((m, i) => m && (searching || activeCat === 'all' || categories[i] === activeCat));
+  const asLike = (i: number): { category: string; provenance: string } => {
+    const c = cards[i];
+    return typeof c === 'string' ? { category: c, provenance: '' } : { category: c.category, provenance: c.provenance || '' };
+  };
+  return matches.map((m, i) => {
+    if (!m) return false;
+    if (searching) return true;
+    if (activeCat === 'all') return true;
+    const { category, provenance } = asLike(i);
+    if (activeCat === 'community') return provenance === 'community';
+    return category === activeCat;
+  });
 }
 
 export function filterCards(cards: CardLike[], query: string): FilterResult {

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -115,6 +115,7 @@ if (searchInput && grid) {
     category: el.dataset.category || el.closest<HTMLElement>('.category-section')?.dataset.category || '',
     primary: el.dataset.searchPrimary || '',
     body: el.dataset.searchBody || '',
+    provenance: el.dataset.provenance || '',
   }));
   let activeCat = 'all';
   let query = '';
@@ -132,7 +133,7 @@ if (searchInput && grid) {
     // — regardless of which pill is active — so cross-category results
     // ("over" → Overture in Infrastructure with Environment selected) don't
     // silently get hidden behind "No matches".
-    const visible = cardVisibility(result.matches, cardLikes.map((c) => c.category), activeCat, query);
+    const visible = cardVisibility(result.matches, cardLikes, activeCat, query);
     const visiblePerSection = new Map<HTMLElement, number>();
     let totalVisible = 0;
     for (let i = 0; i < cardEls.length; i++) {
@@ -151,19 +152,31 @@ if (searchInput && grid) {
       // Hide a section only when (a) the user has scoped to a different pill
       // AND isn't searching, OR (b) it has no visible cards. While searching,
       // sections appear for every category that has matches.
-      const catFiltered = !query && activeCat !== 'all' && cat !== activeCat;
+      // 'community' is a provenance pill, not a content category — every
+      // section that has at least one visible community card should show.
+      // Existing rule covers that via sectionVisible === 0 below; we just
+      // need to skip the category-mismatch hide.
+      const catFiltered = !query && activeCat !== 'all' && activeCat !== 'community' && cat !== activeCat;
       section.classList.toggle('hidden', catFiltered || sectionVisible === 0);
     }
 
     // Pill counts: filtered/total when a query is active, bare total when idle.
     // 'all' chip aggregates across categories; per-cat chips read their own.
     const filtering = !!query;
+    // 'community' chip's filtered count comes from provenance, not category;
+    // filterCards groups countsByCategory under content categories so it
+    // doesn't know about the community pill.
+    const communityFiltered = result.matches.reduce(
+      (n, m, i) => n + (m && cardLikes[i].provenance === 'community' ? 1 : 0), 0,
+    );
     for (const chip of chips) {
       const cat = chip.dataset.cat || '';
       const total = Number(chip.dataset.total || '0');
       const filtered = cat === 'all'
         ? result.totalMatches
-        : (result.countsByCategory.get(cat) || 0);
+        : cat === 'community'
+          ? communityFiltered
+          : (result.countsByCategory.get(cat) || 0);
       const span = chip.querySelector<HTMLElement>('.count');
       if (span) span.textContent = filtering ? `${filtered}/${total}` : String(total);
       // data-count drives the [data-count="0"] dim style + click guard.

--- a/web/src/preview.ts
+++ b/web/src/preview.ts
@@ -64,17 +64,19 @@ let turnstileWidgetId: string | number | null = null;
 const viewOnly = new URLSearchParams(location.search).has('url');
 
 // ---------- Map -----------------------------------------------------------
+// Use the Bharatlas Minimal basemap (same as the catalog viewer) instead
+// of a raw OSM tile dependency. OSM's tile server can throttle public
+// embeds without warning, and ad-blockers / corporate firewalls often
+// block tile.openstreetmap.org outright — symptom is a dark canvas with
+// no labels and no land/water distinction. Minimal is bundled GeoJSON
+// from /world-land.geojson + /india-outline.geojson, served same-origin
+// from R2/Pages so it's reliable.
+import { BASEMAPS } from './basemaps';
+const minimal = BASEMAPS.find((b) => b.id === 'minimal') ?? BASEMAPS[0];
 const BASE_STYLE: maplibregl.StyleSpecification = {
   version: 8,
-  sources: {
-    osm: {
-      type: 'raster',
-      tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
-      tileSize: 256,
-      attribution: '© OpenStreetMap',
-    },
-  },
-  layers: [{ id: 'osm', type: 'raster', source: 'osm' }],
+  sources: minimal.sources,
+  layers: minimal.layers,
 };
 
 const map = new maplibregl.Map({

--- a/web/tests/catalog-filter.test.ts
+++ b/web/tests/catalog-filter.test.ts
@@ -122,3 +122,44 @@ describe('catalog-filter — cardVisibility (search × active-pill interaction)'
     expect(v[7]).toBe(true);
   });
 });
+
+describe('catalog-filter — community pill (provenance filter)', () => {
+  // Community submissions inherit a content category (environment / etc.)
+  // for sectioning, so a "community" pill can't just match data-category.
+  // It must match on provenance. When activeCat='community', show only
+  // cards with provenance='community' regardless of content category.
+  const mixed: CardLike[] = [
+    { category: 'environment',   primary: 'wildlife',         body: '...', provenance: 'curated' },
+    { category: 'environment',   primary: 'goa landuse',      body: '...', provenance: 'community' },
+    { category: 'infrastructure', primary: 'roads',           body: '...', provenance: 'curated' },
+    { category: 'infrastructure', primary: 'bangalore lanes', body: '...', provenance: 'community' },
+  ];
+
+  it("activeCat='community' shows only provenance='community' cards", () => {
+    const matches = mixed.map(() => true);
+    const v = cardVisibility(matches, mixed, 'community', '');
+    expect(v).toEqual([false, true, false, true]);
+  });
+
+  it("activeCat='community' bypasses content-category scoping across all categories", () => {
+    const matches = mixed.map(() => true);
+    const v = cardVisibility(matches, mixed, 'community', '');
+    // Both community cards visible — one in environment, one in infrastructure.
+    expect(v[1]).toBe(true);
+    expect(v[3]).toBe(true);
+  });
+
+  it("activeCat='community' + search query: still respects search matches", () => {
+    // Search hit only on the Goa card (index 1).
+    const matches = mixed.map((_c, i) => i === 1);
+    const v = cardVisibility(matches, mixed, 'community', 'goa');
+    expect(v).toEqual([false, true, false, false]);
+  });
+
+  it("activeCat='environment' (content category) still uses category match, not provenance", () => {
+    const matches = mixed.map(() => true);
+    const v = cardVisibility(matches, mixed, 'environment', '');
+    // Both environment cards visible regardless of provenance.
+    expect(v).toEqual([true, true, false, false]);
+  });
+});


### PR DESCRIPTION
## Summary

Two community-visibility fixes the user surfaced after PR #108 made community submissions actually reach the home page:

### 1. Community pill + community search (home grid)

**Symptoms**: no "Community" pill in the chip row; typing "community" in search didn't find the Goa landuse card.

**Root cause**:
- Community submissions inherit a content category (the Goa card is `data-category="environment"`) so they slot into existing sections — provenance wasn't a filter axis.
- `filterCards` uses two tiers: if any card matches in primary, body matches are skipped. Curated layers like Community-development Blocks match "community" in primary, so the algorithm never falls through to body, and the community card (which only had "community" in its body) stayed hidden.

**Fix**:
- Render a **Community** chip when `community.length > 0`. `cardVisibility` treats `activeCat='community'` as a *provenance* filter rather than a category filter, so cards from any content section all surface together when the pill is selected. Section-hide rule updated to not require category match for the provenance pill.
- Promote "community submission" into the community card's primary haystack so search "community" matches in primary alongside curated cards that do.
- Pill counts: filterCards groups by content category, so the community chip's filtered count is computed separately (provenance match × search match).
- `cardVisibility`'s second arg now accepts `CardLike[]` (richer; carries provenance) in addition to the legacy `string[]` (category-only) so existing callers still work.

4 new vitest cases cover the provenance filter.

### 2. /preview basemap (map rendering)

**Symptom**: map loads features fine but the background is black — no land/water distinction, no labels.

**Root cause**: `/preview` had its own `BASE_STYLE` that pulled raster tiles from `tile.openstreetmap.org`. OSM's public tile server can throttle without warning; ad-blockers and corporate firewalls often block it outright. Either failure mode silently produces a dark canvas.

**Fix**: Switch `/preview` to the same Bharatlas Minimal basemap the catalog viewer uses — bundled GeoJSON (`/world-land.geojson` + `/india-outline.geojson`) served same-origin. One source of truth, no external tile dependency, consistent visual across both map surfaces.

## Test plan
- [x] vitest 513/513 pass (+4 for community pill tests)
- [x] tsc clean
- [ ] Post-deploy: community pill visible on home, click filters to Goa card across all sections
- [ ] Post-deploy: search "community" finds Goa card
- [ ] Post-deploy: `/preview?url=/api/r2/community/nL7zNStsW3/39A.geojson` shows India outline + state borders behind the feature dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)