### PR TITLE
fix(a11y): WCAG 2.2 AA contrast + landmarks

### DIFF
--- a/web/about.template.html
+++ b/web/about.template.html
@@ -46,7 +46,7 @@
   <body>
     <!-- NAV -->
 
-    <main>
+    <main id="main">
     <p class="eyebrow" style="font-size:13px;letter-spacing:.04em;color:var(--accent);margin:8px 0 4px">bharatlas</p>
     <h1 class="hero">India's open atlas.</h1>
     <p class="lede">

--- a/web/docs.template.html
+++ b/web/docs.template.html
@@ -50,6 +50,7 @@
   <body>
     <!-- NAV -->
 
+    <main id="main">
       <h1>API v1 <span class="badge badge--stable">stable</span></h1>
       <p>Public, read-only JSON API for India's open geo layers. No auth, no API key. All endpoints return JSON with CORS enabled.</p>
       <p>Base URL: <code>https://bharatlas.com/api/v1</code></p>
@@ -227,6 +228,7 @@ curl https://bharatlas.com/api/v1/layers/wards_pcmc/counts?group_by=zone</code><
 <!-- DOCS_FAQ_HTML -->
       <h2>For LLMs</h2>
       <p>Use the <a href="/mcp">bharatlas MCP server</a> (<code>npx bharatlas-mcp</code>) to connect Claude, GPT, Gemini, or any MCP-compatible LLM directly to this API. 8 tools with built-in instructions for schema-first querying, spatial joins, and multi-source awareness.</p>
+    </main>
 
     <!-- FOOTER -->
   </body>

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -327,7 +327,7 @@
         transition: background 140ms ease;
         white-space: nowrap;
       }
