### PR TITLE
feat(home): live useful-vote counts on community cards

### DIFF
--- a/web/functions/api/c/useful-counts.ts
+++ b/web/functions/api/c/useful-counts.ts
@@ -1,0 +1,30 @@
+// GET /api/c/useful-counts — bulk up-vote tally for every community
+// submission. Client patches the prerendered 👍 counts on the home grid
+// in-place so they're always current (no catalog.json drift), mirroring
+// the /api/dl/counts pattern.
+//
+// Response shape: { "<submission_id>": <up_count>, ... }
+// Submissions with zero up votes are omitted — the client treats missing
+// entries as 0 (the baked default).
+
+import type { Env } from '../../_middleware';
+import { countAllUpVotes } from '../../lib/ratings';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  try {
+    const tally = await countAllUpVotes(ctx.env.DB);
+    const body = Object.fromEntries(tally);
+    return new Response(JSON.stringify(body), {
+      headers: {
+        'content-type': 'application/json',
+        'access-control-allow-origin': '*',
+        'cache-control': 'public, max-age=30, stale-while-revalidate=120',
+      },
+    });
+  } catch {
+    return new Response('{}', {
+      status: 200,
+      headers: { 'content-type': 'application/json', 'access-control-allow-origin': '*' },
+    });
+  }
+};

--- a/web/functions/lib/ratings.ts
+++ b/web/functions/lib/ratings.ts
@@ -50,6 +50,20 @@ export async function countVotes(db: RunnableD1, submissionId: string): Promise<
   return { up, down, score: up - down };
 }
 
+// Bulk up-vote tally for the home grid patcher. Returns a Map keyed by
+// submission_id with the count of vote=1 rows. Legacy vote=-1 rows are
+// ignored to match the rest of the UI (single-direction Useful vote).
+// Submissions with zero useful votes aren't included — the caller treats
+// missing entries as 0, matching the baked default.
+export async function countAllUpVotes(db: RunnableD1): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const rows = await db
+    .prepare(`SELECT submission_id, COUNT(*) AS up FROM submission_ratings WHERE vote = 1 GROUP BY submission_id`)
+    .all<{ submission_id: string; up: number }>();
+  for (const r of rows.results ?? []) out.set(r.submission_id, Number(r.up) || 0);
+  return out;
+}
+
 export async function getMyVote(
   db: RunnableD1,
   submissionId: string,

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -352,3 +352,25 @@ fetch('/api/dl/counts')
     }
   })
   .catch(() => {});
+
+// Live useful-vote counts for community cards. Mirrors the download-counts
+// pattern above: baked values render at build time; this fetch patches
+// each .comm-card's 👍 N span on page load so newly-cast votes show up
+// without waiting for the next prerender. Missing entries mean 0 votes —
+// leave the baked default alone.
+fetch('/api/c/useful-counts')
+  .then((r) => (r.ok ? r.json() : null))
+  .then((counts: Record<string, number> | null) => {
+    if (!counts) return;
+    for (const card of document.querySelectorAll<HTMLElement>('.comm-card[data-id]')) {
+      const id = card.dataset.id || '';
+      const n = counts[id];
+      if (n == null) continue;
+      card.dataset.useful = String(n);
+      const span = card.querySelector<HTMLElement>('.useful');
+      if (span) span.textContent = `👍 ${n}`;
+      const score = card.querySelector<HTMLElement>('.comm-card__score');
+      if (score) score.title = `${n} found this useful`;
+    }
+  })
+  .catch(() => {});

--- a/web/tests/ratings.test.ts
+++ b/web/tests/ratings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { recordVote, countVotes, getMyVote } from '../functions/lib/ratings';
+import { recordVote, countVotes, getMyVote, countAllUpVotes } from '../functions/lib/ratings';
 
 type Row = { submission_id: string; ip_hash: string; created_at: string; vote: 1 | -1 };
 
@@ -43,6 +43,14 @@ function fakeD1() {
             return { up, down };
           }
           return null;
+        },
+        async all() {
+          if (/SELECT submission_id,\s*COUNT\(\*\)[\s\S]*FROM submission_ratings WHERE vote = 1/.test(sql)) {
+            const tally = new Map<string, number>();
+            for (const r of rows.values()) if (r.vote === 1) tally.set(r.submission_id, (tally.get(r.submission_id) || 0) + 1);
+            return { results: [...tally.entries()].map(([submission_id, up]) => ({ submission_id, up })) };
+          }
+          return { results: [] };
         },
       };
     },
@@ -105,6 +113,38 @@ describe('countVotes', () => {
     await recordVote(db as never, 'sub1', 'B', 1);
     await recordVote(db as never, 'sub1', 'C', -1);
     expect(await countVotes(db as never, 'sub1')).toEqual({ up: 2, down: 1, score: 1 });
+  });
+});
+
+describe('countAllUpVotes', () => {
+  it('returns an empty map when no votes exist', async () => {
+    const db = fakeD1();
+    expect(await countAllUpVotes(db as never)).toEqual(new Map());
+  });
+
+  it('counts up votes per submission across all rows', async () => {
+    const db = fakeD1();
+    await recordVote(db as never, 'sub1', 'A', 1);
+    await recordVote(db as never, 'sub1', 'B', 1);
+    await recordVote(db as never, 'sub2', 'A', 1);
+    const m = await countAllUpVotes(db as never);
+    expect(m.get('sub1')).toBe(2);
+    expect(m.get('sub2')).toBe(1);
+  });
+
+  it('ignores legacy down votes', async () => {
+    const db = fakeD1();
+    await recordVote(db as never, 'sub1', 'A', 1);
+    await recordVote(db as never, 'sub1', 'B', -1);
+    const m = await countAllUpVotes(db as never);
+    expect(m.get('sub1')).toBe(1);
+  });
+
+  it('omits submissions with no up votes', async () => {
+    const db = fakeD1();
+    await recordVote(db as never, 'sub1', 'A', -1);
+    const m = await countAllUpVotes(db as never);
+    expect(m.has('sub1')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Reported: the catalog card for the Goa landuse submission shows `👍 0` while `/c/<id>` shows `1 useful`.

Cause: comm-card vote counts are baked into the home page HTML at prerender time and never refreshed. Once a vote lands after the build, the badge stays stale until the next deploy.

Fix: mirror the dl-counts pattern that already keeps download badges live.

## What changed

- **New `GET /api/c/useful-counts`**. Returns `{ "<submission_id>": <up_count>, ... }` for every submission with ≥1 up vote, in one call. 30s cache + 120s SWR matches `/api/dl/counts`.
- **`countAllUpVotes()`** in `lib/ratings.ts` does the single `GROUP BY submission_id` query. Legacy `vote = -1` rows ignored (matches the rest of the UI's single-direction Useful semantics).
- **`main.ts`** fetches `/api/c/useful-counts` on page load. For each `.comm-card[data-id]`: updates `data-useful`, the `.useful` span text (`👍 N`), and the score-title tooltip. IDs missing from the response mean 0 votes — the baked default stays.

## Test plan
- [x] vitest 520/520 pass (+4 new for `countAllUpVotes`: empty / multi-submission / ignores legacy downvotes / omits zero-vote rows)
- [ ] Post-deploy: reload `bharatlas.com`, the Goa card should show `👍 1` (matching `/c/nL7zNStsW3`)
- [ ] Post-deploy: cast another vote on `/c/<id>`, reload `/`, badge increments without waiting for next prerender

🤖 Generated with [Claude Code](https://claude.com/claude-code)