### PR TITLE
feat(submit): log submission attempts to measure the funnel drop-off

### DIFF
--- a/web/functions/api/submit.ts
+++ b/web/functions/api/submit.ts
@@ -14,6 +14,7 @@ import { insertSubmission, insertToken, findDuplicateByHash } from '../lib/submi
 import { generateToken, hashToken, tokenPrefix } from '../lib/tokens';
 import { nanoid, sha256Hex, sanitizeFilename, ipHashFor } from '../lib/submit-helpers';
 import { normaliseFC } from '../../src/validate';
+import { attemptRowFromResult, attemptRowReject, logAttempt, type AttemptRow } from '../lib/submit-log';
 
 type Env = MiddlewareEnv & {
   TURNSTILE_SECRET: string;
@@ -68,7 +69,15 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   const filename = sanitizeFilename(file.name);
   const ext = filename.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? '';
   const ALLOWED = new Set(['geojson', 'json', 'kml', 'kmz', 'gpx', 'tcx', 'parquet']);
+
+  // Funnel instrumentation — record every attempt outcome so the drop-off past
+  // /submit is measurable. Best-effort + non-blocking (ctx.waitUntil).
+  const ipHash = await ipHashFor(ctx.request, ctx.env.IP_SALT || 'geodata-v1');
+  const logMeta = { ext, bytes: file.size, ipHash };
+  const log = (row: AttemptRow) => ctx.waitUntil(logAttempt(ctx.env.DB, row));
+
   if (!ALLOWED.has(ext)) {
+    log(attemptRowReject('format', `unsupported extension .${ext}`, logMeta));
     return j(415, {
       error: `unsupported file extension .${ext} — accepts: ${[...ALLOWED].join(', ')}`,
     });
@@ -88,15 +97,17 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       const fcField = form.get('fc_json');
       const fcText =
         fcField instanceof File ? await fcField.text() : typeof fcField === 'string' ? fcField : '';
-      if (!fcText) return j(400, { error: 'missing fc_json for non-GeoJSON upload' });
+      if (!fcText) {
+        log(attemptRowReject('parse', 'missing fc_json for non-GeoJSON upload', logMeta));
+        return j(400, { error: 'missing fc_json for non-GeoJSON upload' });
+      }
       rawJson = JSON.parse(fcText);
       fc = normaliseFC(rawJson);
     }
   } catch (e) {
+    log(attemptRowReject('parse', 'failed to parse FeatureCollection', logMeta));
     return j(400, { error: 'failed to parse FeatureCollection', detail: (e as Error).message });
   }
-
-  const ipHash = await ipHashFor(ctx.request, ctx.env.IP_SALT || 'geodata-v1');
 
   const result = await validateSubmission(
     {
@@ -123,6 +134,7 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   );
 
   if (!result.accept) {
+    log(attemptRowFromResult(result, logMeta));
     return j(codeForReason(result.reason), { error: result.reason, report: result.report });
   }
 
@@ -168,8 +180,11 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       }),
     ]);
   } catch (e) {
+    log(attemptRowReject('persist', 'failed to persist submission', logMeta));
     return j(500, { error: 'failed to persist submission', detail: (e as Error).message });
   }
