### PR TITLE
fix(csp): unblock Filter & export + refactor CSP to single source of truth

### DIFF
--- a/web/functions/lib/security-headers.ts
+++ b/web/functions/lib/security-headers.ts
@@ -2,37 +2,80 @@
 // the static-asset `_headers` policy (CF Pages applies `_headers` only to
 // static assets — Function responses override).
 //
-// Mirrors the CSP/HSTS/Permissions-Policy block in web/public/_headers so
-// the curated and edge-rendered pages have the same defense-in-depth posture.
-// `frame-ancestors 'self'` is the only addition vs `_headers` — it locks out
-// clickjacking on Pages Function pages without breaking the same-origin embed
-// mode (/c/<id>?embed=1).
+// CSP is declared as a structured allowlist below and serialised twice:
+//   CSP_STATIC  — mirrors web/public/_headers verbatim (no frame-ancestors,
+//                 since classic Pages can't set it via _headers reliably).
+//   CSP_HTML    — Pages Function variant; adds `frame-ancestors 'self'` to
+//                 lock out clickjacking on /c/<id>, /view/<id>, etc.
+//
+// Why structured: PR-A (#103) introduced a strict CSP, and two latent
+// allowlist gaps surfaced later (CF Web Analytics in #111, the DuckDB
+// extensions CDN in #114). Both required updating two files in lockstep.
+// With a single source of truth here + a sync assertion in
+// tests/security-headers.test.ts, adding an origin is one diff and a
+// drift between the files fails CI instead of shipping silently.
 //
 // Apply by spreading into the Response init headers:
 //   return new Response(html, {
 //     headers: { ...SECURITY_HEADERS_HTML, 'content-type': 'text/html; ...' },
 //   });
 
