### PR TITLE
fix(view): mobile control layer for the map viewer

### DIFF
--- a/web/index.template.html
+++ b/web/index.template.html
@@ -721,6 +721,12 @@
 
         /* Scrim is shown only while a sheet is open (toggled in map.ts). */
         .map-scrim.open { display: block; }
+
+        /* While a sheet is open, hide MapLibre's control layer (zoom +
+           attribution) so it doesn't paint over the sheet — its stacking
+           context fights the fixed sheet. Both return when the sheet closes,
+           so the attribution stays visible in the default state. */
+        #map-overlay.sheet-open .maplibregl-control-container { display: none; }
       }
 
       /* Map popups are a single look — fed by hover on pointer devices and

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -426,6 +426,15 @@
       #map-overlay button.filter-toggle:hover { border-color: var(--accent); color: var(--accent); }
       #map-overlay button.filter-toggle[aria-expanded="true"] { border-color: var(--accent); color: var(--accent); }
 
+      /* Action group. display:contents on desktop is a passthrough — the
+         buttons flow in the header exactly as before. On mobile (max-width:640px)
+         it becomes the fixed bottom toolbar. */
+      .map-actions { display: contents; }
+
+      /* Scrim behind an open mobile sheet. Inert on desktop (popovers dismiss on
+         outside-click); only the mobile block flips .open to visible. */
+      .map-scrim { position: fixed; inset: 0; z-index: 14; background: rgba(0,0,0,0.35); display: none; }
+
       /* Popover (download menu + basemap toggle) */
       .map-pop-wrap { position: relative; display: inline-block; }
       .map-popover {
@@ -614,15 +623,18 @@
 
       /* ───── Mobile (narrow) ───── */
       @media (max-width: 640px) {
-        /* Filter panel becomes a bottom sheet */
+        /* Height of the fixed bottom toolbar; sheets sit on top of it. */
+        #map-overlay { --map-toolbar-h: calc(60px + env(safe-area-inset-bottom)); }
+        /* Filter panel becomes a bottom sheet, above the toolbar */
         .filter-panel {
-          top: auto; left: 0; right: 0; bottom: 0;
-          width: 100%; height: 62vh;
+          top: auto; left: 0; right: 0; bottom: var(--map-toolbar-h);
+          width: 100%; height: 52vh;
           border-left: none;
           border-top: 1px solid var(--line);
           border-top-left-radius: 14px;
           border-top-right-radius: 14px;
           box-shadow: 0 -8px 24px rgba(0,0,0,0.10);
+          z-index: 16;
           animation: filter-slide-up 220ms ease;
         }
         @keyframes filter-slide-up { from { transform: translateY(16px); opacity: 0; } to { transform: none; opacity: 1; } }
@@ -656,39 +668,59 @@
         .filter-search,
         .filter-range__input { min-height: 44px; padding: 10px 12px; font-size: 16px; }
 
-        /* Map header: title on its own line, buttons wrap evenly below */
+        /* Slim top bar: title + back only. The action buttons relocate to the
+           bottom toolbar below, so the bar can never overflow. */
         #map-overlay header.map-bar {
-          flex-wrap: wrap;
-          padding: 8px 12px;
-          gap: 6px;
+          padding: 10px 12px;
+          gap: 10px;
         }
         #map-overlay .map-title {
-          font-size: 13px;
+          flex: 1; min-width: 0;
+          font-size: 14px;
           overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-          width: 100%;
-          order: -1;
         }
-        #map-overlay button.close,
-        #map-overlay button.filter-toggle {
-          font-size: 12px;
-          flex: 1;
+        #map-overlay button.close { flex: 0 0 auto; font-size: 13px; }
+
+        /* Leave room at the bottom for the toolbar so the map (and its
+           attribution) isn't covered; the fixed toolbar fills the gap. */
+        #map-overlay #map { margin-bottom: var(--map-toolbar-h); }
+
+        /* Secondary actions become a fixed bottom toolbar in the thumb zone. */
+        .map-actions {
+          display: flex;
+          position: fixed; left: 0; right: 0; bottom: 0;
+          gap: 6px;
+          padding: 8px 10px calc(8px + env(safe-area-inset-bottom));
+          background: var(--bg);
+          border-top: 1px solid var(--line);
+          z-index: 15;
+        }
+        .map-actions .map-pop-wrap { flex: 1; display: flex; }
+        .map-actions .map-pop-wrap > button,
+        .map-actions > #map-filter {
+          flex: 1; width: 100%;
+          min-height: 44px;
+          font-size: 13px;
+          white-space: nowrap;
           text-align: center;
         }
-        .map-pop-wrap { flex: 1; }
-        .map-pop-wrap button { width: 100%; }
 
-        /* Popovers: full-width bottom sheet on mobile */
+        /* Basemap / Download render as bottom sheets sitting on the toolbar.
+           The single-open controller (map.ts) guarantees only one shows. */
         .map-popover {
           position: fixed;
-          left: 0; right: 0; bottom: 0;
-          top: auto;
+          left: 0; right: 0; top: auto;
+          bottom: var(--map-toolbar-h);
           width: 100%;
-          max-height: 60vh;
+          max-height: 52vh;
           border-radius: 14px 14px 0 0;
-          box-shadow: 0 -8px 24px rgba(0,0,0,0.15);
-          z-index: 20;
+          box-shadow: 0 -8px 24px rgba(0,0,0,0.18);
+          z-index: 16;
           overflow-y: auto;
         }
