### PR TITLE
SEO: Dataset Search distribution + apex canonical for /view

### DIFF
--- a/web/functions/lib/view-dataset.ts
+++ b/web/functions/lib/view-dataset.ts
@@ -94,6 +94,36 @@ function mapLicenceUrl(licence: string): string {
   return licence;
 }
 
+// schema.org DataDownload entries for every format the layer publishes. This
+// is the field Google Dataset Search keys on to surface the actual files —
+// without it a Dataset is eligible but has no downloads to show.
+const DISTRIBUTION_FORMATS: Array<[
+  'parquet' | 'pmtiles' | 'geojson' | 'kml' | 'shapefile',
+  string,
+]> = [
+  ['parquet', 'application/vnd.apache.parquet'],
+  ['pmtiles', 'application/vnd.pmtiles'],
+  ['geojson', 'application/geo+json'],
+  ['kml', 'application/vnd.google-earth.kml+xml'],
+  ['shapefile', 'application/zip'],
+];
+
+function buildDistribution(layer: CatalogLayer): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  for (const [key, encodingFormat] of DISTRIBUTION_FORMATS) {
+    const ref = layer[key] as { url: string; bytes: number } | null | undefined;
+    if (ref?.url) {
+      out.push({
+        '@type': 'DataDownload',
+        encodingFormat,
+        contentUrl: ref.url,
+        ...(ref.bytes ? { contentSize: String(ref.bytes) } : {}),
+      });
+    }
+  }
+  return out;
+}
+
 export function buildViewDataset(
   layer: CatalogLayer,
   levelMeta: LevelMeta | undefined,
@@ -117,6 +147,7 @@ export function buildViewDataset(
       : `${baseDescription} Free to view, slice and download as Parquet, PMTiles, GeoJSON or KML. Open atlas of India by Urban Morph, sourced from ${layer.source}.`;
   const canonical = `${origin}/view/${layer.id}`;
   const ogImage = `${origin}/og/view/${layer.id}.png`;
+  const distribution = buildDistribution(layer);
 
   return {
     title,
@@ -131,8 +162,11 @@ export function buildViewDataset(
       description: ldDescription,
       url: canonical,
       license: layer.licence ? mapLicenceUrl(layer.licence) : undefined,
+      isAccessibleForFree: true,
       creator: { '@type': 'Organization', name: layer.source },
+      publisher: { '@type': 'Organization', name: 'bharatlas', url: 'https://bharatlas.com' },
       spatialCoverage: { '@type': 'Place', name: 'India' },
+      ...(distribution.length ? { distribution } : {}),
     },
     // Sibling JSON-LD block. Google honors multiple <script type="application/
     // ld+json"> blocks on one page and de-dupes by @type. Surfaces breadcrumb

--- a/web/functions/view/[id].ts
+++ b/web/functions/view/[id].ts
@@ -22,7 +22,13 @@ export const onRequestGet: PagesFunction<unknown, keyof Params> = async (ctx) =>
   if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
     return new Response(NOT_FOUND_HTML, { status: 404, headers: { 'content-type': 'text/html; charset=utf-8', ...SECURITY_HEADERS_HTML } });
   }
+  // Same-origin fetches use the request host so this works on previews, dev
+  // (:8788) and the pages.dev fallback. SEO URLs (canonical / OG / JSON-LD)
+  // must always be the primary apex, so www.* and pages.dev variants
+  // consolidate there instead of self-referencing as canonical and splitting
+  // the ranking signal. Mirrors render-view.ts's PUBLIC_ORIGIN.
   const origin = new URL(ctx.request.url).origin;
+  const CANONICAL_ORIGIN = 'https://bharatlas.com';
 
   const [catalogResp, indexResp] = await Promise.all([
     fetch(`${origin}/catalog.json`),
@@ -41,9 +47,9 @@ export const onRequestGet: PagesFunction<unknown, keyof Params> = async (ctx) =>
   const { title, description, canonical, ogImage, jsonLd, breadcrumbJsonLd } = buildViewDataset(
     layer,
     levelMeta,
-    origin,
+    CANONICAL_ORIGIN,
   );
-  const contentHtml = buildViewContent(layer, levelMeta, origin);
+  const contentHtml = buildViewContent(layer, levelMeta, CANONICAL_ORIGIN);
 
   return new HTMLRewriter()
     .on('title', {

--- a/web/tests/view-dataset.test.ts
+++ b/web/tests/view-dataset.test.ts
@@ -136,6 +136,43 @@ describe('buildViewDataset', () => {
   });
 });
 
+describe('buildViewDataset — Dataset distribution (Google Dataset Search)', () => {
+  const withDownloads: CatalogLayer = {
+    ...layer,
+    parquet: { url: 'https://r2.example.com/x.parquet', bytes: 7000000 },
+    geojson: { url: 'https://r2.example.com/x.geojson', bytes: 2000000 },
+    kml: { url: 'https://r2.example.com/x.kml', bytes: 1500000 },
+  };
+
+  it('emits a DataDownload per available format with contentUrl + encodingFormat', () => {
+    const dist = buildViewDataset(withDownloads, { label: 'X' }, ORIGIN).jsonLd.distribution as Array<
+      Record<string, unknown>
+    >;
+    expect(dist).toHaveLength(3);
+    expect(dist).toContainEqual({
+      '@type': 'DataDownload',
+      encodingFormat: 'application/vnd.apache.parquet',
+      contentUrl: 'https://r2.example.com/x.parquet',
+      contentSize: '7000000',
+    });
+    expect(dist.map((d) => d.encodingFormat)).toEqual([
+      'application/vnd.apache.parquet',
+      'application/geo+json',
+      'application/vnd.google-earth.kml+xml',
+    ]);
+  });
+
+  it('omits distribution entirely when the layer has no download files', () => {
+    expect(buildViewDataset(layer, { label: 'X' }, ORIGIN).jsonLd.distribution).toBeUndefined();
+  });
+
+  it('marks the dataset free and names the publisher', () => {
+    const v = buildViewDataset(layer, { label: 'X' }, ORIGIN);
+    expect(v.jsonLd.isAccessibleForFree).toBe(true);
+    expect(v.jsonLd.publisher).toMatchObject({ '@type': 'Organization', name: 'bharatlas' });
+  });
+});
+
 describe('resolveLevelMeta', () => {
   it('returns catalog level_meta by layer.id for external layers', () => {
     const ext = { wards_bengaluru_gba: { label: 'GBA Wards', unit: 'wards' } };


### PR DESCRIPTION
Two SEO follow-ups to #121, both confined to the `/view` edge renderer.

## 1. Dataset `distribution` → Google Dataset Search
GSC already detected the `Dataset` structured data ("Data sets" enhancement), but the JSON-LD had **no downloads attached** — the single most important field for [Dataset Search](https://datasetsearch.research.google.com), which surfaces the actual files.

- Adds a `DataDownload` per published format (parquet, pmtiles, geojson, kml, shapefile) with `contentUrl`, `encodingFormat`, and `contentSize`.
- Adds `isAccessibleForFree: true` and an explicit `publisher` (bharatlas).
- `distribution` is omitted when a layer has no files.

Verified on a live local render of `/view/lgd_states`: all 5 formats present with correct R2 `contentUrl`s.

## 2. `/view` canonical/OG always point to the apex
`view/[id].ts` derived the canonical/OG/JSON-LD origin from `request.url`, so `www.bharatlas.com` and `*.pages.dev` variants declared **themselves** canonical and split the ranking signal — exactly the host duplication visible in Search Console (`www.bharatlas.com/view/...` indexed separately).

- Use a hardcoded `CANONICAL_ORIGIN = https://bharatlas.com` for all SEO URLs (mirrors what `render-view.ts` and the prerender already do).
- Keep the request origin only for the same-origin `catalog.json` / `index.html` fetches, so previews / dev (:8788) / pages.dev still function.

Verified: served from `localhost:8788`, the page now emits `<link rel="canonical" href="https://bharatlas.com/view/lgd_states">`.

Note: this consolidates the host variants via the canonical signal (how Google de-dupes). A hard 301 (www → apex) would be marginally stronger but isn't reliably expressible in Pages `_redirects` (host matching) — a one-line Cloudflare Redirect Rule in the dashboard is the clean way if we want it later.

## Verification
- 561/561 tests pass; new red→green coverage for distribution shape, omit-when-empty, and the free/publisher fields.
- `vite build` green; live local edge render confirms both the JSON-LD distribution and the apex canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)