### PR TITLE
fix(basemap): close coastline gap on Minimal — fill India with LGD outline

### DIFF
--- a/web/src/basemaps.ts
+++ b/web/src/basemaps.ts
@@ -109,6 +109,20 @@ export const BASEMAPS: Basemap[] = [
           'fill-outline-color': '#d0c8be', // subtle taupe coast outline
         },
       },
+      // Fill India with the SAME warm off-white using the LGD-dissolved
+      // polygon, on top of world-land. Natural Earth's 1:110m coastline
+      // disagrees with LGD by several km along the Konkan / Coromandel
+      // coast, so the ocean colour was leaking through inside the outline
+      // ("water seeping past the boundaries"). Stacking this India fill
+      // on top closes the gap exactly to the outline that's drawn next.
+      {
+        id: 'minimal-india-fill',
+        type: 'fill',
+        source: 'india-outline',
+        paint: {
+          'fill-color': '#f5f3ef',
+        },
+      },
       // Complete India outline from the LGD-dissolved polygon. Renders
       // the full coast + all land borders as a single stroke — the osm-in
       // file only had claim lines (J&K, Aksai Chin, Arunachal) so the


### PR DESCRIPTION
## Summary

Reported on /preview: the ocean colour 'seeps past the boundaries' along the Konkan / Coromandel coast — water visible *inside* the brown India outline.

## Cause

The Minimal basemap stacks two coastlines that don't match:

- **Land fill** comes from Natural Earth 1:110m `world-land.geojson` (138 KB, polygon-only).
- **India outline** (the brown stroke) comes from the LGD-dissolved India polygon (`/india-outline.geojson`).

Natural Earth's coastline disagrees with LGD by several km in places, so the background ocean colour shows through the gap between NE's coast and LGD's coast.

## Fix

Add a second fill layer using the same `india-outline` source as the outline line, painted the same warm off-white as the world land fill. Stacked above `world-land`, beneath the outline stroke — closes the discrepancy exactly to the outline that ships with it. India is filled to its actual claimed boundary; ocean stays outside.

No change to other basemaps (Carto Light / Topo / Satellite use raster tiles with their own coastlines). No change to `/world-land.geojson` or `/india-outline.geojson`.

## Test plan
- [x] vitest 513/513 pass
- [ ] Post-deploy: reload `bharatlas.com/preview?url=/api/r2/community/nL7zNStsW3/39A.geojson` and confirm the off-white land fill now reaches the outline along the Konkan coast (no blue strip inside India)
- [ ] Post-deploy: zoom to other coasts (Gujarat, Tamil Nadu, Odisha) and verify same — no land/water bleed at the LGD outline anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)