+
+        /* Scrim is shown only while a sheet is open (toggled in map.ts). */
+        .map-scrim.open { display: block; }
       }
 
       /* Map popups are a single look — fed by hover on pointer devices and
@@ -797,18 +829,21 @@
     <div id="map-overlay" aria-hidden="true">
       <header class="map-bar">
         <span class="map-title" id="map-title">map</span>
-        <div class="map-pop-wrap">
-          <button class="filter-toggle" id="map-basemap" aria-label="Choose base map" aria-expanded="false" aria-haspopup="menu">Base map</button>
-          <div class="map-popover" id="map-basemap-popover" role="menu"></div>
+        <div class="map-actions">
+          <div class="map-pop-wrap">
+            <button class="filter-toggle" id="map-basemap" aria-label="Choose base map" aria-expanded="false" aria-haspopup="menu">Base map</button>
+            <div class="map-popover" id="map-basemap-popover" role="menu"></div>
+          </div>
+          <div class="map-pop-wrap">
+            <button class="filter-toggle" id="map-download" aria-label="Download this layer" aria-expanded="false" aria-haspopup="menu">Download</button>
+            <div class="map-popover" id="map-download-popover" role="menu"></div>
+          </div>
+          <button class="filter-toggle" id="map-filter">Filter &amp; export</button>
         </div>
-        <div class="map-pop-wrap">
-          <button class="filter-toggle" id="map-download" aria-label="Download this layer" aria-expanded="false" aria-haspopup="menu">Download</button>
-          <div class="map-popover" id="map-download-popover" role="menu"></div>
-        </div>
-        <button class="filter-toggle" id="map-filter">Filter &amp; export</button>
         <button class="close" id="map-close">← back</button>
       </header>
       <div id="map"><div id="map-loading">loading map…</div></div>
+      <div class="map-scrim" id="map-scrim" aria-hidden="true"></div>
     </div>
 
     <!-- CATALOG_INLINE -->

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -625,9 +625,13 @@
       @media (max-width: 640px) {
         /* Height of the fixed bottom toolbar; sheets sit on top of it. */
         #map-overlay { --map-toolbar-h: calc(60px + env(safe-area-inset-bottom)); }
-        /* Filter panel becomes a bottom sheet, above the toolbar */
+        /* Filter panel becomes a bottom sheet. It's position:absolute inside
+           #map, which already has margin-bottom = toolbar height, so bottom:0
+           seats it flush on the toolbar. (Using var(--map-toolbar-h) here would
+           double-count that reservation and leave a ~60px gap — unlike the
+           popover, which is position:fixed against the viewport.) */
         .filter-panel {
-          top: auto; left: 0; right: 0; bottom: var(--map-toolbar-h);
+          top: auto; left: 0; right: 0; bottom: 0;
           width: 100%; height: 52vh;
           border-left: none;
           border-top: 1px solid var(--line);

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -694,17 +694,23 @@
           display: flex;
           position: fixed; left: 0; right: 0; bottom: 0;
           gap: 6px;
-          padding: 8px 10px calc(8px + env(safe-area-inset-bottom));
+          padding: 8px 8px calc(8px + env(safe-area-inset-bottom));
           background: var(--bg);
           border-top: 1px solid var(--line);
           z-index: 15;
         }
         .map-actions .map-pop-wrap { flex: 1; display: flex; }
-        .map-actions .map-pop-wrap > button,
-        .map-actions > #map-filter {
+        /* #map-overlay-prefixed so these win over the id-specificity desktop
+           rules (#map-overlay button.filter-toggle { font: inherit; padding }).
+           12px + tight padding shrinks "Filter & export" so it sits comfortably
+           inside its grown flex slot at >=360px (content-sized, no min-width:0,
+           so no ellipsis) and can't spill past the button to clip at the edge. */
+        #map-overlay .map-actions .map-pop-wrap > button,
+        #map-overlay .map-actions > #map-filter {
           flex: 1; width: 100%;
           min-height: 44px;
-          font-size: 13px;
+          font-size: 12px;
+          padding: 6px 8px;
           white-space: nowrap;
           text-align: center;
         }

--- a/web/src/catalog.ts
+++ b/web/src/catalog.ts
@@ -35,8 +35,20 @@ export type LayerFilterStats = {
   column_groups?: Array<{ canonical: string; members: string[] }>;
 };
 
