### PR TITLE
chore(mcp): bharatlas-mcp 1.0.3 (Water/groundwater/agro hints)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/bharatlas-mcp)](https://www.npmjs.com/package/bharatlas-mcp)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
-Ask questions about India's geo data in natural language. This MCP server connects any LLM to bharatlas: open-licensed layers covering admin boundaries (state to village), city wards, forests, wildlife sanctuaries, rivers, reservoirs, dams, eco-sensitive zones, seismic zones, flood history, highways, airports, health facilities, pincodes, electoral constituencies, and community submissions.
+Ask questions about India's geo data in natural language. This MCP server connects any LLM to bharatlas: open-licensed layers covering admin boundaries (state to village), city wards, forests, wildlife sanctuaries, rivers, canals, reservoirs, dams, groundwater (aquifers, extraction), eco-sensitive zones, agro-climatic and biogeographic zones, seismic zones, flood history, highways, airports, health facilities, pincodes, electoral constituencies, and community submissions.
 
 ## Install
 
@@ -68,7 +68,7 @@ Thin wrapper over the [bharatlas REST API](https://bharatlas.com/docs). Each too
 The server sends instructions to the LLM at connection time that teach:
 - **Schema-first pattern**: check column names and sample values before querying (column names vary: `state` vs `State_LGD` vs `stname`)
 - **Source preference**: LGD for admin boundaries, with SOI/Bhuvan/geoBoundaries as alternates
-- **Concept-to-layer mapping**: "water bodies" = rivers + reservoirs + wetlands + ramsar sites + dams
+- **Concept-to-layer mapping**: "water bodies" = rivers + canals + reservoirs + wetlands + ramsar sites + dams; "groundwater" = aquifers + extraction stage
 - **Spatial join workflow**: locate for context, query for data, nearby for proximity
 
 ## Links

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bharatlas-mcp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MCP server for India's open geo data. Query layers, locate points, find nearby features, filter and group data.",
   "keywords": ["mcp", "india", "geo", "geospatial", "gis", "boundaries", "parquet", "pmtiles", "llm", "claude", "bharatlas"],
   "repository": { "type": "git", "url": "https://github.com/urbanmorph/geodata", "directory": "mcp" },

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,12 +2,12 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.urbanmorph/bharatlas-mcp",
   "description": "Query India's open geo data. Locate, filter, nearby search across layers.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "bharatlas-mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "transport": { "type": "stdio" }
     }
   ]


### PR DESCRIPTION
Version bump to **1.0.3** for the npm release of `bharatlas-mcp`.

- Carries the MCP instruction updates already merged in #123: the `list_layers` category enum now lists `water` + `agriculture`, and the concept→layer cheat-sheet routes groundwater/canals/agro-ecological/biogeographic queries.
- README refreshed (layer blurb + concept mapping) to reflect the new layers.
- `package.json` and `server.json` both bumped to 1.0.3.

No functional change — the tools call the live API, which already serves the Water category and the 6 CoRE Stack layers. This release only updates the hint text shipped to clients.

After merge: `cd mcp && npm publish` (publisher does `npm login` first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)