### PR TITLE
fix(csp): upvote button + Cloudflare Web Analytics beacon

### DIFF
--- a/web/functions/lib/render-view.ts
+++ b/web/functions/lib/render-view.ts
@@ -266,40 +266,7 @@ export function renderViewPage(opts: RenderOpts): string {
       Verify provenance via the source link above.</p>
     </footer>
 
-    <script>
-      (() => {
-        const id = document.body.dataset.submissionId;
-        const btn = document.getElementById('vote-useful');
-        const count = document.getElementById('vote-count');
-        if (!btn || !count) return;
-
-        // Display count = up votes only. Existing legacy downvotes in D1
-        // are ignored in the UI per task #61 (single-direction Useful vote).
-        let myVote = 0;
-        const apply = (s) => {
-          count.textContent = String(s.up || 0);
-          myVote = s.myVote === 1 ? 1 : 0;
-          btn.setAttribute('aria-pressed', myVote === 1 ? 'true' : 'false');
-        };
-
-        fetch('/api/c/' + id + '/rate').then(r => r.ok ? r.json() : null).then(s => s && apply(s)).catch(() => {});
-
-        const send = async (vote) => {
-          btn.disabled = true;
-          try {
-            const r = await fetch('/api/c/' + id + '/rate', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ vote }),
-            });
-            if (r.ok) apply(await r.json());
-          } catch {}
-          btn.disabled = false;
-        };
-        // Click to mark useful; click again to clear.
-        btn.addEventListener('click', () => send(myVote === 1 ? 0 : 1));
-      })();
-    </script>
+    <script src="/c-vote.js" defer></script>
   </body>
 </html>`;
 }

--- a/web/functions/lib/security-headers.ts
+++ b/web/functions/lib/security-headers.ts
@@ -17,7 +17,9 @@
 // possible so /about, /c/<id>, /view/<id> all look identical to a browser.
 const CSP =
   "default-src 'self'; " +
-  "script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com 'wasm-unsafe-eval'; " +
+  // static.cloudflareinsights.com is the Cloudflare Web Analytics beacon
+  // (auto-injected by CF when the feature is enabled on the account).
+  "script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com https://static.cloudflareinsights.com 'wasm-unsafe-eval'; " +
   "worker-src 'self' blob:; " +
   "connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com; " +
   "img-src 'self' blob: data: https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://services.arcgisonline.com https://*.tile.opentopomap.org https://avatars.githubusercontent.com; " +

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -8,7 +8,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com; img-src 'self' blob: data: https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://services.arcgisonline.com https://*.tile.opentopomap.org https://avatars.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com https://static.cloudflareinsights.com 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com; img-src 'self' blob: data: https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://services.arcgisonline.com https://*.tile.opentopomap.org https://avatars.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'
 
 # Hashed Vite assets — safe to cache forever.
 /assets/*

--- a/web/public/c-vote.js
+++ b/web/public/c-vote.js
@@ -1,0 +1,35 @@
+// Vote button wiring for /c/<id>. Loaded as a same-origin module so the
+// strict CSP (script-src 'self' …, no 'unsafe-inline') doesn't block it
+// the way the inline <script> body did. Behaviour unchanged: single-
+// direction "Useful" vote, click toggles between marked and cleared.
+//
+// Body must carry data-submission-id="<id>"; the page template sets that.
+(() => {
+  const id = document.body.dataset.submissionId;
+  const btn = document.getElementById('vote-useful');
+  const count = document.getElementById('vote-count');
+  if (!id || !btn || !count) return;
+
+  let myVote = 0;
+  const apply = (s) => {
+    count.textContent = String(s.up || 0);
+    myVote = s.myVote === 1 ? 1 : 0;
+    btn.setAttribute('aria-pressed', myVote === 1 ? 'true' : 'false');
+  };
+
+  fetch('/api/c/' + id + '/rate').then((r) => r.ok ? r.json() : null).then((s) => s && apply(s)).catch(() => {});
+
+  const send = async (vote) => {
+    btn.disabled = true;
+    try {
+      const r = await fetch('/api/c/' + id + '/rate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ vote }),
+      });
+      if (r.ok) apply(await r.json());
+    } catch {}
+    btn.disabled = false;
+  };
+  btn.addEventListener('click', () => send(myVote === 1 ? 0 : 1));
+})();

--- a/web/tests/render-view.test.ts
+++ b/web/tests/render-view.test.ts
@@ -148,6 +148,17 @@ describe('renderViewPage', () => {
     expect(html).toContain('MB');
     expect(html).toContain('geojson');
   });
+
+  it('wires the upvote handler via an external script (CSP-safe, no inline body)', () => {
+    // The vote button click handler used to live in an inline <script>{...}</script>
+    // which got blocked by our strict CSP (script-src 'self' …, no 'unsafe-inline').
+    // The handler now lives in /c-vote.js, referenced via a self-source script tag.
+    const html = renderViewPage({ submission: row(), origin: ORIGIN, ratingsCount: 0, alreadyRated: false });
+    expect(html).toMatch(/<script[^>]+src="\/c-vote\.js"/);
+    // No inline script bodies for app behaviour (JSON-LD blobs are data, not code).
+    const inlineScripts = [...html.matchAll(/<script(?![^>]+src=)(?![^>]+type="application\/ld\+json")[^>]*>([\s\S]*?)<\/script>/g)];
+    expect(inlineScripts).toHaveLength(0);
+  });
 });
 
 describe('renderViewPage — OG/Twitter image meta (v4.7 per-submission)', () => {

--- a/web/tests/security-headers.test.ts
+++ b/web/tests/security-headers.test.ts
@@ -65,6 +65,15 @@ describe('Security headers — Cloudflare Pages _headers file', () => {
     expect(csp![1]).toContain('https://challenges.cloudflare.com');
   });
 
+  it('CSP allows Cloudflare Web Analytics beacon', () => {
+    // CF auto-injects <script src="https://static.cloudflareinsights.com/beacon.min.js/...">
+    // when Web Analytics is enabled at the account level. Without explicit allow
+    // it gets blocked and the console fills with CSP violations.
+    const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/);
+    expect(csp).not.toBeNull();
+    expect(csp![1]).toContain('https://static.cloudflareinsights.com');
+  });
+
   it('CSP does not use unsafe-eval (only wasm-unsafe-eval)', () => {
     const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/);
     expect(csp).not.toBeNull();
@@ -130,6 +139,14 @@ describe('Security headers — SECURITY_HEADERS_HTML (Pages Function responses)'
     expect(csp).toMatch(/https:\/\/cdn\.jsdelivr\.net/);
     // R2 public reads for layer downloads
     expect(csp).toMatch(/https:\/\/pub-0429b8e3b5a946e69ea007df844a6f1c\.r2\.dev/);
+  });
+
+  it('CSP allows the Cloudflare Web Analytics beacon', () => {
+    // CF auto-injects <script src="https://static.cloudflareinsights.com/...">
+    // on every response from a domain with Web Analytics enabled. Without
+    // an explicit allow the browser blocks it on every Pages Function page.
+    expect(SECURITY_HEADERS_HTML['content-security-policy'])
+      .toContain('https://static.cloudflareinsights.com');
   });
 });
 


### PR DESCRIPTION
## Summary

Two CSP violations on /c/<id> reported from the browser console:

```
nL7zNStsW3:136 Executing inline script violates the following Content Security
Policy directive 'script-src 'self' blob: https://cdn.jsdelivr.net
https://challenges.cloudflare.com 'wasm-unsafe-eval'' …

Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/…'
violates the following Content Security Policy directive …
```

Symptoms:
1. The 👍 useful button on every community submission did nothing — the inline `<script>` that wired it was blocked.
2. Cloudflare Web Analytics beacon (auto-injected at the account level) was blocked too, so analytics coverage on `/c/<id>`, `/view/<id>`, and other Pages Function pages was silently zero.

## Fix

**1. Externalise the vote handler.** Move the IIFE from `render-view.ts` into `web/public/c-vote.js`, served same-origin (allowed by CSP `'self'`). `render-view.ts` now emits `<script src="/c-vote.js" defer></script>`. Same behaviour, no inline script body.

**2. Allow the Cloudflare Insights beacon.** Add `https://static.cloudflareinsights.com` to `script-src` in BOTH the static `web/public/_headers` (covers `/`, `/about`, `/preview`, prerendered pages) AND `web/functions/lib/security-headers.ts` (covers `/c/<id>`, `/view/<id>`, `/sitemap.xml`, Pages Function responses). Keeping them in lockstep — every response has the same posture.

## Test plan
- [x] vitest 516/516 pass (+3 new: no inline scripts in render-view, CSP allows cloudflareinsights on both static `_headers` and Pages Function `SECURITY_HEADERS_HTML`)
- [ ] Post-deploy: open `/c/nL7zNStsW3` in browser DevTools, confirm zero CSP violations in console
- [ ] Post-deploy: click the 👍 button, count increments, count persists across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)