### PR TITLE
feat(home): community card parity — inline View map + Download

### DIFF
--- a/web/index.template.html
+++ b/web/index.template.html
@@ -118,6 +118,9 @@
       .comm-card__score .useful { color: var(--accent-strong); }
       .comm-card__desc { color: var(--muted); font-size: 13px; margin: 6px 0 8px; }
       .comm-card__meta { color: var(--muted); font-size: 12px; }
+      .comm-card__actions { display: flex; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+      .comm-card__actions .btn { font-size: 13px; padding: 6px 12px; }
+      .comm-card__dl .size { color: var(--muted); margin-left: 6px; font-size: 12px; font-variant-numeric: tabular-nums; }
 
       /* Drag-anywhere overlay */
       body.is-dragging::after {

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -790,6 +790,16 @@ function renderCommunityCard(s, opts = {}) {
     `data-search-body="${esc(bodyHaystack)}"`,
   ].join(' ');
   const credit = s.is_original ? `original work by ${esc(s.attribution)}` : `source: ${esc(s.attribution)}`;
+  // Inline View map + Download for parity with curated rows. Community
+  // files are stored as-is in R2 under community/<id>/<filename>, so the
+  // download is single-format (not the curated multi-format strip).
+  // /api/r2/community/... is the allowlisted same-origin proxy that
+  // streams the R2 object (PR-A locked the prefix down to community/*).
+  // /preview?url=… pipes the same file into the drag-drop verify viewer
+  // so the user gets the map view we already render there.
+  const r2Path = `/api/r2/${esc(s.r2_key)}`;
+  const previewUrl = `/preview?url=${encodeURIComponent('/api/r2/' + s.r2_key)}`;
+  const filename = s.r2_key.split('/').pop() || `${s.id}.${s.format}`;
   return `<article class="comm-card${collapsed}" ${dataAttrs}>
     <div class="comm-card__head">
       <div class="comm-card__title"><a href="/c/${esc(s.id)}">${esc(s.name)}</a><span class="badge badge--community">community</span></div>
@@ -799,6 +809,10 @@ function renderCommunityCard(s, opts = {}) {
     </div>
     ${s.description ? `<p class="comm-card__desc">${esc(s.description)}</p>` : ''}
     <div class="comm-card__meta">${esc(s.format)} · ${s.feature_count != null ? s.feature_count.toLocaleString('en-IN') + ' features · ' : ''}${credit}</div>
+    <div class="comm-card__actions">
+      <a class="btn comm-card__view" href="${previewUrl}">View on map →</a>
+      <a class="btn comm-card__dl" href="${r2Path}" download="${esc(filename)}">Download .${esc(s.format)}<span class="size">${s.bytes != null ? fmtBytes(s.bytes) : ''}</span></a>
+    </div>
   </article>`;
 }
 

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -179,6 +179,39 @@ describe('CLS regression guards (Web Vitals)', () => {
   });
 });
 
+describe('Community cards have parity with curated rows (View + Download)', () => {
+  // Earlier community cards only linked to /c/<id> (the share page); to
+  // see them on the map or grab the file you had to click through. Curated
+  // rows have inline "View map" + multi-format Download links. We can't
+  // give community parity on multi-format (we don't bake them) or on the
+  // filter affordance (no LGD chain), but View + single-format Download
+  // are cheap to surface and remove a click for every community visit.
+  it('every comm-card on home has a "View map" link to /preview?url=/api/r2/community/...', () => {
+    const html = readFileSync(resolve(__dirname, '..', 'index.html'), 'utf8');
+    const cards = html.match(/<article class="comm-card[^>]+>[\s\S]*?<\/article>/g) || [];
+    if (cards.length === 0) return; // no community submissions yet — vacuous pass
+    for (const card of cards) {
+      const id = card.match(/data-id="([^"]+)"/)![1];
+      expect(card, `comm-card ${id} missing View map link`).toMatch(
+        /href="\/preview\?url=[^"]*%2Fapi%2Fr2%2Fcommunity%2F[^"]+"/,
+      );
+      expect(card, `comm-card ${id} View map text`).toMatch(/View on map|View map/);
+    }
+  });
+
+  it('every comm-card has an inline Download link to /api/r2/community/<id>/<filename>', () => {
+    const html = readFileSync(resolve(__dirname, '..', 'index.html'), 'utf8');
+    const cards = html.match(/<article class="comm-card[^>]+>[\s\S]*?<\/article>/g) || [];
+    if (cards.length === 0) return;
+    for (const card of cards) {
+      const id = card.match(/data-id="([^"]+)"/)![1];
+      expect(card, `comm-card ${id} missing inline Download link`).toMatch(
+        /href="\/api\/r2\/community\/[^"]+"[^>]*download/,
+      );
+    }
+  });
+});
+
 describe('SEO/AEO — curated cards expose data vintage on the home grid', () => {
   // Every curated card SHOULD surface either a "fetched" or "vintage"
   // line so users (and AEO consumers) can judge freshness. Today only


### PR DESCRIPTION
## Summary

Community cards on the home grid previously had no inline affordance for the two things curated rows offer (View map + Download). To see the map or grab the file, users had to click through to /c/<id> first. The UI/UX audit flagged this as the only dimension where community scored 5/10 vs curated's 9/10.

## What changed

Two new buttons inside `renderCommunityCard`:

- **View on map** → `/preview?url=/api/r2/community/<id>/<filename>` — pipes the file into the same drag-drop verify viewer the contributor used; map renders the same way for everyone.
- **Download .\<format\>** → `/api/r2/community/<id>/<filename>` — single-format download (community uploads stored as-is; we don't bake them). File-size badge alongside, same shape as curated row's per-format badges. Uses the allowlisted same-origin proxy locked down to `community/*` in PR-A.

## What community cards still don't have, and why

- **Multi-format download** — we don't bake community files into pmtiles / parquet / kml / shp. Single-format is honest about what's there.
- **Filter & export** — community files lack the LGD attribute chain that powers slice-by-state. Would need a content-agnostic attribute filter (separate future work).
- **"Compare sources" alts row** — community IS its own source.

## Test plan
- [x] 2 new vitest cases pin both buttons (View link → `/preview?url=…`, Download link → `/api/r2/community/<id>/<filename>`)
- [x] 534/534 vitest green
- [ ] Post-deploy: reload `bharatlas.com/`, expand the Environment section, confirm the Goa landuse card shows both buttons inline
- [ ] Click View on map → loads the file into /preview map view
- [ ] Click Download → 1.6 MB .geojson saves locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)