-// Single source of truth for the CSP string — match _headers verbatim where
-// possible so /about, /c/<id>, /view/<id> all look identical to a browser.
-const CSP =
-  "default-src 'self'; " +
-  // static.cloudflareinsights.com is the Cloudflare Web Analytics beacon
-  // (auto-injected by CF when the feature is enabled on the account).
-  "script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com https://static.cloudflareinsights.com 'wasm-unsafe-eval'; " +
-  "worker-src 'self' blob:; " +
-  // extensions.duckdb.org is fetched at runtime by DuckDB-WASM the first
-  // time the Filter & export panel queries a parquet (it lazy-loads the
-  // `parquet` extension). Without the allow, DuckDB silently fails with
-  // "table index is out of bounds".
-  "connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com https://extensions.duckdb.org; " +
-  "img-src 'self' blob: data: https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://services.arcgisonline.com https://*.tile.opentopomap.org https://avatars.githubusercontent.com; " +
-  "style-src 'self' 'unsafe-inline'; " +
-  "font-src 'self'; " +
-  "frame-src https://challenges.cloudflare.com; " +
-  "frame-ancestors 'self'; " +
-  "object-src 'none'; " +
-  "base-uri 'self'";
+// Each directive lists its allowed sources in deployment order. The trailing
+// per-line comments are the audit log — any reviewer can scan WHY a host is
+// reachable from the browser.
+const CSP_DIRECTIVES: Array<[directive: string, sources: string[]]> = [
+  ['default-src', ["'self'"]],
+  ['script-src', [
+    "'self'",
+    'blob:',                                  // DuckDB-WASM worker bootstrap
+    'https://cdn.jsdelivr.net',               // DuckDB-WASM + MapLibre bundle
+    'https://challenges.cloudflare.com',      // Turnstile widget
+    'https://static.cloudflareinsights.com',  // CF Web Analytics beacon (auto-injected)
+    "'wasm-unsafe-eval'",                     // DuckDB-WASM WebAssembly execution
+  ]],
+  ['worker-src', ["'self'", 'blob:']],        // DuckDB-WASM workers
+  ['connect-src', [
+    "'self'",
+    'blob:',
+    'https://cdn.jsdelivr.net',                                     // DuckDB-WASM bundle fetches
+    'https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev',          // R2 public bucket — catalog parquets, pmtiles
+    'https://challenges.cloudflare.com',                            // Turnstile API
+    'https://extensions.duckdb.org',                                // DuckDB-WASM lazy `parquet` extension fetch
+  ]],
+  ['img-src', [
+    "'self'",
+    'blob:',
+    'data:',                                       // inline data URIs (favicons, svg)
+    'https://*.basemaps.cartocdn.com',             // Carto Light/Dark basemap tiles
+    'https://tile.openstreetmap.org',              // OSM basemap tiles
+    'https://services.arcgisonline.com',           // Esri World Imagery basemap tiles
+    'https://*.tile.opentopomap.org',              // OpenTopoMap basemap tiles
+    'https://avatars.githubusercontent.com',       // GitHub avatars in /about credits
+  ]],
+  ['style-src', ["'self'", "'unsafe-inline'"]],   // inline <style> in prerendered HTML
+  ['font-src', ["'self'"]],
+  ['frame-src', ['https://challenges.cloudflare.com']],  // Turnstile iframe
+  ['object-src', ["'none'"]],
+  ['base-uri', ["'self'"]],
+];
+
+function serialise(directives: Array<[string, string[]]>): string {
+  return directives.map(([d, s]) => `${d} ${s.join(' ')}`).join('; ');
+}
+
+/** CSP string mirrored to web/public/_headers. */
+export const CSP_STATIC: string = serialise(CSP_DIRECTIVES);
+
+/** CSP string used by Pages Function HTML responses. Adds frame-ancestors
+ *  'self' between frame-src and object-src to block clickjacking while
+ *  keeping the same-origin embed mode (/c/<id>?embed=1) working. */
+export const CSP_HTML: string = serialise(
+  CSP_DIRECTIVES.flatMap(([d, s]) =>
+    d === 'object-src'
+      ? ([['frame-ancestors', ["'self'"]], [d, s]] as Array<[string, string[]]>)
+      : ([[d, s]] as Array<[string, string[]]>),
+  ),
+);
 
 const SHARED = {
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
@@ -45,7 +88,7 @@ const SHARED = {
 /** Full block for HTML-rendering Pages Functions (/c/<id>, /view/<id>). */
 export const SECURITY_HEADERS_HTML = {
   ...SHARED,
-  'content-security-policy': CSP,
+  'content-security-policy': CSP_HTML,
 } as const;
 
 /** Non-HTML responses (sitemap.xml, future XML/JSON) — CSP is irrelevant

--- a/web/functions/lib/security-headers.ts
+++ b/web/functions/lib/security-headers.ts
@@ -21,7 +21,11 @@ const CSP =
   // (auto-injected by CF when the feature is enabled on the account).
   "script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com https://static.cloudflareinsights.com 'wasm-unsafe-eval'; " +
   "worker-src 'self' blob:; " +
-  "connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com; " +
+  // extensions.duckdb.org is fetched at runtime by DuckDB-WASM the first
+  // time the Filter & export panel queries a parquet (it lazy-loads the
+  // `parquet` extension). Without the allow, DuckDB silently fails with
+  // "table index is out of bounds".
+  "connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com https://extensions.duckdb.org; " +
   "img-src 'self' blob: data: https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://services.arcgisonline.com https://*.tile.opentopomap.org https://avatars.githubusercontent.com; " +
   "style-src 'self' 'unsafe-inline'; " +
   "font-src 'self'; " +

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -8,7 +8,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com https://static.cloudflareinsights.com 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com; img-src 'self' blob: data: https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://services.arcgisonline.com https://*.tile.opentopomap.org https://avatars.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com https://static.cloudflareinsights.com 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com https://extensions.duckdb.org; img-src 'self' blob: data: https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://services.arcgisonline.com https://*.tile.opentopomap.org https://avatars.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'
 
 # Hashed Vite assets — safe to cache forever.
 /assets/*

--- a/web/tests/security-headers.test.ts
+++ b/web/tests/security-headers.test.ts
@@ -101,7 +101,35 @@ describe('Security headers — Cloudflare Pages _headers file', () => {
   });
 });
 
-import { SECURITY_HEADERS_HTML, SECURITY_HEADERS_NON_HTML } from '../functions/lib/security-headers';
+import {
+  SECURITY_HEADERS_HTML,
+  SECURITY_HEADERS_NON_HTML,
+  CSP_STATIC,
+  CSP_HTML,
+} from '../functions/lib/security-headers';
+
+describe('Security headers — sync between _headers and security-headers.ts', () => {
+  // CSP is declared once as a structured allowlist in security-headers.ts.
+  // Both surfaces (static _headers, Pages Function SECURITY_HEADERS_HTML)
+  // derive from that source. These tests catch drift: if someone adds an
+  // origin in one place and forgets the other, CI fails loudly instead of
+  // shipping a half-applied policy.
+  const headersFile = readFileSync(resolve(__dirname, '..', 'public', '_headers'), 'utf8');
+
+  it('_headers CSP matches CSP_STATIC byte-for-byte', () => {
+    expect(headersFile).toContain(`Content-Security-Policy: ${CSP_STATIC}`);
+  });
+
+  it('SECURITY_HEADERS_HTML CSP equals CSP_HTML', () => {
+    expect(SECURITY_HEADERS_HTML['content-security-policy']).toBe(CSP_HTML);
+  });
+
+  it("CSP_HTML differs from CSP_STATIC only by frame-ancestors 'self'", () => {
+    // The Pages Function variant adds clickjacking protection. If they
+    // diverge any further, the audit narrative breaks.
+    expect(CSP_HTML).toContain(CSP_STATIC.replace('object-src', "frame-ancestors 'self'; object-src"));
+  });
+});
 
 describe('Security headers — SECURITY_HEADERS_HTML (Pages Function responses)', () => {
   // CF Pages applies `_headers` only to static assets, not to Pages Function

--- a/web/tests/security-headers.test.ts
+++ b/web/tests/security-headers.test.ts
@@ -74,6 +74,17 @@ describe('Security headers — Cloudflare Pages _headers file', () => {
     expect(csp![1]).toContain('https://static.cloudflareinsights.com');
   });
 
+  it('CSP connect-src allows the DuckDB extensions CDN', () => {
+    // DuckDB-WASM lazily fetches the `parquet` extension from
+    // extensions.duckdb.org the first time the Filter & export panel
+    // queries a parquet. Without an explicit connect-src allow the
+    // browser blocks the fetch and DuckDB errors with the cryptic
+    // "table index is out of bounds" — the codec never loaded.
+    const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/);
+    expect(csp).not.toBeNull();
+    expect(csp![1]).toContain('https://extensions.duckdb.org');
+  });
+
   it('CSP does not use unsafe-eval (only wasm-unsafe-eval)', () => {
     const csp = headersFile.match(/Content-Security-Policy:\s*([^\n]+)/);
     expect(csp).not.toBeNull();
@@ -147,6 +158,14 @@ describe('Security headers — SECURITY_HEADERS_HTML (Pages Function responses)'
     // an explicit allow the browser blocks it on every Pages Function page.
     expect(SECURITY_HEADERS_HTML['content-security-policy'])
       .toContain('https://static.cloudflareinsights.com');
+  });
+
+  it('CSP connect-src allows the DuckDB extensions CDN', () => {
+    // DuckDB-WASM lazily fetches extensions from extensions.duckdb.org
+    // when the Filter & export panel queries a parquet for the first
+    // time. Blocked = silent "table index out of bounds" runtime error.
+    expect(SECURITY_HEADERS_HTML['content-security-policy'])
+      .toContain('https://extensions.duckdb.org');
   });
 });
 


### PR DESCRIPTION
## Summary

Two related changes — fixing the immediate Filter & export regression, plus making the underlying dual-write problem that caused it (and #111 before it) impossible going forward.

## 1. Unblock the Filter & export panel

Reported: Filter & export throws \`table index is out of bounds\` with a CSP block in the console:

\`\`\`
Connecting to 'https://extensions.duckdb.org/v1.5.1/wasm_eh/parquet.duckdb_extension.wasm'
violates the following Content Security Policy directive: 'connect-src 'self' blob: ...'
\`\`\`

DuckDB-WASM lazy-loads its \`parquet\` extension from \`extensions.duckdb.org\` the first time a parquet codec is exercised — Filter & export panel, /preview drag-drop of a .parquet, any "Download as GeoJSON / KML" off a slice, parquet validation on /preview. Our strict CSP (set in PR-A / #103) didn't allow that origin in \`connect-src\`, so the fetch was blocked, the codec never registered, and parquet queries failed with the cryptic runtime error.

Add \`https://extensions.duckdb.org\` to \`connect-src\` in both surfaces.

## 2. Refactor CSP to a single source of truth

PR-A spread the CSP allowlist across two hand-edited files (\`web/public/_headers\` + \`web/functions/lib/security-headers.ts\`). Every change since has required a coordinated dual edit, and both fixes (#111 CF Insights, #114 DuckDB extensions) only got noticed via prod symptoms. The bucket rename queued under the bharatlas rebrand will hit this same trap.

Make the allowlist declarative:

\`\`\`ts
CSP_DIRECTIVES: Array<[directive, sources[]]>
     ↓ serialise
CSP_STATIC    — mirrored into _headers
CSP_HTML      — CSP_STATIC + frame-ancestors 'self' for Pages Functions
\`\`\`

Each origin gets a trailing per-line comment (purpose / which feature needs it). The structured allowlist doubles as the audit log so any reviewer can scan WHY each external host is reachable.

Three new pinning tests catch drift:

- \`_headers\` CSP must equal \`CSP_STATIC\` byte-for-byte
- \`SECURITY_HEADERS_HTML\` CSP must equal \`CSP_HTML\`
- \`CSP_HTML\` must differ from \`CSP_STATIC\` only by adding \`frame-ancestors 'self'\`

**No behaviour change** — generated CSP strings are byte-identical to the previous hand-rolled ones, verified by all 11 existing spot-check tests still passing alongside the 3 new pinning tests.

## Test plan
- [x] vitest 525/525 pass (+5 new in this PR: 2 for the extensions.duckdb.org allow, 3 for the sync/drift detection)
- [ ] Post-deploy: open Filter & export on a curated parquet layer (e.g. lgd_districts), apply a filter, confirm the query completes and there are zero CSP console violations
- [ ] Post-deploy: drag-drop a .parquet on /preview — same validation expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)