+
+  log(attemptRowFromResult(result, logMeta));
 
   const origin = new URL(ctx.request.url).origin;
   return j(200, {

--- a/web/functions/lib/submit-log.ts
+++ b/web/functions/lib/submit-log.ts
@@ -1,0 +1,70 @@
+// Funnel instrumentation for /api/submit.
+//
+// Hard-rejected submissions are bounced at validation BEFORE any DB write, so
+// they leave no trace in the `submissions` table — which is why the
+// contribution funnel was a black box past `/submit`. This records the outcome
+// of every POST (which gate rejected, or accepted) to `submit_attempts` so the
+// drop-off becomes measurable.
+//
+// Privacy: stores only the failing gate + coarse file facts (extension, size)
+// and the already-hashed IP. No file bytes, no name / attribution / source text.
+// Best-effort: logging must NEVER fail a real submission.
+
+import type { ValidationResult, ValidationReport } from './validate-server';
+
+export type AttemptOutcome = 'accepted' | 'rejected';
+
+export type AttemptRow = {
+  outcome: AttemptOutcome;
+  gate: string | null; // failing gate key, or null when accepted
+  reason: string | null; // human reason string, or null when accepted
+  ext: string | null; // file extension
+  bytes: number | null; // file size
+  ip_hash: string | null; // already-hashed IP (matches submissions/rate_limits)
+};
+
+type AttemptMeta = { ext?: string | null; bytes?: number | null; ipHash?: string | null };
+
+/** Coarse file facts shared by every row, with undefined normalised to null. */
+function fileFacts(meta: AttemptMeta): Pick<AttemptRow, 'ext' | 'bytes' | 'ip_hash'> {
+  return { ext: meta.ext ?? null, bytes: meta.bytes ?? null, ip_hash: meta.ipHash ?? null };
+}
+
+/** First gate in the validation report with ok === false (validateSubmission
+ *  short-circuits on the first failure, so there is at most one). */
+export function failingGate(report: ValidationReport): string | null {
+  for (const [gate, result] of Object.entries(report)) {
+    if (result && result.ok === false) return gate;
+  }
+  return null;
+}
+
+/** Build an attempt row from a full validateSubmission result. */
+export function attemptRowFromResult(result: ValidationResult, meta: AttemptMeta): AttemptRow {
+  return result.accept
+    ? { outcome: 'accepted', gate: null, reason: null, ...fileFacts(meta) }
+    : { outcome: 'rejected', gate: failingGate(result.report), reason: result.reason, ...fileFacts(meta) };
+}
+
+/** Build a rejected row for an early exit that never reaches validateSubmission
+ *  (bad format, unparseable file). */
+export function attemptRowReject(gate: string, reason: string, meta: AttemptMeta): AttemptRow {
+  return { outcome: 'rejected', gate, reason, ...fileFacts(meta) };
+}
+
+/** Best-effort insert. Swallows every error so a logging failure (e.g. the
+ *  table not yet migrated) can never break a submission. Pair with
+ *  ctx.waitUntil() so it adds zero latency to the response. */
+export async function logAttempt(db: D1Database, row: AttemptRow): Promise<void> {
+  try {
+    await db
+      .prepare(
+        `INSERT INTO submit_attempts (outcome, gate, reason, ext, bytes, ip_hash)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(row.outcome, row.gate, row.reason, row.ext, row.bytes, row.ip_hash)
+      .run();
+  } catch {
+    /* logging is best-effort — never propagate */
+  }
+}

--- a/web/migrations/0006_submit_attempts.sql
+++ b/web/migrations/0006_submit_attempts.sql
@@ -1,0 +1,18 @@
+-- Funnel instrumentation: record the outcome of every /api/submit POST.
+-- Hard-rejected attempts are bounced at validation before the submissions
+-- insert, so without this they leave no trace and the funnel past /submit is
+-- a black box. Stores only the failing gate + coarse file facts — no file
+-- bytes, no name / attribution / source text.
+
+CREATE TABLE IF NOT EXISTS submit_attempts (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  outcome     TEXT NOT NULL,   -- 'accepted' | 'rejected'
+  gate        TEXT,            -- failing gate: captcha|rateLimit|size|filename|format|name|license|attribution|sourceUrl|crs|geometry|parse|persist (NULL when accepted)
+  reason      TEXT,            -- human reason string (NULL when accepted)
+  ext         TEXT,            -- file extension
+  bytes       INTEGER,         -- file size
+  ip_hash     TEXT             -- already-hashed IP (matches submissions/rate_limits)
+);
+CREATE INDEX IF NOT EXISTS idx_attempts_created ON submit_attempts (created_at);
+CREATE INDEX IF NOT EXISTS idx_attempts_gate ON submit_attempts (gate);

--- a/web/tests/submit-log.test.ts
+++ b/web/tests/submit-log.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateSubmission,
+  type SubmissionInput,
+  type ValidationDeps,
+} from '../functions/lib/validate-server';
+import { failingGate, attemptRowFromResult, attemptRowReject } from '../functions/lib/submit-log';
+import type { FC } from '../src/validate';
+
+function pointFC(x = 72.8, y = 19.0): FC {
+  return {
+    type: 'FeatureCollection',
+    features: [
+      { type: 'Feature', geometry: { type: 'Point', coordinates: [x, y] }, properties: { name: 'x' } },
+    ],
+  };
+}
+
+function input(overrides: Partial<SubmissionInput> = {}): SubmissionInput {
+  return {
+    turnstileToken: 'ok',
+    ipHash: 'A',
+    filename: 'mumbai_bike_lanes.geojson',
+    bytes: 1024,
+    contentHash: 'a'.repeat(64),
+    fc: pointFC(),
+    rawJson: undefined,
+    name: 'Mumbai bike lanes',
+    description: null,
+    category: 'infrastructure',
+    license: 'CC-BY-4.0',
+    attribution: 'BBMP Open Data Portal',
+    sourceUrl: 'https://example.com/data',
+    isOriginal: false,
+    ...overrides,
+  };
+}
+
+function deps(overrides: Partial<ValidationDeps> = {}): ValidationDeps {
+  return {
+    verifyCaptcha: async () => true,
+    checkRate: async () => ({ ok: true }),
+    findDuplicate: async () => null,
+    ...overrides,
+  };
+}
+
+describe('failingGate', () => {
+  it('finds the single gate that rejected a submission', async () => {
+    const r = await validateSubmission(
+      input({ rawJson: { crs: { properties: { name: 'urn:ogc:def:crs:EPSG::3857' } } } }),
+      deps(),
+    );
+    expect(r.accept).toBe(false);
+    expect(failingGate(r.report)).toBe('crs');
+  });
+
+  it('returns null for a clean (all-ok) report', async () => {
+    const r = await validateSubmission(input(), deps());
+    expect(failingGate(r.report)).toBeNull();
+  });
+});
+
+describe('attemptRowFromResult', () => {
+  it('maps an accept to outcome=accepted with null gate/reason', async () => {
+    const r = await validateSubmission(input(), deps());
+    const row = attemptRowFromResult(r, { ext: 'geojson', bytes: 1024, ipHash: 'A' });
+    expect(row).toMatchObject({
+      outcome: 'accepted',
+      gate: null,
+      reason: null,
+      ext: 'geojson',
+      bytes: 1024,
+      ip_hash: 'A',
+    });
+  });
+
+  it('maps a reject to outcome=rejected carrying the gate + reason', async () => {
+    const r = await validateSubmission(input({ license: 'CC-BY-NC-4.0' }), deps());
+    const row = attemptRowFromResult(r, { ext: 'geojson', bytes: 50, ipHash: 'B' });
+    expect(row.outcome).toBe('rejected');
+    expect(row.gate).toBe('license');
+    expect(row.reason).toMatch(/licen[cs]e/i);
+  });
+});
+
+describe('attemptRowReject (pre-validation early exits)', () => {
+  it('builds a rejected row from a synthetic gate (e.g. shapefile upload)', () => {
+    const row = attemptRowReject('format', 'unsupported extension .shp', {
+      ext: 'shp',
+      bytes: 10,
+      ipHash: null,
+    });
+    expect(row).toEqual({
+      outcome: 'rejected',
+      gate: 'format',
+      reason: 'unsupported extension .shp',
+      ext: 'shp',
+      bytes: 10,
+      ip_hash: null,
+    });
+  });
+});


### PR DESCRIPTION
## Why
The contribution funnel leaks entirely at `/submit`: ~140 `/preview` → ~100 `/submit` views per 30d, but **1 completed submission in all of history**. We couldn't see *where* it fails, because hard-rejected submissions are bounced at validation **before** any DB write, so they leave no trace. This makes the drop-off measurable.

## What
- New `submit_attempts` table (migration `0006`) recording every POST outcome: `outcome` (accepted/rejected), `gate` (which validation gate rejected), `reason`, `ext`, `bytes`, `ip_hash`.
- `submit-log.ts`: pure mappers (`failingGate`, `attemptRowFromResult`, `attemptRowReject`) + best-effort `logAttempt`.
- `submit.ts`: logs at every exit (format reject, parse fail, each validation gate, persist fail, and accept), fired via `ctx.waitUntil` so it adds zero latency and can never break a submission.

## Privacy
Stores only the failing gate + coarse file facts (extension, size) + the already-hashed IP. No file bytes, no name/attribution/source text.

## Reading the funnel (once data accrues)
```sql
SELECT gate, COUNT(*) FROM submit_attempts WHERE outcome='rejected' GROUP BY gate ORDER BY 2 DESC;
SELECT outcome, COUNT(*) FROM submit_attempts GROUP BY outcome;
SELECT ext, COUNT(*) FROM submit_attempts GROUP BY ext;
```

## Deploy note
Migration `0006` is applied to the prod D1 (`geodata-submissions`) as part of this change. Logging is best-effort and no-ops until the table exists, so ordering is safe. Tests: **585 pass** (5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)