### PR TITLE
fix(cls): restore category only on back/forward, not fresh loads

### DIFF
--- a/web/src/embed-snippet.ts
+++ b/web/src/embed-snippet.ts
@@ -46,6 +46,16 @@ export function nextStateOnClose(
   };
 }
 
+// Restore the saved category filter ONLY when the user returns from a /view/
+// via the back/forward button — never on a fresh load or refresh. That makes
+// it true breadcrumb behaviour, and keeps the first paint shift-free (no
+// post-paint apply()/section-expand → no CLS) for direct + search arrivals,
+// which are the common case. `navType` is PerformanceNavigationTiming.type
+// ('navigate' | 'reload' | 'back_forward' | 'prerender' | undefined).
+export function shouldRestoreCategory(navType: string | undefined, saved: string | null): boolean {
+  return navType === 'back_forward' && !!saved && saved !== 'all';
+}
+
 // What the URL should become after the user closes the map overlay. Three
 // call-sites (close button, Escape key, hash-clear) all funnel through here
 // so the URL bar always matches what the user is looking at (the catalog).

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,6 +1,6 @@
 // Tiny entry: hash-based map routing + hover-prefetch of the map chunk.
 // Map code is in a separate chunk; only loaded when the user opens a map.
-import { isEmbedPath, isViewPath, nextStateOnClose } from './embed-snippet';
+import { isEmbedPath, isViewPath, nextStateOnClose, shouldRestoreCategory } from './embed-snippet';
 import { filterCards, cardVisibility, type CardLike } from './catalog-filter';
 
 // The crawler-only `.view-seo` article that /view/<id>'s Pages Function
@@ -235,13 +235,19 @@ if (searchInput && grid) {
     });
   }
 
-  // Restore category from sessionStorage (survives back-navigation from /view/).
+  // Breadcrumb restore: re-apply the saved category ONLY when the user returns
+  // from a /view/ via back/forward — not on a fresh load or refresh. That keeps
+  // the first paint shift-free (no post-paint apply()/section-expand → no CLS)
+  // for direct + search arrivals, which are the common case. See
+  // shouldRestoreCategory. (bfcache often restores the filtered DOM as-is on
+  // back, making this just the fallback for when bfcache doesn't fire.)
+  const navType = (performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined)?.type;
   const saved = (() => { try { return sessionStorage.getItem('cat'); } catch { return null; } })();
-  if (saved && saved !== 'all') {
+  if (shouldRestoreCategory(navType, saved)) {
     const match = chips.find((c) => c.dataset.cat === saved);
     if (match) {
       chips.forEach((c) => c.classList.toggle('active', c === match));
-      activeCat = saved;
+      activeCat = saved!;
       apply();
     }
   }

--- a/web/tests/embed-snippet.test.ts
+++ b/web/tests/embed-snippet.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect } from 'vitest';
-import { embedIframeHtml, isEmbedPath, isViewPath, urlAfterCloseMap, titleAfterCloseMap, nextStateOnClose } from '../src/embed-snippet';
+import { embedIframeHtml, isEmbedPath, isViewPath, urlAfterCloseMap, titleAfterCloseMap, nextStateOnClose, shouldRestoreCategory } from '../src/embed-snippet';
+
+describe('shouldRestoreCategory (breadcrumb restore, CLS-safe first paint)', () => {
+  it('restores on back/forward with a saved non-all category', () => {
+    expect(shouldRestoreCategory('back_forward', 'environment')).toBe(true);
+  });
+
+  it('does NOT restore on a fresh navigate or a reload — keeps first paint shift-free', () => {
+    expect(shouldRestoreCategory('navigate', 'environment')).toBe(false);
+    expect(shouldRestoreCategory('reload', 'environment')).toBe(false);
+  });
+
+  it('does NOT restore when nothing is saved or it is the default "all"', () => {
+    expect(shouldRestoreCategory('back_forward', null)).toBe(false);
+    expect(shouldRestoreCategory('back_forward', '')).toBe(false);
+    expect(shouldRestoreCategory('back_forward', 'all')).toBe(false);
+  });
+
+  it('does NOT restore when the navigation type is unknown', () => {
+    expect(shouldRestoreCategory(undefined, 'environment')).toBe(false);
+  });
+});
 
 describe('embed-snippet — embedIframeHtml', () => {
   it('emits a sane iframe snippet with the encoded layer id', () => {


### PR DESCRIPTION
## CLS: restore category only on back/forward (breadcrumb), not on fresh load

The sessionStorage category restore (`main.ts`) re-ran `apply()` on **every** home load whenever a `cat` was saved, expanding/filtering the grid **after first paint** — the dominant CLS source in the Jun analytics (`#catalog-grid > section.category-section.expanded` ≈ 0.27).

### Fix
Gate the restore on `PerformanceNavigationTiming.type === 'back_forward'` via a pure `shouldRestoreCategory(navType, saved)` helper:
- **Fresh load / refresh / direct / search arrival** (`navigate`/`reload`) → no restore → no post-paint `apply()` → **shift-free first paint** (the common case).
- **Back from a `/view/`** (`back_forward`) → restore → breadcrumb behaviour. bfcache often restores the filtered DOM as-is on back, so this is the fallback.

This matches the original intent of the restore (return-to-filter when coming back from a view), which today misfires on every load.

### Not included
A separate, smaller residual remains on `?q=` arrivals (q-precheck reveals collapsed rows pre-paint, but `apply()` still hides non-matching cards after paint). Left for a follow-up.

### Tests
`shouldRestoreCategory` unit-tested (back_forward / navigate / reload / null / all / undefined); 552 vitest + 48 pytest green; tsc no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
