### PR TITLE
chore(ci): bump to Node 24 + checkout/setup-node v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,11 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: web/package-lock.json
 


### PR DESCRIPTION
Moves CI off the Node 20 action runtime that GitHub deprecates on 2026-06-16 (removed 2026-09-16).

- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- build `node-version: 20` → `24`

The v5 majors run on Node 24, clearing the deprecation warning. This PR's own `pull_request` CI run exercises install + vitest + build on the new config (deploy step stays gated to push-to-main, so nothing deploys from the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)