+/** Per-layer (or per-level) display metadata. Inlined in the page catalog so
+ *  the viewer can resolve a friendly title without a network round-trip. The
+ *  edge (functions/lib/view-dataset.ts) reads the same field for /view SEO. */
+export type LevelMeta = {
+  label?: string;
+  seo_title?: string;
+  unit?: string;
+  description?: string;
+  seo_description?: string;
+};
+
 export type Catalog = {
   layers?: Layer[];
+  level_meta?: Record<string, LevelMeta>;
   states?: Array<{ code: number; name: string }>;
   state_counts?: Record<string, Record<string, number>>;
   state_bounds?: Record<string, [number, number, number, number]>;

--- a/web/src/layer-display.ts
+++ b/web/src/layer-display.ts
@@ -1,0 +1,34 @@
+// Human-facing title for the /view map chrome.
+//
+// Mirrors the edge resolution in functions/lib/view-dataset.ts
+// (buildViewDataset's `title`): seo_title > label > name > prettified id.
+// The two are deliberately separate copies — the edge builds <title>/<h1> for
+// crawlers, this builds the in-app map-bar label — so keep them in sync when
+// the precedence changes.
+//
+// Why this exists: map.ts used to set the bar to the raw layer id, so ward
+// pages read "wards_..." (truncated) on mobile. These layers carry an
+// seo_title in catalog.level_meta; resolve through it for a friendly label.
+
+export type DisplayLayer = { id: string; name?: string | null };
+export type DisplayLevelMeta =
+  | { seo_title?: string | null; label?: string | null }
+  | null
+  | undefined;
+
+/** "wards_bengaluru_bbmp_2022" -> "wards bengaluru bbmp 2022". Last-resort
+ *  fallback when a layer has neither level meta nor a display name. */
+export function prettifyId(id: string): string {
+  return id.replace(/_/g, ' ').trim();
+}
+
+const clean = (s: string | null | undefined): string => (s ?? '').trim();
+
+export function displayTitle(layer: DisplayLayer, levelMeta?: DisplayLevelMeta): string {
+  return (
+    clean(levelMeta?.seo_title) ||
+    clean(levelMeta?.label) ||
+    clean(layer.name) ||
+    prettifyId(layer.id)
+  );
+}

--- a/web/src/map-padding.ts
+++ b/web/src/map-padding.ts
@@ -1,0 +1,25 @@
+// Pure decision for how the map should be padded while the Filter & export
+// panel is open, so the fitted data frames clear of the panel.
+//
+// Detect the panel kind by WIDTH relative to the viewport: a full-width panel
+// is the mobile bottom sheet (reserve vertical room below the data); a narrow
+// panel is the desktop right drawer (reserve room on the right). Keyed off
+// width, not the sheet's bottom edge — the sheet floats above the bottom
+// toolbar on mobile, so a "touches the viewport bottom" test would misclassify
+// it as a side drawer and pad the right by the full panel width, which exceeds
+// the canvas and trips MapLibre's "cannot fit within canvas" warning.
+//
+// Extracted from map.ts so it unit-tests without importing MapLibre.
+
+export type Padding = { top: number; bottom: number; left: number; right: number };
+
+export function paddingForPanelRect(
+  r: { width: number; height: number },
+  vw: number,
+  base = 20,
+): Padding {
+  if (r.width >= vw * 0.7) {
+    return { top: base, bottom: base + r.height, left: base, right: base };
+  }
+  return { top: base, bottom: base, left: base, right: base + r.width };
+}

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -13,6 +13,7 @@ import { type ActiveFilter, type MaplibreFilter } from './filter-where';
 import { featureCollectionBounds, type FC } from './validate';
 import { reduceOverlay, initialOverlayState, type OverlayState, type OverlayAction, type Surface } from './view-overlays';
 import { displayTitle } from './layer-display';
+import { paddingForPanelRect, type Padding } from './map-padding';
 
 type Layer = {
   id: string;
@@ -176,17 +177,12 @@ function snapToIndiaIfLarge(bounds: [number, number, number, number]): [number, 
 }
 
 
-function panelAwarePadding(): { top: number; bottom: number; left: number; right: number } {
+function panelAwarePadding(): Padding {
   const base = 20;
   const panel = document.querySelector<HTMLElement>('.filter-panel');
   if (!panel) return { top: base, bottom: base, left: base, right: base };
   const r = panel.getBoundingClientRect();
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
-  if (r.bottom >= vh - 1 && r.width >= vw * 0.7) {
-    return { top: base, bottom: base + r.height, left: base, right: base };
-  }
-  return { top: base, bottom: base, left: base, right: base + r.width };
+  return paddingForPanelRect(r, window.innerWidth, base);
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -11,6 +11,8 @@ import { embedIframeHtml } from './embed-snippet';
 import { imageFilename, dataUrlToBlob, triggerDownload } from './image-export';
 import { type ActiveFilter, type MaplibreFilter } from './filter-where';
 import { featureCollectionBounds, type FC } from './validate';
+import { reduceOverlay, initialOverlayState, type OverlayState, type OverlayAction, type Surface } from './view-overlays';
+import { displayTitle } from './layer-display';
 
 type Layer = {
   id: string;
@@ -43,6 +45,92 @@ let map: MlMap | null = null;
 let filterAbort: AbortController | null = null;
 let activeBasemap: BasemapId = 'minimal';
 let layerBounds: [number, number, number, number] = INDIA_BOUNDS;
+
+// ---------------------------------------------------------------------------
+// Single-open overlay controller
+// ---------------------------------------------------------------------------
+//
+// The map chrome has three secondary surfaces — basemap picker, download menu,
+// filter/export — that used to toggle independently, so on mobile (where each
+// is a bottom sheet) opening one left the others stacked behind it. The pure
+// reducer in view-overlays.ts is the single source of truth for which surface
+// is open; this DOM layer applies that state. See spec-view-mobile-controls.md.
+
+type SurfaceHandle = { btn: HTMLElement | null; show: () => void; hide: () => void };
+const surfaceHandles: Partial<Record<Surface, SurfaceHandle>> = {};
+let overlayState: OverlayState = initialOverlayState;
+
+const isMobileViewport = (): boolean =>
+  typeof window !== 'undefined' && window.matchMedia('(max-width: 640px)').matches;
+
+function applyOverlay(prevActive: Surface | null): void {
+  const active = overlayState.active;
+  if (prevActive && prevActive !== active) surfaceHandles[prevActive]?.hide();
+  if (active) surfaceHandles[active]?.show();
+  document.getElementById('map-scrim')?.classList.toggle('open', active !== null);
+  for (const name of Object.keys(surfaceHandles) as Surface[]) {
+    surfaceHandles[name]?.btn?.setAttribute('aria-expanded', String(name === active));
+  }
+  map?.resize();
+}
+
+function dispatchOverlay(action: OverlayAction): void {
+  const next = reduceOverlay(overlayState, action);
+  if (next === overlayState) return;
+  const prev = overlayState.active;
+  overlayState = next;
+  applyOverlay(prev);
+}
+
+function resetOverlays(): void {
+  const prev = overlayState.active;
+  overlayState = initialOverlayState;
+  if (prev) surfaceHandles[prev]?.hide();
+  document.getElementById('map-scrim')?.classList.remove('open');
+}
+
+// A surface that dismisses itself (e.g. the filter panel's own close button)
+// tells the controller so without re-triggering its hide(): the DOM is already
+// gone, we just clear the state + chrome.
+function notifyOverlayClosed(name: Surface): void {
+  if (overlayState.active !== name) return;
+  overlayState = initialOverlayState;
+  document.getElementById('map-scrim')?.classList.remove('open');
+  surfaceHandles[name]?.btn?.setAttribute('aria-expanded', 'false');
+}
+
+// Outside-click dismisses the transient menus (basemap / download). Buttons and
+// popovers stopPropagation, so this only fires on a true outside click. The
+// filter panel and the scrim manage their own dismissal.
+document.addEventListener(
+  'click',
+  () => {
+    if (overlayState.active === 'basemap' || overlayState.active === 'download') {
+      dispatchOverlay({ type: 'close' });
+    }
+  },
+  { passive: true },
+);
+// Tapping the scrim (mobile) closes whatever sheet is open.
+document.getElementById('map-scrim')?.addEventListener('click', () =>
+  dispatchOverlay({ type: 'close' }),
+);
+
+// Register a popover-style surface (basemap, download). The button toggles it;
+// returns a close fn for callers that complete an action and want to dismiss.
+function registerPopover(name: Surface, btn: HTMLButtonElement, popover: HTMLElement): () => void {
+  surfaceHandles[name] = {
+    btn,
+    show: () => popover.classList.add('open'),
+    hide: () => popover.classList.remove('open'),
+  };
+  btn.onclick = (e) => {
+    e.stopPropagation();
+    dispatchOverlay({ type: 'toggle', surface: name });
+  };
+  popover.onclick = (e) => e.stopPropagation();
+  return () => dispatchOverlay({ type: 'close' });
+}
 
 // ---------------------------------------------------------------------------
 // PMTiles protocol + archive cache
@@ -437,29 +525,6 @@ function applyActiveFilters(
 }
 
 // ---------------------------------------------------------------------------
-// Popover helper
-// ---------------------------------------------------------------------------
-
-function bindPopover(btn: HTMLButtonElement, popover: HTMLElement): () => void {
-  const close = () => {
-    popover.classList.remove('open');
-    btn.setAttribute('aria-expanded', 'false');
-  };
-  const open = () => {
-    for (const p of document.querySelectorAll('.map-popover.open')) p.classList.remove('open');
-    popover.classList.add('open');
-    btn.setAttribute('aria-expanded', 'true');
-  };
-  btn.onclick = (e) => {
-    e.stopPropagation();
-    popover.classList.contains('open') ? close() : open();
-  };
-  popover.onclick = (e) => e.stopPropagation();
-  document.addEventListener('click', close, { passive: true });
-  return close;
-}
-
-// ---------------------------------------------------------------------------
 // Header button wiring
 // ---------------------------------------------------------------------------
 
@@ -536,7 +601,7 @@ function wireDownloadButton(layer: Layer): void {
       }
     }
   });
-  bindPopover(btn, popover);
+  registerPopover('download', btn, popover);
 }
 
 function wireBasemapButton(): void {
@@ -544,7 +609,7 @@ function wireBasemapButton(): void {
   const popover = document.getElementById('map-basemap-popover');
   if (!btn || !popover) return;
   btn.classList.add('shown');
-  const closePopover = bindPopover(btn, popover);
+  const closePopover = registerPopover('basemap', btn, popover);
   const render = () => {
     popover.innerHTML =
       `<div class="map-popover__title">Base map</div>` +
@@ -577,6 +642,7 @@ async function wireFilterButton(layer: Layer) {
   filterAbort = new AbortController();
   const signal = filterAbort.signal;
 
+  delete surfaceHandles.filter;
   btn.classList.remove('shown');
   document.querySelector('.filter-panel')?.remove();
   if (!layer.parquet?.url) return;
@@ -593,56 +659,87 @@ async function wireFilterButton(layer: Layer) {
       : (cb) => setTimeout(cb, 1500);
   idle(() => import('./filter'));
 
+  const resetFilterChrome = () => {
+    btn.disabled = false;
+    btn.textContent = 'Filter & export';
+    applyActiveFilters([], null);
+    flyTo(layerBounds, { padding: BASE_PADDING });
+  };
+
+  // Switching surfaces on mobile tears the sheet down (direct removal mirrors
+  // closeLayer); the user's filters reset, same as the panel's own close.
+  const dismissFilterPanel = () => {
+    if (!document.querySelector('.filter-panel')) return;
+    document.querySelector('.filter-panel')?.remove();
+    resetFilterChrome();
+  };
+
+  const openFilterPanel = async () => {
+    if (document.querySelector('.filter-panel')) return; // already open
+    const container = document.getElementById('map')!;
+
+    const { VERBS_ENGINE } = await import('./loading');
+    const panel = document.createElement('div');
+    panel.className = 'filter-panel';
+    panel.innerHTML = `<div style="padding:24px;color:var(--muted);font-size:14px"></div>`;
+    container.appendChild(panel);
+    const msg = panel.firstElementChild!;
+    let vi = 0;
+    msg.textContent = VERBS_ENGINE[0];
+    const timer = setInterval(() => { msg.textContent = VERBS_ENGINE[++vi % VERBS_ENGINE.length]; }, 1800);
+
+    const result = await columnsPromise;
+    clearInterval(timer);
+    panel.remove();
+    if (signal.aborted || !result) {
+      notifyOverlayClosed('filter');
+      return;
+    }
+
+    const { columns: ranked, rowCount } = result;
+    btn.disabled = true;
+    btn.textContent = 'Loading…';
+    try {
+      const { mountFilterPanel } = await import('./filter');
+      if (signal.aborted) {
+        notifyOverlayClosed('filter');
+        return;
+      }
+      mountFilterPanel(layer, container, ranked, rowCount, {
+        onClose: () => {
+          resetFilterChrome();
+          notifyOverlayClosed('filter');
+        },
+        onActiveFiltersChange: (filters, mapFilter) => {
+          applyActiveFilters(filters, mapFilter);
+        },
+      });
+      if (map) {
+        requestAnimationFrame(() => {
+          flyTo(layerBounds, { padding: panelAwarePadding(), duration: 300 });
+        });
+      }
+    } catch (e) {
+      console.error('filter panel failed to load', e);
+    } finally {
+      btn.disabled = false;
+      btn.textContent = 'Filter & export';
+    }
+  };
+
+  // The filter panel is a persistent workspace, not a transient menu: on
+  // desktop it coexists with the basemap/download dropdowns (hide is a no-op,
+  // matching today). On mobile every surface is a bottom sheet competing for
+  // the same space, so switching away tears it down.
+  surfaceHandles.filter = {
+    btn,
+    show: () => { void openFilterPanel(); },
+    hide: () => { if (isMobileViewport()) dismissFilterPanel(); },
+  };
+
   btn.addEventListener(
     'click',
-    async () => {
-      if (document.querySelector('.filter-panel')) return;
-      const container = document.getElementById('map')!;
-
-      const { VERBS_ENGINE } = await import('./loading');
-      const panel = document.createElement('div');
-      panel.className = 'filter-panel';
-      panel.innerHTML = `<div style="padding:24px;color:var(--muted);font-size:14px"></div>`;
-      container.appendChild(panel);
-      const msg = panel.firstElementChild!;
-      let vi = 0;
-      msg.textContent = VERBS_ENGINE[0];
-      const timer = setInterval(() => { msg.textContent = VERBS_ENGINE[++vi % VERBS_ENGINE.length]; }, 1800);
-
-      const result = await columnsPromise;
-      clearInterval(timer);
-      panel.remove();
-      if (signal.aborted || !result) return;
-
-      const { columns: ranked, rowCount } = result;
-      btn.disabled = true;
-      btn.textContent = 'Loading…';
-      try {
-        const { mountFilterPanel } = await import('./filter');
-        if (signal.aborted) return;
-        mountFilterPanel(layer, container, ranked, rowCount, {
-          onClose: () => {
-            btn.disabled = false;
-            btn.textContent = 'Filter & export';
-            applyActiveFilters([], null);
-            flyTo(layerBounds, { padding: BASE_PADDING });
-          },
-          onActiveFiltersChange: (filters, mapFilter) => {
-            applyActiveFilters(filters, mapFilter);
-          },
-        });
-        if (map) {
-          requestAnimationFrame(() => {
-            flyTo(layerBounds, { padding: panelAwarePadding(), duration: 300 });
-          });
-        }
-      } catch (e) {
-        console.error('filter panel failed to load', e);
-      } finally {
-        btn.disabled = false;
-        btn.textContent = 'Filter & export';
-      }
-    },
+    () => dispatchOverlay({ type: 'toggle', surface: 'filter' }),
     { signal },
   );
 }
@@ -652,18 +749,25 @@ async function wireFilterButton(layer: Layer) {
 // ---------------------------------------------------------------------------
 
 export async function openLayer(layerId: string, opts: { titleEl: HTMLElement }) {
-  const cat = (await getCatalog()) as { layers?: Layer[] };
+  resetOverlays();
+  const cat = (await getCatalog()) as { layers?: Layer[]; level_meta?: Record<string, { label?: string; seo_title?: string }> };
   const layer = cat.layers?.find((l) => l.id === layerId);
   if (!layer) {
     opts.titleEl.textContent = `unknown layer: ${layerId}`;
     return;
   }
-  // Community layers have no admin level; lead with their submitted name so
-  // the viewer header reads sensibly instead of "undefined · …".
+  // Prefer the friendly title from level_meta (e.g. "Greater Bengaluru Wards
+  // (2025)") so the bar never shows a raw id like "wards_bengaluru_gba". Layers
+  // without a level_meta entry (most standard admin levels resolve theirs only
+  // on the edge via BUILTIN_LEVEL_META) keep the level · source · rows line.
+  const levelMeta = cat.level_meta?.[layerId];
   const rowsLabel = layer.rows?.toLocaleString('en-IN') ?? '—';
-  opts.titleEl.textContent = layer.level
-    ? `${layer.level} · ${layer.source} · ${rowsLabel} rows`
-    : `${layer.name ?? layer.source} · ${rowsLabel} features`;
+  const friendly = (levelMeta?.label || levelMeta?.seo_title || layer.name || '').trim();
+  opts.titleEl.textContent = friendly
+    ? displayTitle({ id: layerId, name: layer.name }, levelMeta)
+    : layer.level
+      ? `${layer.level} · ${layer.source} · ${rowsLabel} rows`
+      : `${layer.source} · ${rowsLabel} features`;
 
   wireFilterButton(layer).catch((e) => console.warn('wireFilterButton failed', e));
   wireDownloadButton(layer);
@@ -711,6 +815,7 @@ export function closeLayer() {
   }
   filterAbort?.abort();
   filterAbort = null;
+  resetOverlays();
   const btn = document.getElementById('map-filter') as HTMLButtonElement | null;
   if (btn) btn.classList.remove('shown');
   document.querySelector('.filter-panel')?.remove();

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -69,6 +69,10 @@ function applyOverlay(prevActive: Surface | null): void {
   if (prevActive && prevActive !== active) surfaceHandles[prevActive]?.hide();
   if (active) surfaceHandles[active]?.show();
   document.getElementById('map-scrim')?.classList.toggle('open', active !== null);
+  // `sheet-open` hides MapLibre's control layer on mobile so the attribution +
+  // zoom controls don't paint over the open sheet (their stacking context
+  // fights the fixed sheet). See the max-width:640px block in the template.
+  document.getElementById('map-overlay')?.classList.toggle('sheet-open', active !== null);
   for (const name of Object.keys(surfaceHandles) as Surface[]) {
     surfaceHandles[name]?.btn?.setAttribute('aria-expanded', String(name === active));
   }
@@ -88,6 +92,7 @@ function resetOverlays(): void {
   overlayState = initialOverlayState;
   if (prev) surfaceHandles[prev]?.hide();
   document.getElementById('map-scrim')?.classList.remove('open');
+  document.getElementById('map-overlay')?.classList.remove('sheet-open');
 }
 
 // A surface that dismisses itself (e.g. the filter panel's own close button)
@@ -97,6 +102,7 @@ function notifyOverlayClosed(name: Surface): void {
   if (overlayState.active !== name) return;
   overlayState = initialOverlayState;
   document.getElementById('map-scrim')?.classList.remove('open');
+  document.getElementById('map-overlay')?.classList.remove('sheet-open');
   surfaceHandles[name]?.btn?.setAttribute('aria-expanded', 'false');
 }
 

--- a/web/src/view-overlays.ts
+++ b/web/src/view-overlays.ts
@@ -1,0 +1,37 @@
+// Single-open overlay state for the /view map chrome.
+//
+// The map viewer has three secondary surfaces — basemap picker, filter/export,
+// download menu — plus a reserved slot for the Find-my-ward FAB (Step 1). They
+// used to toggle independently, so on mobile opening one left the others
+// stacked behind it. This reducer makes "which surface is open" a single source
+// of truth: exactly one, or none, is ever active.
+//
+// Pure on purpose. The DOM controller that applies this state (open classes,
+// scrim, focus, map.resize) lives in map.ts where the elements are; this module
+// is just the state machine so it unit-tests without a browser.
+
+export type Surface = 'basemap' | 'filter' | 'download' | 'findward';
+
+export type OverlayState = { active: Surface | null };
+
+export type OverlayAction =
+  | { type: 'open'; surface: Surface }
+  | { type: 'toggle'; surface: Surface }
+  | { type: 'close' };
+
+export const initialOverlayState: OverlayState = { active: null };
+
+export function reduceOverlay(state: OverlayState, action: OverlayAction): OverlayState {
+  switch (action.type) {
+    case 'open':
+      // Idempotent: re-opening the active surface returns the same reference so
+      // subscribers can skip a needless re-render.
+      return state.active === action.surface ? state : { active: action.surface };
+    case 'toggle':
+      return { active: state.active === action.surface ? null : action.surface };
+    case 'close':
+      return state.active === null ? state : { active: null };
+    default:
+      return state;
+  }
+}

--- a/web/tests/layer-display.test.ts
+++ b/web/tests/layer-display.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { displayTitle, prettifyId } from '../src/layer-display';
+
+// The /view map chrome currently shows the raw layer id ("wards_..."),
+// truncated, which reads as broken on mobile. displayTitle resolves the same
+// human title the edge uses (functions/lib/view-dataset.ts buildViewDataset):
+// seo_title > label > name > prettified id. Keep the two in sync.
+
+describe('prettifyId', () => {
+  it('turns an underscored id into spaced words', () => {
+    expect(prettifyId('lgd_states')).toBe('lgd states');
+    expect(prettifyId('wards_bengaluru_bbmp_2022')).toBe('wards bengaluru bbmp 2022');
+  });
+
+  it('leaves an already-clean id alone', () => {
+    expect(prettifyId('airports')).toBe('airports');
+  });
+});
+
+describe('displayTitle (precedence mirrors the edge buildViewDataset title)', () => {
+  it('prefers seo_title above everything', () => {
+    expect(
+      displayTitle(
+        { id: 'wards_bengaluru_bbmp_2022', name: 'BBMP wards' },
+        { seo_title: 'Bengaluru Ward Map', label: 'Wards' },
+      ),
+    ).toBe('Bengaluru Ward Map');
+  });
+
+  it('falls back to label when seo_title is absent', () => {
+    expect(displayTitle({ id: 'lgd_states' }, { label: 'States (2024)' })).toBe('States (2024)');
+  });
+
+  it('falls back to the layer name when there is no level meta', () => {
+    expect(displayTitle({ id: 'c_ab12', name: 'Goa Landuse Zones' })).toBe('Goa Landuse Zones');
+  });
+
+  it('falls back to the prettified id when nothing else is set', () => {
+    expect(displayTitle({ id: 'wards_vadodara' })).toBe('wards vadodara');
+  });
+
+  it('treats blank / whitespace-only fields as absent and falls through', () => {
+    expect(
+      displayTitle({ id: 'wards_surat', name: 'Surat Wards' }, { seo_title: '   ', label: '' }),
+    ).toBe('Surat Wards');
+  });
+
+  it('gives a ward layer a friendly title, never the raw id', () => {
+    const title = displayTitle(
+      { id: 'wards_ahmedabad', name: 'Ahmedabad Wards' },
+      { seo_title: 'Ahmedabad Ward Map', label: 'Wards' },
+    );
+    expect(title).toBe('Ahmedabad Ward Map');
+    expect(title).not.toContain('_');
+  });
+});

--- a/web/tests/map-padding.test.ts
+++ b/web/tests/map-padding.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { paddingForPanelRect } from '../src/map-padding';
+
+// The viewer re-frames the map when the Filter & export panel is open, padding
+// the side the panel occupies. The mobile bottom sheet is full-width; the
+// desktop drawer is narrow on the right. Detect by WIDTH — an earlier version
+// keyed off the sheet touching the viewport bottom, but once the sheet floats
+// above the bottom toolbar that test misfired and padded the RIGHT by the full
+// panel width (wider than the canvas), tripping MapLibre's "cannot fit within
+// canvas" warning. Regression guard for that.
+
+describe('paddingForPanelRect', () => {
+  const base = 20;
+
+  it('no panel → uniform base padding', () => {
+    // width 0 is treated as "no occupying panel" by callers; helper still pads.
+    expect(paddingForPanelRect({ width: 0, height: 0 }, 390, base)).toEqual({
+      top: base, bottom: base, left: base, right: base,
+    });
+  });
+
+  it('full-width mobile bottom sheet → pads the BOTTOM by its height, never the right', () => {
+    const p = paddingForPanelRect({ width: 390, height: 440 }, 390, base);
+    expect(p).toEqual({ top: base, bottom: base + 440, left: base, right: base });
+    // The bug was right = base + 390 (wider than the 390px canvas).
+    expect(p.right).toBe(base);
+  });
+
+  it('narrow desktop right drawer → pads the RIGHT by its width', () => {
+    expect(paddingForPanelRect({ width: 360, height: 600 }, 1100, base)).toEqual({
+      top: base, bottom: base, left: base, right: base + 360,
+    });
+  });
+
+  it('width at the 70%-of-viewport threshold counts as a bottom sheet', () => {
+    const p = paddingForPanelRect({ width: 280, height: 300 }, 400, base); // 280 === 0.7*400
+    expect(p.bottom).toBe(base + 300);
+    expect(p.right).toBe(base);
+  });
+
+  it('defaults base to 20 when omitted', () => {
+    expect(paddingForPanelRect({ width: 360, height: 600 }, 1100).right).toBe(20 + 360);
+  });
+});

--- a/web/tests/view-overlays.test.ts
+++ b/web/tests/view-overlays.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  reduceOverlay,
+  initialOverlayState,
+  type OverlayState,
+} from '../src/view-overlays';
+
+// The /view map chrome had three independently-toggled surfaces (basemap,
+// download, filter), so opening one left the others stacked behind it on
+// mobile. reduceOverlay makes "which surface is open" single-source-of-truth:
+// exactly one (or none) is ever active. This is the regression guard for the
+// stacking bug.
+
+describe('reduceOverlay', () => {
+  it('starts with nothing open', () => {
+    expect(initialOverlayState).toEqual({ active: null });
+  });
+
+  it('open(X) makes X the only active surface', () => {
+    expect(reduceOverlay(initialOverlayState, { type: 'open', surface: 'filter' })).toEqual({
+      active: 'filter',
+    });
+  });
+
+  it('opening a second surface closes the first (no stacking)', () => {
+    const filterOpen = reduceOverlay(initialOverlayState, { type: 'open', surface: 'filter' });
+    const basemapOpen = reduceOverlay(filterOpen, { type: 'open', surface: 'basemap' });
+    expect(basemapOpen).toEqual({ active: 'basemap' });
+  });
+
+  it('open(X) when X is already active is a no-op that keeps the same reference', () => {
+    const open: OverlayState = { active: 'download' };
+    expect(reduceOverlay(open, { type: 'open', surface: 'download' })).toBe(open);
+  });
+
+  it('toggle(X) opens X when closed and closes X when it is the active one', () => {
+    const opened = reduceOverlay(initialOverlayState, { type: 'toggle', surface: 'filter' });
+    expect(opened).toEqual({ active: 'filter' });
+    const closed = reduceOverlay(opened, { type: 'toggle', surface: 'filter' });
+    expect(closed).toEqual({ active: null });
+  });
+
+  it('toggle(Y) while X is open switches to Y (still single-open)', () => {
+    const filterOpen: OverlayState = { active: 'filter' };
+    expect(reduceOverlay(filterOpen, { type: 'toggle', surface: 'basemap' })).toEqual({
+      active: 'basemap',
+    });
+  });
+
+  it('close() clears whatever is open', () => {
+    const open: OverlayState = { active: 'basemap' };
+    expect(reduceOverlay(open, { type: 'close' })).toEqual({ active: null });
+  });
+
+  it('close() when nothing is open keeps the same reference (no needless render)', () => {
+    expect(reduceOverlay(initialOverlayState, { type: 'close' })).toBe(initialOverlayState);
+  });
+
+  it('reserves a findward surface for the Find-my-ward FAB (Step 1)', () => {
+    expect(reduceOverlay(initialOverlayState, { type: 'open', surface: 'findward' })).toEqual({
+      active: 'findward',
+    });
+  });
+});


### PR DESCRIPTION
## What

The `/view/<id>` map viewer was unusable on phones: the top action bar overflowed (back button clipped, labels wrapping mid-word), and its three secondary surfaces — basemap, download, filter — toggled independently, so opening one left the others stacked behind it.

This rebuilds the mobile control layer (`<=640px` only; **desktop untouched**):

- **Slim top bar** — back + a friendly layer title (e.g. "BBMP Ward Map: 243 wards (Bengaluru, 2022)" instead of `wards_bengaluru_bbmp_2022`), resolved from `level_meta` via a new pure `displayTitle` helper.
- **Bottom action toolbar** — Base map / Download / Filter & export move to a thumb-zone toolbar. They relocate via a `display:contents` → `position:fixed` swap, so the desktop bar is byte-identical.
- **Single-open sheets** — a pure reducer (`view-overlays.ts`) is the single source of truth for which surface is open; opening one closes the others. This is the fix for the stacking bug.
- Basemap / Download / Filter render as one consistent bottom-sheet metaphor above the toolbar.

## Sub-fixes found during QA

- Filter-panel padding heuristic mis-classified the floated sheet → MapLibre `cannot fit within canvas` warning. Extracted a pure `paddingForPanelRect` with tests.
- MapLibre attribution painted over open sheets (stacking-context fight) → hide the control layer while a sheet is open, restored on close.
- Sheet sat ~60px above the toolbar (double-counted the toolbar reservation) → seated flush.
- Toolbar label sizing was silently overridden by an id-specificity desktop rule → prefixed the mobile selector + 12px so all three labels fit cleanly at `>=360px`.

## Testing

- Red-green TDD: **22 new unit tests** (single-open reducer, title precedence, padding heuristic). Full suite **609 passing**.
- Headless-verified at 360 / 390 / 414 / desktop: no overflow, single-open works, no console warnings, attribution + flush sheet correct.
- Desktop chrome verified pixel-identical via the `display:contents` passthrough.

## Notes

- Scoped strictly to the `/view` mobile chrome — no change to desktop, the home page, `/preview`, `/c/[id]`, or embed mode.
- The implementation spec is at `supporting-docs/spec-view-mobile-controls.md` (that dir is gitignored repo-wide, so it's local-only).
- Find-my-ward FAB is documented as a follow-on that drops into the same single-open sheet system (reducer already reserves a `findward` surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)