### PR TITLE
Ward-map SEO titles + search-filter isolate/zoom on /view

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -396,7 +396,9 @@
       "description": "Greater Bengaluru Authority \u2014 369 final wards across 5 corporations, notified Nov 2025.",
       "source_url": "https://data.opencity.in/dataset/gba-wards-delimitation-2025",
       "source_org": "Greater Bengaluru Authority",
-      "notes": "Latest GBA delimitation. Pair with the 5-corp polygons for parent grouping."
+      "notes": "Latest GBA delimitation. Pair with the 5-corp polygons for parent grouping.",
+      "seo_title": "Bengaluru Ward Map: 369 wards (GBA 2025)",
+      "seo_description": "Map of all 369 Greater Bengaluru wards (GBA, notified Nov 2025) across 5 corporations. View boundaries and download as GeoJSON, KML or Parquet."
     },
     "corporation_bengaluru": {
       "label": "Greater Bengaluru Corporations (2025)",
@@ -412,7 +414,9 @@
       "description": "Bruhat Bengaluru Mahanagara Palike \u2014 243 wards from the 2022 draft delimitation. Historical reference; superseded by the 2025 GBA 369-ward scheme.",
       "source_url": "https://data.opencity.in/dataset/bbmp-wards",
       "source_org": "BBMP",
-      "notes": "Use the GBA 2025 layer for current ward boundaries."
+      "notes": "Use the GBA 2025 layer for current ward boundaries.",
+      "seo_title": "BBMP Ward Map: 243 wards (Bengaluru, 2022)",
+      "seo_description": "Map of 243 BBMP wards from Bengaluru's 2022 draft delimitation (historical, superseded by the 2025 GBA scheme). Download as GeoJSON or KML."
     },
     "bda_jurisdiction": {
       "label": "BDA Jurisdiction",
@@ -436,7 +440,9 @@
       "description": "Greater Chennai Corporation \u2014 200 ward boundaries across the 15 zones.",
       "source_url": "https://data.opencity.in/dataset/gcc-ward-information",
       "source_org": "Greater Chennai Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Chennai Ward Map: 200 wards (GCC)",
+      "seo_description": "Interactive map of all 200 wards in Chennai (GCC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_hyderabad": {
       "label": "Hyderabad (GHMC) Wards",
@@ -444,7 +450,9 @@
       "description": "Greater Hyderabad Municipal Corporation \u2014 145 wards across 6 zones.",
       "source_url": "https://data.opencity.in/dataset/hyderabad-wards-info",
       "source_org": "Greater Hyderabad Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Hyderabad Ward Map: 145 wards (GHMC)",
+      "seo_description": "Interactive map of all 145 wards in Hyderabad (GHMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_mumbai": {
       "label": "Mumbai (BMC) Wards",
@@ -452,7 +460,9 @@
       "description": "Brihanmumbai Municipal Corporation \u2014 24 administrative wards (A\u2013T plus the city-island spread).",
       "source_url": "https://data.opencity.in/dataset/mumbai-wards",
       "source_org": "Brihanmumbai Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Mumbai Ward Map: 24 wards (BMC)",
+      "seo_description": "Interactive map of all 24 wards in Mumbai (BMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "electoral_wards_mumbai_2017": {
       "label": "Mumbai Electoral Wards (2017)",
@@ -460,7 +470,9 @@
       "description": "227 electoral ward divisions of Mumbai, 2017 delimitation. Use for election + civic-rep maps.",
       "source_url": "https://data.opencity.in/dataset/mumbai-electoral-wards",
       "source_org": "Mumbai State Election Commission",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Mumbai Electoral Ward Map: 227 wards (2017)",
+      "seo_description": "Map of all 227 Mumbai electoral wards (2017 delimitation) for election and civic-rep mapping. View boundaries and download as GeoJSON, KML or Parquet."
     },
     "wards_kolkata": {
       "label": "Kolkata (KMC) Wards",
@@ -468,7 +480,9 @@
       "description": "Kolkata Municipal Corporation \u2014 141 ward boundaries across the 16 boroughs.",
       "source_url": "https://data.opencity.in/dataset/kolkata-wards",
       "source_org": "Kolkata Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Kolkata Ward Map: 141 wards (KMC)",
+      "seo_description": "Interactive map of all 141 wards in Kolkata (KMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_pune": {
       "label": "Pune (PMC) Wards",
@@ -476,7 +490,9 @@
       "description": "Pune Municipal Corporation \u2014 58 administrative wards.",
       "source_url": "https://data.opencity.in/dataset/pune-wards",
       "source_org": "Pune Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Pune Ward Map: 58 wards (PMC)",
+      "seo_description": "Interactive map of all 58 wards in Pune (PMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_ahmedabad": {
       "label": "Ahmedabad (AMC) Wards",
@@ -484,7 +500,9 @@
       "description": "Ahmedabad Municipal Corporation \u2014 48 wards across the 7 zones.",
       "source_url": "https://data.opencity.in/dataset/ahmedabad-wards",
       "source_org": "Ahmedabad Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Ahmedabad Ward Map: 48 wards (AMC)",
+      "seo_description": "Interactive map of all 48 wards in Ahmedabad (AMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_jaipur": {
       "label": "Jaipur (JMC) Wards",
@@ -492,7 +510,9 @@
       "description": "Jaipur Municipal Corporation \u2014 150 ward boundaries.",
       "source_url": "https://data.opencity.in/dataset/jaipur-wards",
       "source_org": "Jaipur Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Jaipur Ward Map: 150 wards (JMC)",
+      "seo_description": "Interactive map of all 150 wards in Jaipur (JMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_gurugram": {
       "label": "Gurugram (MCG) Wards",
@@ -500,7 +520,9 @@
       "description": "Municipal Corporation of Gurugram \u2014 35 ward boundaries.",
       "source_url": "https://data.opencity.in/dataset/gurugram-wards",
       "source_org": "Municipal Corporation of Gurugram",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Gurugram Ward Map: 35 wards (MCG)",
+      "seo_description": "Interactive map of all 35 wards in Gurugram (MCG). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_kochi": {
       "label": "Kochi (KMC) Wards",
@@ -508,7 +530,9 @@
       "description": "Kochi Municipal Corporation ward boundaries \u2014 74 administrative wards covering the city. Sourced from Oorvani Foundation's OpenCity data portal.",
       "source_url": "https://data.opencity.in/dataset/kochi-wards",
       "source_org": "Kochi Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Kochi Ward Map: 74 wards (KMC)",
+      "seo_description": "Interactive map of all 74 wards in Kochi (KMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_bhubaneshwar": {
       "label": "Bhubaneshwar (BMC) Wards",
@@ -516,7 +540,9 @@
       "description": "Bhubaneshwar Municipal Corporation ward boundaries \u2014 67 wards covering Odisha's capital city. Sourced from Oorvani Foundation's OpenCity data portal.",
       "source_url": "https://data.opencity.in/dataset/bhubaneshwar-wards",
       "source_org": "Bhubaneshwar Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Bhubaneswar Ward Map: 67 wards (BMC)",
+      "seo_description": "Interactive map of all 67 wards in Bhubaneswar (BMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_vizag": {
       "label": "Visakhapatnam (GVMC) Wards",
@@ -524,7 +550,9 @@
       "description": "Greater Visakhapatnam Municipal Corporation \u2014 98 wards.",
       "source_url": "https://data.opencity.in/dataset/visakhapatnam-wards",
       "source_org": "Greater Visakhapatnam Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Visakhapatnam Ward Map: 98 wards (GVMC)",
+      "seo_description": "Interactive map of all 98 wards in Visakhapatnam (GVMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_thane": {
       "label": "Thane (TMC) Wards",
@@ -532,7 +560,9 @@
       "description": "Thane Municipal Corporation \u2014 47 wards across the city.",
       "source_url": "https://data.opencity.in/dataset/thane-wards",
       "source_org": "Thane Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Thane Ward Map: 47 wards (TMC)",
+      "seo_description": "Interactive map of all 47 wards in Thane (TMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_delhi": {
       "label": "Delhi Wards (MCD + NDMC + Cantonment)",
@@ -540,7 +570,9 @@
       "description": "Municipal Corporation of Delhi, NDMC, and Delhi Cantonment Board wards. 290 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Delhi",
       "source_org": "DataMeet",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Delhi Ward Map: 290 wards (MCD, NDMC, Cantt)",
+      "seo_description": "Interactive map of all 290 Delhi municipal wards (MCD, NDMC and Cantonment). View ward boundaries and numbers, and download as GeoJSON, KML or Parquet."
     },
     "wards_indore": {
       "label": "Indore (IMC) Wards (2024)",
@@ -548,7 +580,9 @@
       "description": "Indore Municipal Corporation \u2014 85 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/indore-wards-map",
       "source_org": "Indore Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Indore Ward Map: 85 wards (IMC)",
+      "seo_description": "Interactive map of all 85 wards in Indore (IMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_coimbatore": {
       "label": "Coimbatore (CCMC) Wards (2011)",
@@ -556,7 +590,9 @@
       "description": "Coimbatore City Municipal Corporation \u2014 100 ward boundaries. Census 2011 reorganization.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Coimbatore",
       "source_org": "DataMeet",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Coimbatore Ward Map: 100 wards (CCMC)",
+      "seo_description": "Interactive map of all 100 wards in Coimbatore (CCMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_madurai": {
       "label": "Madurai (MCM) Wards (2024)",
@@ -564,7 +600,9 @@
       "description": "Madurai City Municipal Corporation \u2014 100 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/madurai-wards-map",
       "source_org": "Madurai City Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Madurai Ward Map: 100 wards (MCM)",
+      "seo_description": "Interactive map of all 100 wards in Madurai (MCM). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_navi_mumbai": {
       "label": "Navi Mumbai (NMMC) Wards (2024)",
@@ -572,7 +610,9 @@
       "description": "Navi Mumbai Municipal Corporation \u2014 111 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/navi-mumbai-wards-map",
       "source_org": "Navi Mumbai Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Navi Mumbai Ward Map: 111 wards (NMMC)",
+      "seo_description": "Interactive map of all 111 wards in Navi Mumbai (NMMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_guwahati": {
       "label": "Guwahati (GMC) Wards (2022)",
@@ -580,7 +620,9 @@
       "description": "Guwahati Municipal Corporation \u2014 60 ward boundaries. 2022 delimitation.",
       "source_url": "https://data.opencity.in/dataset/guwahati-wards-information",
       "source_org": "Guwahati Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Guwahati Ward Map: 60 wards (GMC)",
+      "seo_description": "Interactive map of all 60 wards in Guwahati (GMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_mysuru": {
       "label": "Mysuru (MCC) Wards",
@@ -588,7 +630,9 @@
       "description": "Mysuru City Corporation \u2014 65 ward boundaries.",
       "source_url": "https://data.opencity.in/dataset/mysuru-city-corporation-wards-info",
       "source_org": "Mysuru City Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Mysuru Ward Map: 65 wards (MCC)",
+      "seo_description": "Interactive map of all 65 wards in Mysuru (MCC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_bhopal": {
       "label": "Bhopal (BMC) Wards (2024)",
@@ -596,7 +640,9 @@
       "description": "Bhopal Municipal Corporation \u2014 86 ward boundaries. 2024 delimitation.",
       "source_url": "https://data.opencity.in/dataset/bhopal-wards-map",
       "source_org": "Bhopal Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Bhopal Ward Map: 86 wards (BMC)",
+      "seo_description": "Interactive map of all 86 wards in Bhopal (BMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_chandigarh": {
       "label": "Chandigarh (MC) Wards",
@@ -604,7 +650,9 @@
       "description": "Municipal Corporation of Chandigarh \u2014 28 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Chandigarh",
       "source_org": "Municipal Corporation of Chandigarh",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Chandigarh Ward Map: 28 wards (MC)",
+      "seo_description": "Interactive map of all 28 wards in Chandigarh (MC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_lucknow": {
       "label": "Lucknow (LMC) Wards",
@@ -612,7 +660,9 @@
       "description": "Lucknow Municipal Corporation \u2014 112 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Lucknow",
       "source_org": "Lucknow Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Lucknow Ward Map: 112 wards (LMC)",
+      "seo_description": "Interactive map of all 112 wards in Lucknow (LMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_kanpur": {
       "label": "Kanpur (KMC) Wards",
@@ -620,7 +670,9 @@
       "description": "Kanpur Municipal Corporation \u2014 58 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Kanpur",
       "source_org": "Kanpur Municipal Corporation",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Kanpur Ward Map: 58 wards (KMC)",
+      "seo_description": "Interactive map of all 58 wards in Kanpur (KMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_patna": {
       "label": "Patna (PMC) Wards (~2019)",
@@ -628,7 +680,9 @@
       "description": "Patna Municipal Corporation \u2014 75 wards (628 sub-ward polygons). Two naming schemes: numbered \"Ward N\" and spelled-out names.",
       "source_url": "https://github.com/datta07/INDIAN-SHAPEFILES/tree/master/METROPOLITAN%20CITIES",
       "source_org": "datta07/INDIAN-SHAPEFILES",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Patna Ward Map: 628 wards (PMC)",
+      "seo_description": "Interactive map of all 628 wards in Patna (PMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_surat": {
       "label": "Surat (SMC) Wards (~2019)",
@@ -636,7 +690,9 @@
       "description": "Surat Municipal Corporation \u2014 30 ward boundaries with named wards.",
       "source_url": "https://github.com/datta07/INDIAN-SHAPEFILES/tree/master/METROPOLITAN%20CITIES",
       "source_org": "datta07/INDIAN-SHAPEFILES",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Surat Ward Map: 30 wards (SMC)",
+      "seo_description": "Interactive map of all 30 wards in Surat (SMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_vadodara": {
       "label": "Vadodara (VMC) Wards",
@@ -644,7 +700,9 @@
       "description": "Vadodara Municipal Corporation \u2014 12 administrative ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Vadodara",
       "source_org": "DataMeet",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Vadodara Ward Map: 12 wards (VMC)",
+      "seo_description": "Interactive map of all 12 wards in Vadodara (VMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_faridabad": {
       "label": "Faridabad (MCF) Wards",
@@ -652,7 +710,9 @@
       "description": "Municipal Corporation of Faridabad \u2014 40 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Faridabad",
       "source_org": "DataMeet",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Faridabad Ward Map: 40 wards (MCF)",
+      "seo_description": "Interactive map of all 40 wards in Faridabad (MCF). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_pcmc": {
       "label": "Pimpri-Chinchwad (PCMC) Electoral Wards",
@@ -660,7 +720,9 @@
       "description": "Pimpri-Chinchwad Municipal Corporation \u2014 66 electoral ward boundaries across 6 zones.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/PCMC",
       "source_org": "DataMeet",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Pimpri-Chinchwad Ward Map: 66 wards (PCMC)",
+      "seo_description": "Interactive map of all 66 wards in Pimpri-Chinchwad (PCMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_vijayawada": {
       "label": "Vijayawada (VMC) Wards",
@@ -668,7 +730,9 @@
       "description": "Vijayawada Municipal Corporation \u2014 77 ward boundaries.",
       "source_url": "https://github.com/datameet/Municipal_Spatial_Data/tree/master/Vijayawada",
       "source_org": "DataMeet",
-      "notes": ""
+      "notes": "",
+      "seo_title": "Vijayawada Ward Map: 77 wards (VMC)",
+      "seo_description": "Interactive map of all 77 wards in Vijayawada (VMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "vedas_power_plants": {
       "label": "Power plants (VEDAS 2023)",

--- a/web/functions/lib/view-dataset.ts
+++ b/web/functions/lib/view-dataset.ts
@@ -25,6 +25,11 @@ export type LevelMeta = {
   label: string;
   unit?: string;
   description?: string;
+  /** SEO-tuned <title>/<h1>, overrides the short display `label` on the
+   * /view page only (home-page cards keep `label`). Used for ward layers. */
+  seo_title?: string;
+  /** SEO-tuned meta description, overrides `description` on the /view page. */
+  seo_description?: string;
 };
 
 export type ViewDataset = {
@@ -94,10 +99,11 @@ export function buildViewDataset(
   levelMeta: LevelMeta | undefined,
   origin: string,
 ): ViewDataset {
-  const title = levelMeta?.label || layer.name || layer.id.replace(/_/g, ' ');
+  const title = levelMeta?.seo_title || levelMeta?.label || layer.name || layer.id.replace(/_/g, ' ');
   const unit = levelMeta?.unit || 'features';
   const count = layer.rows != null ? layer.rows.toLocaleString('en-IN') : null;
   const baseDescription =
+    levelMeta?.seo_description ??
     levelMeta?.description ??
     (layer.description || `${title} — ${count ? count + ' ' + unit + ' · ' : ''}${layer.source}.`);
   const description = baseDescription.slice(0, META_DESC_MAX);
@@ -157,7 +163,9 @@ export function buildViewContent(
   levelMeta: LevelMeta | undefined,
   origin: string,
 ): string {
-  const title = levelMeta?.label || layer.name || layer.id.replace(/_/g, ' ');
+  // H1 uses the SEO title (keyword-aligned with the <title>); the body
+  // paragraph keeps the richer `description` (official corp name + zones).
+  const title = levelMeta?.seo_title || levelMeta?.label || layer.name || layer.id.replace(/_/g, ' ');
   const count = layer.rows != null ? layer.rows.toLocaleString('en-IN') : null;
   const unit = levelMeta?.unit || 'features';
   const desc = levelMeta?.description || layer.description || layer.notes || '';

--- a/web/src/filter-where.ts
+++ b/web/src/filter-where.ts
@@ -100,9 +100,13 @@ export function buildMaplibreFilter(filters: ActiveFilter[]): MaplibreFilter {
       else if (conds.length > 1) exprs.push(['all', ...conds]);
     } else if (f.kind === 'bool') {
       exprs.push(['==', ['get', f.col], f.v]);
+    } else if (f.kind === 'search') {
+      // Case-insensitive "contains", mirroring the SQL ILIKE '%q%'. MapLibre's
+      // `["in", needle, haystack]` does substring matching when haystack is a
+      // string; downcase both sides so the in-tile repaint isolates the match.
+      const q = f.q.trim().toLowerCase();
+      if (q) exprs.push(['in', q, ['downcase', ['to-string', ['get', f.col]]]]);
     }
-    // 'search' (ILIKE) is intentionally skipped — no equivalent in MapLibre
-    // tile filters. Caller falls back to the tier-2 ID-list path.
   }
   if (!exprs.length) return null;
   if (exprs.length === 1) return exprs[0];

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -405,7 +405,17 @@ function applyActiveFilters(
       const features = m.queryRenderedFeatures(undefined, {
         layers: (['fill', 'point'] as string[]).filter((id) => m.getLayer(id)),
       });
-      if (!features.length) return;
+      // Nothing rendered while a filter is active means the in-tile filter
+      // matched no features — usually the filtered column isn't carried as a
+      // PMTiles property on this layer. Don't strand the user on a blank map:
+      // drop the map filter (the DuckDB count/export still reflect the filter).
+      if (!features.length) {
+        for (const id of DATA_LAYERS) {
+          if (!m.getLayer(id)) continue;
+          m.setFilter(id, id === 'point' ? POINT_GEOM_FILTER : null);
+        }
+        return;
+      }
       const bounds = new maplibregl.LngLatBounds();
       for (const f of features) {
         if (f.geometry.type === 'Point') {

--- a/web/tests/filter-where.test.ts
+++ b/web/tests/filter-where.test.ts
@@ -116,12 +116,33 @@ describe('buildMaplibreFilter — empty + skipped kinds', () => {
     expect(buildMaplibreFilter([])).toBeNull();
   });
 
-  it('returns null when only a search filter is active', () => {
-    expect(buildMaplibreFilter([{ col: 'name', kind: 'search', q: 'a' }])).toBeNull();
+  it('returns null when a search filter is empty/whitespace only', () => {
+    expect(buildMaplibreFilter([{ col: 'name', kind: 'search', q: '   ' }])).toBeNull();
   });
 
   it('skips IN filters with no values', () => {
     expect(buildMaplibreFilter([{ col: 'zone', kind: 'in', values: [] }])).toBeNull();
+  });
+});
+
+describe('buildMaplibreFilter — search (case-insensitive contains)', () => {
+  it('translates a search filter to downcase + in so the match isolates on the map', () => {
+    expect(
+      buildMaplibreFilter([{ col: 'KGISWardName', kind: 'search', q: 'Sanjaya Nagar' }]),
+    ).toEqual(['in', 'sanjaya nagar', ['downcase', ['to-string', ['get', 'KGISWardName']]]]);
+  });
+
+  it('composes a search filter with an IN filter under all', () => {
+    expect(
+      buildMaplibreFilter([
+        { col: 'zone', kind: 'in', values: ['East'] },
+        { col: 'KGISWardName', kind: 'search', q: 'Adyar' },
+      ]),
+    ).toEqual([
+      'all',
+      ['in', ['get', 'zone'], ['literal', ['East']]],
+      ['in', 'adyar', ['downcase', ['to-string', ['get', 'KGISWardName']]]],
+    ]);
   });
 });
 

--- a/web/tests/view-dataset.test.ts
+++ b/web/tests/view-dataset.test.ts
@@ -17,6 +17,35 @@ describe('buildViewDataset', () => {
     expect(buildViewDataset(layer, undefined, ORIGIN).title).toBe('lgd villages');
   });
 
+  it('prefers seo_title over label for the page <title> (ward SEO override)', () => {
+    const v = buildViewDataset(
+      layer,
+      { label: 'Ahmedabad (AMC) Wards', seo_title: 'Ahmedabad Ward Map: 48 wards (AMC)' },
+      ORIGIN,
+    );
+    expect(v.title).toBe('Ahmedabad Ward Map: 48 wards (AMC)');
+    expect(v.jsonLd.name).toBe('Ahmedabad Ward Map: 48 wards (AMC)');
+  });
+
+  it('prefers seo_description over description for the meta description', () => {
+    const v = buildViewDataset(
+      layer,
+      {
+        label: 'Ahmedabad (AMC) Wards',
+        description: 'Ahmedabad Municipal Corporation — 48 wards across the 7 zones.',
+        seo_description: 'Interactive map of all 48 wards in Ahmedabad (AMC). View ward boundaries and numbers.',
+      },
+      ORIGIN,
+    );
+    expect(v.description).toContain('Interactive map of all 48 wards in Ahmedabad');
+  });
+
+  it('falls back to label/description when seo_* are absent', () => {
+    const v = buildViewDataset(layer, { label: 'Villages', description: 'Revenue villages.' }, ORIGIN);
+    expect(v.title).toBe('Villages');
+    expect(v.description).toContain('Revenue villages.');
+  });
+
   it('prefers layer.name over humanised id for level-less community layers', () => {
     const community: CatalogLayer = {
       id: 'c_nL7zNStsW3',
@@ -141,6 +170,22 @@ describe('buildViewContent', () => {
   it('falls back to humanised id when no levelMeta', () => {
     const html = buildViewContent(layer, undefined, ORIGIN);
     expect(html).toContain('lgd villages');
+  });
+
+  it('uses seo_title in the h1 when present, keeping the richer body description', () => {
+    const html = buildViewContent(
+      layer,
+      {
+        label: 'Ahmedabad (AMC) Wards',
+        seo_title: 'Ahmedabad Ward Map: 48 wards (AMC)',
+        description: 'Ahmedabad Municipal Corporation — 48 wards across the 7 zones.',
+      },
+      ORIGIN,
+    );
+    expect(html).toContain('<h1');
+    expect(html).toContain('Ahmedabad Ward Map: 48 wards (AMC)');
+    // body paragraph keeps the official-name description, not the SEO line
+    expect(html).toContain('Ahmedabad Municipal Corporation');
   });
 
   it('includes feature count formatted with Indian locale', () => {


### PR DESCRIPTION
Two related improvements that came out of the Search Console review of ward traffic.

## 1. Ward-map titles & descriptions (SEO)
GSC showed ward pages getting impressions but ~0 clicks: titles like *"Chennai (GCC) Wards"* never contained the actual search phrase **"ward map"**, and the acronym broke the keyword.

- Adds `seo_title` + `seo_description` to the 32 `city-wards` entries in `catalog.json` → `level_meta` (patched in place, additions-only diff).
- `view-dataset.ts` prefers them on `/view` pages (`<title>`, meta description, `<h1>`, JSON-LD `Dataset.name`). Non-ward layers fall back to the existing `label`/`description` unchanged.
- Home-page cards and OG cards intentionally keep the short `label`.
- Lettered/named-ward cities (Mumbai, Surat, Patna) say "names" not "numbers"; edge cases handled (BBMP historical, Delhi, Bengaluru GBA, Mumbai electoral). Titles ≤60 chars, descriptions ≤158, no em-dashes.

Example: `Ahmedabad Ward Map: 48 wards (AMC)` + *"Interactive map of all 48 wards in Ahmedabad (AMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."*

## 2. Search filter isolates + zooms on the map (viewer fix)
`buildMaplibreFilter` skipped the `search` (ILIKE) affordance, so typing a ward/road/facility name updated the row count but **never repainted the map** — it just sat there showing all features.

- Implements `search` as a case-insensitive contains (`["in", q, ["downcase", ["to-string", ["get", col]]]]`), mirroring the SQL `ILIKE '%q%'`. `setFilter` now isolates the match and the existing `fitBounds` zooms to it.
- Adds a **blank-map guard**: if the in-tile filter matches nothing visible (a secondary column not baked into the layer's PMTiles), drop the map filter instead of stranding the user on an empty map. Count/export still reflect the filter.

Catalog-wide audit (parquet columns vs PMTiles fields, 101 layers): **83/94 PMTiles layers have full coverage** — every filterable column isolates. The remaining 11 carry their primary name/code column in the tiles (works); only a few secondary attributes (dates, sub-codes, emails) aren't baked in and degrade safely to count/export-only. The known geometry-highlight tail is intentionally **not** addressed here.

## Verification
- 558/558 tests pass; new red→green coverage for the SEO override + fallback and the search-filter contains expression.
- `prerender` + `vite build` green; verified live on `wrangler pages dev` that ward `/view` pages render the new `<head>` and a ward-name search isolates + zooms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)