### PR TITLE
chore: LICENSE SPDX fix + README hero + API/MCP examples

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,8 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-Note: this licence covers the code in this repository only. Each data layer
-in the catalog carries its own open licence (CC0-1.0, CC-BY-4.0, CC-BY-SA-4.0,
-ODbL-1.0, ODC-PDDL-1.0, GODL-India). See the per-card line on the catalog at
-https://bharatlas.com/ for the licence applicable to a given layer.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A visual catalog, REST API, MCP server, drag-drop verifier, and anonymous contri
 
 **Live**: https://bharatlas.com
 
+[![bharatlas — India's open atlas](https://bharatlas.com/og-default.png)](https://bharatlas.com)
+
 ```
 catalog               → India national boundary (LGD-dissolved)
                         + state · district · subdistrict · block · village (LGD)
@@ -81,7 +83,38 @@ npm run dev    # http://localhost:5173
 npm test
 ```
 
-For the full submission flow (D1 + R2 + Turnstile + Pages Functions), see [docs/full-dev.md](./docs/full-dev.md) (TODO) or read `wrangler.toml` + `.dev.vars.example`.
+For the full submission flow (D1 + R2 + Turnstile + Pages Functions), read `wrangler.toml` + `.dev.vars.example`.
+
+## API in 30 seconds
+
+REST: `https://bharatlas.com/api/v1` — no API key, rate-limited per IP. Full docs at [bharatlas.com/docs](https://bharatlas.com/docs).
+
+```bash
+# list every catalog layer (curated + accepted community)
+curl 'https://bharatlas.com/api/v1/layers'
+
+# inspect a layer's schema before querying
+curl 'https://bharatlas.com/api/v1/layers/lgd_districts/schema'
+
+# filter + group: how many districts per state?
+curl 'https://bharatlas.com/api/v1/layers/lgd_districts/query?group_by=stname'
+
+# point-in-polygon: every admin boundary at (lat, lng)
+curl 'https://bharatlas.com/api/v1/locate?lat=12.9716&lng=77.5946'
+
+# nearest features within a radius
+curl 'https://bharatlas.com/api/v1/nearby?lat=12.9716&lng=77.5946&layer=nic_health&radius_km=10'
+```
+
+MCP for LLMs (Claude, GPT, Gemini, Cursor): one-line install, 8 tools. Setup at [bharatlas.com/mcp](https://bharatlas.com/mcp).
+
+```bash
+# Claude Code
+claude mcp add bharatlas npx bharatlas-mcp
+
+# Claude Desktop / other clients (claude_desktop_config.json)
+{ "mcpServers": { "bharatlas": { "command": "npx", "args": ["bharatlas-mcp"] } } }
+```
 
 ## Contributing
 
@@ -92,10 +125,6 @@ For the full submission flow (D1 + R2 + Turnstile + Pages Functions), see [docs/
 5. The maintainer reviews and merges. Merge to main = auto-deploy.
 
 Commit messages: short subject, body explains *why* not *what*. Examples in `git log`.
-
-## Changelog
-
-See [releases](https://github.com/urbanmorph/geodata/releases) and [merged PRs](https://github.com/urbanmorph/geodata/pulls?q=is%3Amerged).
 
 ## Security
 


### PR DESCRIPTION
## Summary

Three README/repo polish items in one PR.

### 1. LICENSE detection (SPDX badge)

GitHub's Licensee detector is strict — any non-canonical content makes it fall back to `spdx_id: NOASSERTION` / `name: "Other"`. Our LICENSE had standard MIT + a trailing paragraph clarifying that the licence covers code only (not the catalog's data layers). That paragraph killed the detection.

Trimmed the trailing 4 lines. The clarification is already in README's `## Licence` section. LICENSE is now byte-equivalent to the canonical MIT template; the GitHub repo sidebar should now report MIT and the MIT-licensed filter on GitHub should surface bharatlas.

### 2. README hero image

The project's entire premise is visual but the README had no image. Added the existing `og-default.png` (1200x630, already deployed at `bharatlas.com/og-default.png`) right after the **Live** link — no new asset shipped, no repo bloat.

### 3. "API in 30 seconds" + MCP setup

Five curl one-liners covering the headline endpoints (`/layers`, `/layers/<id>/schema`, `/layers/<id>/query?group_by=…`, `/locate`, `/nearby`) plus the `claude mcp add bharatlas npx bharatlas-mcp` snippet. The tagline already called these out as headline features but the README had zero examples — people had to click through to `/docs` and `/mcp` to see how to actually call them.

### 4. Drop the changelog section

`## Changelog → releases` linked to a page with zero releases (we don't tag releases). Dead-on-arrival; cut. The `v1.0` badge still conveys the stable-point; the `merged PRs` link is one click away in GitHub UI anyway.

Also dropped the orphan `docs/full-dev.md (TODO)` reference — that doc doesn't exist; the same info lives in `wrangler.toml` + `.dev.vars.example` which the line still points at.

## Test plan
- [x] vitest 520/520 still pass (LICENSE + README change unrelated to tests, ran anyway)
- [ ] Post-merge: `gh api repos/urbanmorph/geodata/license --jq '{spdx: .license.spdx_id}'` reports `MIT`
- [ ] Post-merge: README renders the hero image on GitHub above the feature map

🤖 Generated with [Claude Code](https://claude.com/claude-code)