### PR TITLE
fix(glama): maintainer = personal GitHub user, not org

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "maintainers": [
-    "urbanmorph"
+    "sathya-sankaran"
   ]
 }


### PR DESCRIPTION
glama.ai's `glama.json` `maintainers` field expects the **GitHub username** of the person claiming the server, not an org name. It was `["urbanmorph"]` (the org), so claiming as `sathya-sankaran` found no match and glama showed an empty "welcome" with nothing to claim.

Set to `["sathya-sankaran"]` to match the working mdshare config.

After merge to `main`, glama re-indexes from the default branch (may take a crawl cycle; can also be re-triggered from the glama dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)