-      .btn-primary:hover { background: var(--accent); color: #fff; text-decoration: none; }
+      .btn-primary:hover { background: var(--accent-fill); color: #fff; text-decoration: none; }
       .btn-primary.disabled { background: transparent; color: var(--muted); border: 1px dashed var(--line); cursor: not-allowed; }
 
       .dl-inline { display: inline-flex; gap: 16px; align-items: center; font-size: 13px; color: var(--muted); }
@@ -352,6 +352,7 @@
         line-height: 1.5;
       }
       .row__viewer-hint strong { color: var(--fg); font-weight: 500; }
+      .row__source a, .row__downloads a { text-decoration: none; }
 
       details.alt { margin-top: 10px; font-size: 12px; }
       details.alt > summary {
@@ -372,7 +373,7 @@
       .alt__row .links a { color: var(--fg); }
       .alt__row .links .dot { color: var(--line); margin: 0 4px; }
       .alt__row--primary { padding-bottom: 6px; border-bottom: 1px dashed var(--line); margin-bottom: 4px; }
-      .alt__row .tag { font-size: 12px; padding: 1px 6px; background: var(--accent); color: #fff; border-radius: 999px; margin-left: 4px; vertical-align: middle; letter-spacing: .04em; }
+      .alt__row .tag { font-size: 12px; padding: 1px 6px; background: var(--accent-fill); color: #fff; border-radius: 999px; margin-left: 4px; vertical-align: middle; letter-spacing: .04em; }
 
       footer { margin-top: 56px; color: var(--muted); font-size: 12px; line-height: 1.7; }
       footer p { margin: 6px 0; }
@@ -527,7 +528,7 @@
         border-color: var(--fg);
       }
       .filter-panel__btn--primary .muted { color: color-mix(in srgb, var(--bg) 70%, var(--fg)); }
-      .filter-panel__btn--primary:hover:not(:disabled) { background: var(--accent); border-color: var(--accent); color: #fff; }
+      .filter-panel__btn--primary:hover:not(:disabled) { background: var(--accent-fill); border-color: var(--accent-fill); color: #fff; }
       .filter-panel__btn--primary:hover:not(:disabled) .muted { color: rgba(255,255,255,0.7); }
       .filter-panel__btn:disabled { background: transparent; color: var(--muted); border-color: var(--line); cursor: not-allowed; opacity: .55; }
       .filter-panel__hint { font-size: 12px; color: var(--muted); line-height: 1.5; margin: 0; }
@@ -589,7 +590,7 @@
       .filter-typeahead__item {
         padding: 6px 11px; cursor: pointer; font-size: 13px; color: var(--fg);
       }
-      .filter-typeahead__item:hover { background: var(--accent); color: #fff; }
+      .filter-typeahead__item:hover { background: var(--accent-fill); color: #fff; }
       .filter-typeahead__clear {
         position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
         background: none; border: none; color: var(--muted); cursor: pointer;
@@ -759,7 +760,7 @@
   </head>
   <body>
     <!-- NAV -->
-    <main>
+    <main id="main">
     <header class="hero">
       <h1 class="hero__title">Find a map. Or share one.</h1>
       <p class="hero__sub">

--- a/web/mcp.template.html
+++ b/web/mcp.template.html
@@ -43,6 +43,7 @@
   <body>
     <!-- NAV -->
 
+    <main id="main">
       <h1>MCP Server <span class="badge--stable">v1</span></h1>
       <p>Ask questions about India's geo data in natural language. The bharatlas MCP server connects LLMs (Claude, GPT, Gemini, Cursor, etc.) to curated geo layers plus community submissions.</p>
 
@@ -80,7 +81,7 @@
 .vscode/mcp.json (project) or settings.json</code></pre>
       </div>
 
-      <p style="font-size:13px;color:var(--subtle)">Developers: test tools without an LLM via <code>npx @modelcontextprotocol/inspector npx bharatlas-mcp</code></p>
+      <p style="font-size:13px;color:var(--muted)">Developers: test tools without an LLM via <code>npx @modelcontextprotocol/inspector npx bharatlas-mcp</code></p>
 
       <h2>What you can ask</h2>
 
@@ -153,6 +154,7 @@
         <li><a href="/docs">REST API reference</a></li>
         <li><a href="https://github.com/urbanmorph/geodata/tree/main/mcp">GitHub source</a></li>
       </ul>
+    </main>
 
     <!-- FOOTER -->
   </body>

--- a/web/preview.template.html
+++ b/web/preview.template.html
@@ -68,7 +68,7 @@
       #publish-cta.show { display: block; }
       #publish-cta .cta-line { font-size: 13px; font-weight: 500; margin: 0 0 8px; }
       #publish-cta button.primary {
-        background: var(--accent); color: #fff; border: 0; width: 100%;
+        background: var(--accent-fill); color: #fff; border: 0; width: 100%;
         padding: 10px 14px; border-radius: 6px;
         font: inherit; font-weight: 500; font-size: 14px; cursor: pointer;
       }
@@ -131,7 +131,7 @@
       #captcha { margin: 12px 0; min-height: 65px; }
 
       button.primary {
-        background: var(--accent); color: #fff; border: 0;
+        background: var(--accent-fill); color: #fff; border: 0;
         width: 100%; padding: 10px 14px; border-radius: 6px;
         font: inherit; font-weight: 500; font-size: 14px; cursor: pointer;
       }
@@ -165,7 +165,7 @@
         margin: -16px 0 24px; line-height: 1.5;
       }
       #success a.cta {
-        display: inline-block; background: var(--accent); color: #fff; text-decoration: none;
+        display: inline-block; background: var(--accent-fill); color: #fff; text-decoration: none;
         padding: 10px 20px; border-radius: 6px; font-weight: 500; font-size: 14px;
       }
       #success a.cta:hover { opacity: 0.92; }
@@ -250,7 +250,7 @@
       }
       #paste-back-form input:focus { outline: none; border-color: var(--accent); }
       #paste-back-form button {
-        background: var(--accent); color: #fff; border: 0;
+        background: var(--accent-fill); color: #fff; border: 0;
         padding: 7px 14px; border-radius: 6px;
         font: inherit; font-size: 13px; cursor: pointer;
       }
@@ -276,7 +276,7 @@
   <body>
     <!-- NAV -->
 
-    <main>
+    <main id="main">
     <h1 class="page-title">View, verify, or publish a geo file</h1>
     <p class="page-sub">Drop a file to render it on a map and check it. Optionally publish to the open catalog. Nothing is uploaded unless you click <strong>Publish</strong>.</p>
 

--- a/web/privacy.template.html
+++ b/web/privacy.template.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <!-- NAV -->
-    <main>
+    <main id="main">
     <h1 class="hero">Privacy</h1>
     <p class="lede">
       bharatlas runs without accounts, without third-party analytics, and without tracking

--- a/web/scripts/shared-chrome.mjs
+++ b/web/scripts/shared-chrome.mjs
@@ -12,8 +12,8 @@ export const TOKENS = `
     --bg: #ffffff; --bg-elevated: #fafafa; --bg-card: #f5f5f5;
     --fg: #0a0a0a; --muted: #525965; --muted-strong: #374151;
     --subtle: #9ca3af; --line: #e5e7eb; --line-bright: #d1d5db;
-    --accent: #6366f1; --accent-strong: #4f46e5;
-    --accent-fill: #6366f1; --accent-fill-hover: #4f46e5;
+    --accent: #4f46e5; --accent-strong: #4338ca;
+    --accent-fill: #4f46e5; --accent-fill-hover: #4338ca;
     --ok: #16a34a; --warn: #d97706; --err: #dc2626;
   }
   @media (prefers-color-scheme: dark) {
@@ -22,7 +22,7 @@ export const TOKENS = `
       --fg: #ededed; --muted: #9ca3af; --muted-strong: #d4d4d8;
       --subtle: #525252; --line: #262626; --line-bright: #404040;
       --accent: #818cf8; --accent-strong: #6366f1;
-      --accent-fill: #6366f1; --accent-fill-hover: #818cf8;
+      --accent-fill: #4f46e5; --accent-fill-hover: #4338ca;
       --ok: #4ade80; --warn: #fbbf24; --err: #f87171;
     }
   }
@@ -39,6 +39,14 @@ export const TOKENS = `
     outline-offset: 2px !important;
     border-radius: var(--radius-sm);
   }
+  .skip-link {
+    position: absolute; left: -9999px; top: var(--sp-2);
+    background: var(--bg); color: var(--accent);
+    padding: var(--sp-2) var(--sp-3); border: 1px solid var(--line);
+    border-radius: var(--radius-md); z-index: 1000;
+  }
+  .skip-link:focus { left: var(--sp-2); }
+  main :is(p, li) a { text-decoration: underline; text-underline-offset: 2px; }
   .site-header {
     display: flex; align-items: baseline; justify-content: space-between;
     gap: var(--sp-4); flex-wrap: wrap; margin-bottom: var(--sp-6);
@@ -85,7 +93,8 @@ export const NAV_LINKS = [
 ];
 
 export function renderNav(activeKey) {
-  return `<header class="site-header">
+  return `<a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
       <a class="site-brand" href="/">bhar<span class="mark-accent">atlas</span><span class="tagline">India's open atlas</span></a>
       <nav class="site-nav">
         ${NAV_LINKS.map(

--- a/web/submit.html
+++ b/web/submit.html
@@ -32,8 +32,8 @@
     --bg: #ffffff; --bg-elevated: #fafafa; --bg-card: #f5f5f5;
     --fg: #0a0a0a; --muted: #6b7280; --muted-strong: #374151;
     --subtle: #9ca3af; --line: #e5e7eb; --line-bright: #d1d5db;
-    --accent: #6366f1; --accent-strong: #4f46e5;
-    --accent-fill: #6366f1; --accent-fill-hover: #4f46e5;
+    --accent: #4f46e5; --accent-strong: #4338ca;
+    --accent-fill: #4f46e5; --accent-fill-hover: #4338ca;
     --ok: #16a34a; --warn: #d97706; --err: #dc2626;
   }
   @media (prefers-color-scheme: dark) {
@@ -42,7 +42,7 @@
       --fg: #ededed; --muted: #9ca3af; --muted-strong: #d4d4d8;
       --subtle: #525252; --line: #262626; --line-bright: #404040;
       --accent: #818cf8; --accent-strong: #6366f1;
-      --accent-fill: #6366f1; --accent-fill-hover: #818cf8;
+      --accent-fill: #4f46e5; --accent-fill-hover: #4338ca;
       --ok: #4ade80; --warn: #fbbf24; --err: #f87171;
     }
   }
@@ -59,6 +59,14 @@
     outline-offset: 2px !important;
     border-radius: var(--radius-sm);
   }
+  .skip-link {
+    position: absolute; left: -9999px; top: var(--sp-2);
+    background: var(--bg); color: var(--accent);
+    padding: var(--sp-2) var(--sp-3); border: 1px solid var(--line);
+    border-radius: var(--radius-md); z-index: 100;
+  }
+  .skip-link:focus { left: var(--sp-2); }
+  .page-title { font-size: var(--fs-xl); font-weight: 600; letter-spacing: -.01em; margin: 0 0 var(--sp-5); }
   .site-header {
     display: flex; align-items: baseline; justify-content: space-between;
     gap: var(--sp-4); flex-wrap: wrap; margin-bottom: var(--sp-6);
@@ -150,7 +158,7 @@
       #captcha { margin: 16px 0; min-height: 65px; }
 
       button.primary {
-        background: var(--accent); color: #fff; border: 0;
+        background: var(--accent-fill); color: #fff; border: 0;
         padding: 10px 20px; border-radius: 6px; font: inherit; font-weight: 500; font-size: 14px;
         cursor: pointer;
       }
@@ -183,7 +191,7 @@
       }
       #success .actions { display: flex; gap: 8px; flex-wrap: wrap; margin: 10px 0 24px; }
       #success a.cta {
-        display: inline-block; background: var(--accent); color: #fff; text-decoration: none;
+        display: inline-block; background: var(--accent-fill); color: #fff; text-decoration: none;
         padding: 10px 20px; border-radius: 6px; font-weight: 500; font-size: 14px;
       }
       #success a.cta:hover { opacity: 0.92; }
@@ -204,6 +212,7 @@
     </style>
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to content</a>
     <header class="site-header">
       <a class="site-brand" href="/">bhar<span class="mark-accent">atlas</span><span class="tagline">India's open atlas</span></a>
       <nav class="site-nav">
@@ -214,6 +223,9 @@
         <a href="https://github.com/urbanmorph/geodata" target="_blank" rel="noopener">github</a>
       </nav>
     </header>
+
+    <main id="main">
+    <h1 class="page-title">Submit a geo layer</h1>
 
     <label id="drop" for="file">
       <strong>Drop a file or click to choose</strong>
@@ -319,6 +331,7 @@
       Files are parsed in your browser before upload — no server-side processing.<br />
       Rate limit: 5 submissions per hour, 20 per day, per IP.
     </div>
+    </main>
 
     <footer class="site-footer">
       <p>Open licences only. Each layer carries its source link on the card.</p>

--- a/web/terms.template.html
+++ b/web/terms.template.html
@@ -29,7 +29,7 @@
   </head>
   <body>
     <!-- NAV -->
-    <main>
+    <main id="main">
     <h1 class="hero">Terms</h1>
     <p class="lede">
       By using bharatlas you agree to these terms. They're short because the platform is

--- a/web/tests/contrast.test.ts
+++ b/web/tests/contrast.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { TOKENS } from '../scripts/shared-chrome.mjs';
+
+// WCAG 2.x relative luminance + contrast ratio — pure, from the spec.
+// https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+function luminance(hex: string): number {
+  const h = hex.replace('#', '');
+  const n = h.length === 3 ? [...h].map((c) => c + c).join('') : h;
+  const ch = [0, 2, 4].map((i) => parseInt(n.slice(i, i + 2), 16) / 255);
+  const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  return 0.2126 * lin(ch[0]) + 0.7152 * lin(ch[1]) + 0.0722 * lin(ch[2]);
+}
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Pull the design-token hex values out of the shared TOKENS CSS string, so a
+// future palette tweak that drops a colour below threshold fails CI here.
+function tokenScope(scope: 'light' | 'dark'): Record<string, string> {
+  const dark = TOKENS.match(/prefers-color-scheme:\s*dark[^{]*\{\s*:root\s*\{([^}]*)\}/);
+  const light = TOKENS.match(/:root\s*\{([^}]*)\}/);
+  const body = (scope === 'dark' ? dark : light)?.[1] ?? '';
+  const map: Record<string, string> = {};
+  for (const m of body.matchAll(/(--[a-z-]+):\s*(#[0-9a-fA-F]{3,6})/g)) map[m[1]] = m[2];
+  return map;
+}
+
+const WHITE = '#ffffff';
+const AA_TEXT = 4.5; // normal-size text
+const AA_UI = 3; // UI components / large text (1.4.11, 1.4.3 large)
+
+describe('WCAG contrast util', () => {
+  it('matches known reference ratios', () => {
+    expect(contrast('#000000', '#ffffff')).toBeCloseTo(21, 0);
+    expect(contrast('#ffffff', '#ffffff')).toBeCloseTo(1, 5);
+    expect(contrast('#767676', '#ffffff')).toBeGreaterThanOrEqual(4.5); // canonical AA grey
+  });
+});
+
+describe('design tokens meet WCAG 2.2 AA (light)', () => {
+  const t = tokenScope('light');
+
+  it('foreground + secondary text on backgrounds', () => {
+    expect(contrast(t['--fg'], t['--bg'])).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(contrast(t['--muted'], t['--bg'])).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(contrast(t['--muted-strong'], t['--bg'])).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(contrast(t['--muted'], t['--bg-card'])).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it('accent link/label text on white and on cards', () => {
+    expect(contrast(t['--accent'], t['--bg'])).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(contrast(t['--accent'], t['--bg-card'])).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it('white text on filled accent buttons', () => {
+    expect(contrast(WHITE, t['--accent-fill'])).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it('focus outline is visible against the background', () => {
+    expect(contrast(t['--accent-strong'], t['--bg'])).toBeGreaterThanOrEqual(AA_UI);
+  });
+});
+
+describe('design tokens meet WCAG 2.2 AA (dark)', () => {
+  const t = tokenScope('dark');
+
+  it('foreground + secondary text on backgrounds', () => {
+    expect(contrast(t['--fg'], t['--bg'])).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(contrast(t['--muted'], t['--bg'])).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(contrast(t['--muted-strong'], t['--bg'])).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it('accent link/label text on background', () => {
+    expect(contrast(t['--accent'], t['--bg'])).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it('white text on filled accent buttons', () => {
+    expect(contrast(WHITE, t['--accent-fill'])).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+});

--- a/web/tests/shared-chrome.test.ts
+++ b/web/tests/shared-chrome.test.ts
@@ -9,8 +9,11 @@ describe('TOKENS', () => {
     expect(TOKENS).toContain('--fs-display: 36px');
   });
 
-  it('uses the mdshare-aligned indigo accent in both modes', () => {
-    expect(TOKENS).toContain('--accent: #6366f1');
+  it('uses a WCAG-AA indigo accent in both modes', () => {
+    // Light accent darkened #6366f1 -> #4f46e5 so link/button text clears 4.5:1
+    // (diverges from mdshare's #6366f1; see contrast.test.ts for the proof).
+    // Dark accent #818cf8 already passes as text on #0a0a0a.
+    expect(TOKENS).toContain('--accent: #4f46e5');
     expect(TOKENS).toContain('--accent: #818cf8'); // dark-mode variant
   });
 


### PR DESCRIPTION
Closes the WCAG 2.2 AA gaps surfaced by a full static audit (PSI flagged contrast on content-heavy `/view` pages that an earlier home-only run missed). Static-auditable criteria only; the map-overlay modal focus work is deliberately deferred (needs live keyboard/SR testing).

## Contrast (1.4.3) — root cause + fix
`--accent` was doing double duty as link text **and** button background. Darkened the light accent and split fills onto a real `--accent-fill` token:

| Surface | Before | After | Mode |
|---|---|---|---|
| Accent link/label text | 4.47:1 ❌ | 6.29:1 ✅ | light |
| Accent text on cards | 4.10:1 ❌ | 5.77:1 ✅ | light |
| White text on filled buttons | 4.47:1 ❌ | 6.29:1 ✅ | light |
| White text on filled buttons | **2.98:1** ❌ | 6.29:1 ✅ | dark |
| Accent link text on `#0a0a0a` | 6.43:1 ✅ | 6.43:1 ✅ | dark (untouched) |

The dark-mode button (white on `#818cf8`) was the worst offender and was invisible to PSI's light-mode run — caught only because the test checks both schemes.

## Also in this PR
- **1.4.1 Use of color** — in-prose links underline at rest; catalog data-rows opted out so the card grid stays clean.
- **1.3.1 / 2.4.1 landmarks** — `<main>` added to submit/docs/mcp (were missing).
- **2.4.6 headings** — visible `<h1>` on submit; visually-hidden `<h1>` on the full-bleed verify.
- **2.4.1 bypass blocks** — skip-to-content link as the first focusable element on every prerendered page + submit.
- **1.4.3 subtle text** — the single `--subtle` text line on `/mcp` → `--muted` (7:1).

## Test
New `web/tests/contrast.test.ts` parses the actual token blocks and asserts every text/button pair against AA. It was **red** on the old palette (the three 4.467:1 cases) and is green now — a permanent regression guard against any future palette tweak dropping below threshold. Full suite: **580/580 pass**, `npm run build` green.

## Notes for the reviewer
- Light `--accent` now **diverges from mdshare's shared `#6366f1`** (`shared-chrome.mjs` is commented "kept in sync with mdshare") — mdshare almost certainly carries the identical 4.47:1 fail and should get the same change.
- `web/verify.html` is gitignored, so its identical token fix is **local-only and not in this PR**. If `/verify` is a deployed page, it needs to be tracked for the fix to take.
- **Deferred (not here):** map-overlay modal focus trap/restore/`inert` (C, medium); submit `aria-describedby` hints + input border non-text contrast (D, low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)