### PR TITLE
feat(view): Find my location — geometry-aware per-layer locate (Step 1a)

### DIFF
--- a/web/functions/api/v1/layers/[id]/locate.ts
+++ b/web/functions/api/v1/layers/[id]/locate.ts
@@ -1,0 +1,95 @@
+// GET /api/v1/layers/{id}/locate?lat=..&lng=..[&mode=auto|contains|nearest]
+//
+// "Locate me in this layer." Geometry-branched:
+//   contains  — point-in-polygon over the layer's PMTiles (reuses lib/locate)
+//   nearest   — closest feature + distance + bearing (reuses lib/nearby)
+//   auto      — try contains (if the layer has pmtiles), else/empty -> nearest.
+//
+// The web client passes an explicit `mode` from the per-layer locate config
+// (polygon layers = contains, line/point = nearest); `auto` is the convenience
+// default for API/MCP callers who don't know the geometry. The result is
+// location-specific + privacy-sensitive, so it is never cached.
+
+import type { Env } from '../../../_middleware';
+import { loadCatalog } from '../../../../lib/catalog-loader';
+import { locate } from '../../../../lib/locate';
+import { nearby } from '../../../../lib/nearby';
+import { pickContains, bearingLabel } from '../../../../lib/locate-layer';
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  const id = (ctx.params as { id: string }).id;
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    return json(400, { error: 'Invalid layer ID', status: 400 });
+  }
+
+  const url = new URL(ctx.request.url);
+  const lat = parseFloat(url.searchParams.get('lat') || '');
+  const lng = parseFloat(url.searchParams.get('lng') || '');
+  if (Number.isNaN(lat) || Number.isNaN(lng)) {
+    return json(400, { error: 'lat and lng query params are required', status: 400 });
+  }
+  if (lat < 6 || lat > 38 || lng < 68 || lng > 98) {
+    return json(400, { error: 'lat must be 6-38, lng must be 68-98 (India bounding box)', status: 400 });
+  }
+
+  const mode = (url.searchParams.get('mode') || 'auto') as 'auto' | 'contains' | 'nearest';
+  const zoom = Math.min(Math.max(parseInt(url.searchParams.get('zoom') || '14', 10), 4), 16);
+  const radiusKm = Math.min(Math.max(parseFloat(url.searchParams.get('radius_km') || '25'), 1), 200);
+
+  const catalog = await loadCatalog(url.origin);
+  const layer = catalog.layers.find((l) => l.id === id);
+  if (!layer) return json(404, { error: 'Layer not found', status: 404 });
+
+  const base = { layer_id: id, point: { lat, lng } };
+
+  // CONTAINS — point-in-polygon. Tried unless the caller forced nearest.
+  if (mode !== 'nearest' && layer.pmtiles) {
+    try {
+      const resp = await locate(lat, lng, [id], zoom, catalog, ctx.env.R2);
+      const feature = pickContains(resp, id);
+      // A hit ends it. A miss ends it too when contains was explicit (so the UI
+      // can say "outside this layer's area" rather than jumping to a far-away
+      // nearest); in `auto` a miss falls through to nearest below.
+      if (feature || mode === 'contains') {
+        return ok({ ...base, mode: 'contains', feature });
+      }
+    } catch (e) {
+      if (mode === 'contains') return json(500, { error: (e as Error).message, status: 500 });
+      // auto: fall through to nearest
+    }
+  }
+
+  // NEAREST — closest feature within radius, with distance + compass bearing.
+  if (mode !== 'contains' && layer.parquet) {
+    try {
+      const r = await nearby(lat, lng, radiusKm, id, catalog, ctx.env.R2, 1);
+      const f = r.features[0];
+      if (!f) {
+        return ok({ ...base, mode: 'nearest', feature: null, out_of_coverage: true, searched_radius_km: radiusKm });
+      }
+      return ok({
+        ...base,
+        mode: 'nearest',
+        feature: { properties: f.properties },
+        distance_km: f._distance_km,
+        bearing: bearingLabel(lat, lng, f._lat, f._lng),
+      });
+    } catch (e) {
+      return json(400, { error: (e as Error).message, status: 400 });
+    }
+  }
+
+  // mode=contains with no pmtiles, mode=nearest with no parquet, or auto with
+  // neither queryable surface: nothing to locate against.
+  return ok({ ...base, mode: mode === 'auto' ? 'contains' : mode, feature: null });
+};
+
+function ok(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json', 'cache-control': 'private, no-store' },
+  });
+}
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}

--- a/web/functions/lib/locate-layer.ts
+++ b/web/functions/lib/locate-layer.ts
@@ -1,0 +1,45 @@
+// Pure helpers behind GET /api/v1/layers/{id}/locate (find-my-location).
+//
+// The endpoint composes two existing engines — `locate` (contains: point-in-
+// polygon over PMTiles) and `nearby` (nearest: parquet bbox/centroid) — and
+// branches per layer geometry. These are the geometry-free bits: the compass
+// bearing rendered on a "nearest" result, and pulling a single layer's
+// containing feature out of the aggregate `locate` response (which groups hits
+// by category across many layers).
+
+import type { LocateResponse } from './locate';
+
+const COMPASS_8 = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'] as const;
+export type Compass = (typeof COMPASS_8)[number];
+
+/** Initial great-circle bearing from A to B, degrees clockwise from north (0-360). */
+export function compassBearing(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const phi1 = (lat1 * Math.PI) / 180;
+  const phi2 = (lat2 * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const y = Math.sin(dLng) * Math.cos(phi2);
+  const x = Math.cos(phi1) * Math.sin(phi2) - Math.sin(phi1) * Math.cos(phi2) * Math.cos(dLng);
+  return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+}
+
+/** Snap any degree value to the nearest of N/NE/E/SE/S/SW/W/NW. */
+export function compass8(deg: number): Compass {
+  const norm = ((deg % 360) + 360) % 360;
+  return COMPASS_8[Math.round(norm / 45) % 8];
+}
+
+export function bearingLabel(lat1: number, lng1: number, lat2: number, lng2: number): Compass {
+  return compass8(compassBearing(lat1, lng1, lat2, lng2));
+}
+
+/** The aggregate `locate` groups hits by category; find this layer's feature. */
+export function pickContains(
+  resp: LocateResponse,
+  layerId: string,
+): { properties: Record<string, unknown> } | null {
+  for (const hits of Object.values(resp.results)) {
+    const hit = hits.find((h) => h.layer_id === layerId);
+    if (hit) return hit.feature;
+  }
+  return null;
+}

--- a/web/functions/lib/security-headers.ts
+++ b/web/functions/lib/security-headers.ts
@@ -85,7 +85,7 @@ const SHARED = {
   'x-content-type-options': 'nosniff',
   'referrer-policy': 'strict-origin-when-cross-origin',
   'permissions-policy':
-    'camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()',
+    'camera=(), microphone=(), geolocation=(self), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()',
 } as const;
 
 /** Full block for HTML-rendering Pages Functions (/c/<id>, /view/<id>). */

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -426,6 +426,44 @@
       #map-overlay button.filter-toggle:hover { border-color: var(--accent); color: var(--accent); }
       #map-overlay button.filter-toggle[aria-expanded="true"] { border-color: var(--accent); color: var(--accent); }
 
+      /* Toolbar buttons carry an icon + a label. The desktop top bar shows the
+         label only (icon hidden) and reads exactly as before; the mobile bottom
+         toolbar (max-width:640px) stacks the icon over the label. */
+      .tbtn .tb-ico { display: none; }
+      .tbtn .tb-ico svg { width: 21px; height: 21px; display: block; }
+      .tb-pulse { display: none; position: absolute; inset: 0; }
+
+      /* Find-my-location result sheet. Hidden until JS opens it; a small fixed
+         card on desktop, a bottom sheet on mobile (see the 640px block). */
+      .locate-sheet { display: none; }
+      #map-overlay .locate-sheet.open {
+        display: block; position: absolute; left: 16px; bottom: 16px; z-index: 16;
+        width: min(340px, calc(100% - 32px));
+        background: var(--bg); border: 1px solid var(--line); border-radius: 12px;
+        box-shadow: 0 12px 36px rgba(0,0,0,0.18); padding: 16px 18px;
+      }
+      .ls-kicker { font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: var(--muted);
+        display: flex; align-items: center; gap: 7px; margin-bottom: 4px; }
+      .ls-kicker svg { width: 14px; height: 14px; color: var(--accent); flex: 0 0 auto; }
+      .ls-name { font-size: 20px; font-weight: 700; letter-spacing: -.02em; margin: 0 0 2px; line-height: 1.2; }
+      .ls-sub { color: var(--muted); margin: 0; font-size: 13px; }
+      .ls-dist { color: var(--accent); font-weight: 600; }
+      .ls-caveat { margin: 8px 0 0; font-size: 12px; color: var(--muted);
+        background: var(--card-bg); border-radius: 6px; padding: 8px 11px; }
+      .ls-actions { display: flex; gap: 8px; margin-top: 14px; }
+      .ls-actions button { flex: 1; min-height: 44px; cursor: pointer;
+        font: 600 13px/1 ui-sans-serif, system-ui, sans-serif; border-radius: 6px;
+        border: 1px solid var(--line); background: var(--bg); color: var(--fg); }
+      .ls-actions button:hover { border-color: var(--accent); color: var(--accent); }
+      .ls-actions button.primary { background: var(--accent-fill); border-color: var(--accent-fill); color: #fff; }
+      .ls-close { position: absolute; top: 8px; right: 12px; background: none; border: none;
+        color: var(--muted); font-size: 20px; line-height: 1; cursor: pointer; }
+      .ls-msg { color: var(--muted); font-size: 14px; }
+      .ls-spinner { display: inline-block; width: 14px; height: 14px; margin-right: 8px; vertical-align: -2px;
+        border: 2px solid var(--line); border-top-color: var(--accent); border-radius: 50%;
+        animation: ls-spin .8s linear infinite; }
+      @keyframes ls-spin { to { transform: rotate(360deg); } }
+
       /* Action group. display:contents on desktop is a passthrough — the
          buttons flow in the header exactly as before. On mobile (max-width:640px)
          it becomes the fixed bottom toolbar. */
@@ -700,19 +738,43 @@
           z-index: 15;
         }
         .map-actions .map-pop-wrap { flex: 1; display: flex; }
-        /* #map-overlay-prefixed so these win over the id-specificity desktop
-           rules (#map-overlay button.filter-toggle { font: inherit; padding }).
-           12px + tight padding shrinks "Filter & export" so it sits comfortably
-           inside its grown flex slot at >=360px (content-sized, no min-width:0,
-           so no ellipsis) and can't spill past the button to clip at the edge. */
-        #map-overlay .map-actions .map-pop-wrap > button,
-        #map-overlay .map-actions > #map-filter {
-          flex: 1; width: 100%;
-          min-height: 44px;
-          font-size: 12px;
-          padding: 6px 8px;
-          white-space: nowrap;
-          text-align: center;
+        /* All four toolbar items are icon-over-label, borderless, equal-width.
+           `#map-overlay ... button.tbtn` beats the id-specificity rules
+           `#map-overlay button.filter-toggle.shown { display:inline-block }`
+           and `{ font:inherit; padding }`, so display:flex + our sizing win. */
+        #map-overlay .map-actions > button.tbtn { flex: 1; }
+        #map-overlay .map-actions button.tbtn {
+          display: flex; flex-direction: column; align-items: center; justify-content: center;
+          gap: 3px; width: 100%; min-height: 48px;
+          border: none; background: transparent; padding: 4px 2px;
+          font-size: 11px; color: var(--fg); white-space: nowrap;
+        }
+        #map-overlay .map-actions button.tbtn .tb-ico { display: grid; place-items: center; position: relative; }
+        #map-overlay .map-actions button.tbtn .tb-ico svg { color: var(--muted); }
+        #map-overlay .map-actions button.tbtn:hover { background: var(--card-bg); }
+        #map-overlay .map-actions button.tbtn:hover .tb-ico svg,
+        #map-overlay .map-actions button.tbtn[aria-expanded="true"] .tb-ico svg { color: var(--accent); }
+        #map-overlay .map-actions button.tbtn[aria-expanded="true"] { color: var(--accent); }
+
+        /* locate radar ping while geolocating */
+        #map-locate.locating .tb-ico svg { color: var(--accent); }
+        #map-locate.locating .tb-pulse { display: block; }
+        #map-locate.locating .tb-pulse::before,
+        #map-locate.locating .tb-pulse::after {
+          content: ""; position: absolute; left: 50%; top: 50%; width: 18px; height: 18px; margin: -9px;
+          border-radius: 50%; border: 2px solid var(--accent);
+          animation: tb-ping 1.3s ease-out infinite;
+        }
+        #map-locate.locating .tb-pulse::after { animation-delay: .65s; }
+        @keyframes tb-ping { 0% { transform: scale(.35); opacity: .9; } 100% { transform: scale(2.4); opacity: 0; } }
+
+        /* locate result sheet → bottom sheet above the toolbar */
+        #map-overlay .locate-sheet.open {
+          left: 0; right: 0; bottom: var(--map-toolbar-h); width: 100%;
+          border: none; border-top: 1px solid var(--line);
+          border-radius: 14px 14px 0 0; box-shadow: 0 -8px 24px rgba(0,0,0,0.18);
+          padding: 14px 18px calc(18px + env(safe-area-inset-bottom));
+          animation: filter-slide-up 220ms ease;
         }
 
         /* Basemap / Download render as bottom sheets sitting on the toolbar.
@@ -847,19 +909,21 @@
         <span class="map-title" id="map-title">map</span>
         <div class="map-actions">
           <div class="map-pop-wrap">
-            <button class="filter-toggle" id="map-basemap" aria-label="Choose base map" aria-expanded="false" aria-haspopup="menu">Base map</button>
+            <button class="filter-toggle tbtn" id="map-basemap" aria-label="Choose base map" aria-expanded="false" aria-haspopup="menu"><span class="tb-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><path d="M12 3l9 5-9 5-9-5 9-5z"/><path d="M3 13l9 5 9-5"/></svg></span><span class="tb-label">Base map</span></button>
             <div class="map-popover" id="map-basemap-popover" role="menu"></div>
           </div>
           <div class="map-pop-wrap">
-            <button class="filter-toggle" id="map-download" aria-label="Download this layer" aria-expanded="false" aria-haspopup="menu">Download</button>
+            <button class="filter-toggle tbtn" id="map-download" aria-label="Download this layer" aria-expanded="false" aria-haspopup="menu"><span class="tb-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v11"/><path d="M8 11l4 4 4-4"/><path d="M4 19h16"/></svg></span><span class="tb-label">Download</span></button>
             <div class="map-popover" id="map-download-popover" role="menu"></div>
           </div>
-          <button class="filter-toggle" id="map-filter">Filter &amp; export</button>
+          <button class="filter-toggle tbtn" id="map-filter"><span class="tb-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"/></svg></span><span class="tb-label">Filter</span></button>
+          <button class="filter-toggle tbtn locate-btn" id="map-locate"><span class="tb-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><circle cx="12" cy="12" r="6.5"/><path d="M12 1.5v3M12 19.5v3M1.5 12h3M19.5 12h3"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/></svg><span class="tb-pulse" aria-hidden="true"></span></span><span class="tb-label">Locate</span></button>
         </div>
         <button class="close" id="map-close">← back</button>
       </header>
       <div id="map"><div id="map-loading">loading map…</div></div>
       <div class="map-scrim" id="map-scrim" aria-hidden="true"></div>
+      <div class="locate-sheet" id="locate-sheet" role="dialog" aria-modal="false" aria-hidden="true"></div>
     </div>
 
     <!-- CATALOG_INLINE -->

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -7,7 +7,7 @@
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()
+  Permissions-Policy: camera=(), microphone=(), geolocation=(self), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), interest-cohort=()
   Content-Security-Policy: default-src 'self'; script-src 'self' blob: https://cdn.jsdelivr.net https://challenges.cloudflare.com https://static.cloudflareinsights.com 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' blob: https://cdn.jsdelivr.net https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://challenges.cloudflare.com https://extensions.duckdb.org https://*.basemaps.cartocdn.com https://*.tile.opentopomap.org https://services.arcgisonline.com; img-src 'self' blob: data: https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://services.arcgisonline.com https://*.tile.opentopomap.org https://avatars.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'
 
 # Hashed Vite assets — safe to cache forever.

--- a/web/src/locate-config.ts
+++ b/web/src/locate-config.ts
@@ -1,0 +1,29 @@
+// Per-layer "Find my location" config: whether the locate item shows in the
+// bottom bar, its short toolbar label, and the spatial mode the endpoint should
+// use. Explicit per-layer config (curated `level_meta`, or a baked community
+// layer) wins; for Step 1a ward layers are auto-enabled as a built-in so the
+// feature lights up without a catalog change. 1b+ turns on more layers by
+// adding `locate_label` (+ optional `locate_mode`) to their level_meta — no code.
+
+export type LocateMode = 'contains' | 'nearest';
+export type LocateConfig = { label: string; mode: LocateMode };
+
+export type LocateLayer = { id: string; level?: string | null; name?: string | null };
+export type LocateLevelMeta =
+  | { locate_label?: string | null; locate_mode?: string | null }
+  | null
+  | undefined;
+
+const WARD_RE = /^wards_/;
+
+export function resolveLocateConfig(layer: LocateLayer, levelMeta?: LocateLevelMeta): LocateConfig | null {
+  const label = levelMeta?.locate_label?.trim();
+  if (label) {
+    return { label, mode: levelMeta?.locate_mode === 'nearest' ? 'nearest' : 'contains' };
+  }
+  // 1a built-in: ward layers (id or level starts with "wards_") = contains.
+  if (WARD_RE.test(layer.id) || (layer.level != null && WARD_RE.test(layer.level))) {
+    return { label: 'My ward', mode: 'contains' };
+  }
+  return null;
+}

--- a/web/src/locate-format.ts
+++ b/web/src/locate-format.ts
@@ -1,0 +1,27 @@
+// Pure formatting for the Find-my-location result sheet (no DOM).
+//
+// pickFeatureName turns a generic feature's properties into a human title.
+// Column names vary per layer, so it's best-effort: a name column wins, then a
+// ward/number column rendered as "Ward N", then the first usable string.
+
+const JUNK_KEY = /^_|geom|shape_|shape\.|st_area|st_perimeter|objectid|ogc_fid|\bfid\b|^id$|simptol|simpgnflag/i;
+
+const clean = (v: unknown): string => (v == null ? '' : String(v)).trim();
+
+export function pickFeatureName(props: Record<string, unknown>): string {
+  const entries = Object.entries(props).filter(([k, v]) => !JUNK_KEY.test(k) && clean(v) !== '');
+
+  // 1. a "name" column (textual, not a bare numeric code)
+  const named = entries.find(([k, v]) => /name/i.test(k) && typeof v !== 'number');
+  if (named) return clean(named[1]);
+
+  // 2. a ward / number column -> "Ward N"
+  const ward = entries.find(([k]) => /ward.*?(no|num|code)|^no$|number/i.test(k));
+  if (ward) return `Ward ${clean(ward[1])}`;
+
+  // 3. first usable string value
+  const str = entries.find(([, v]) => typeof v === 'string');
+  if (str) return clean(str[1]);
+
+  return 'Found';
+}

--- a/web/src/locate.ts
+++ b/web/src/locate.ts
@@ -1,0 +1,100 @@
+// Find-my-location flow: geolocate -> GET /api/v1/layers/{id}/locate -> render
+// the result in the #locate-sheet. Lazy-loaded by map.ts when the user taps the
+// Locate toolbar item; the result sheet is governed by the single-open overlay
+// controller (scrim + close), so this module only owns its own content.
+
+import { pickFeatureName } from './locate-format';
+import type { LocateConfig } from './locate-config';
+
+type LocateApiResponse = {
+  mode: 'contains' | 'nearest';
+  feature: { properties: Record<string, unknown> } | null;
+  distance_km?: number;
+  bearing?: string;
+  out_of_coverage?: boolean;
+};
+
+const esc = (s: string): string =>
+  s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c] as string);
+
+const PIN =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/></svg>';
+
+export function openLocate(opts: {
+  layerId: string;
+  config: LocateConfig;
+  sheet: HTMLElement;
+  btn: HTMLElement;
+  onClose: () => void;
+}): void {
+  const { layerId, config, sheet, btn, onClose } = opts;
+  sheet.classList.add('open');
+  sheet.setAttribute('aria-hidden', 'false');
+  const stopPulse = () => btn.classList.remove('locating');
+
+  const render = (html: string) => {
+    sheet.innerHTML = `<button class="ls-close" type="button" aria-label="Close">×</button>${html}`;
+    sheet.querySelector('.ls-close')?.addEventListener('click', onClose);
+  };
+  const msg = (t: string) => `<p class="ls-msg">${esc(t)}</p>`;
+  const kicker = (t: string) => `<div class="ls-kicker">${PIN}<span>${esc(t)}</span></div>`;
+
+  render(`<p class="ls-msg"><span class="ls-spinner"></span>Locating you…</p>`);
+
+  if (!('geolocation' in navigator)) {
+    stopPulse();
+    render(msg("Your browser doesn't support location."));
+    return;
+  }
+
+  navigator.geolocation.getCurrentPosition(
+    async (pos) => {
+      stopPulse();
+      const { latitude: lat, longitude: lng } = pos.coords;
+      try {
+        const r = await fetch(
+          `/api/v1/layers/${encodeURIComponent(layerId)}/locate?lat=${lat}&lng=${lng}&mode=${config.mode}`,
+        );
+        if (r.status === 400) {
+          // outside India bbox — the only 400 the endpoint returns for valid coords
+          render(kicker('Outside coverage') +
+            `<h2 class="ls-name">You're outside this layer's area</h2>` +
+            `<p class="ls-sub">This data covers India.</p>`);
+          return;
+        }
+        if (!r.ok) throw new Error(String(r.status));
+        renderResult((await r.json()) as LocateApiResponse);
+      } catch {
+        render(msg("Couldn't look that up — try again."));
+      }
+    },
+    (err) => {
+      stopPulse();
+      render(msg(err.code === err.PERMISSION_DENIED
+        ? 'Location permission denied. Allow it in your browser to use this.'
+        : "Couldn't get your location — try again outdoors."));
+    },
+    { enableHighAccuracy: true, timeout: 10000, maximumAge: 30000 },
+  );
+
+  function renderResult(data: LocateApiResponse) {
+    if (!data.feature) {
+      render(kicker(data.mode === 'nearest' ? 'Nothing nearby' : 'Not found') +
+        `<h2 class="ls-name">You're outside this layer's area</h2>` +
+        `<p class="ls-sub">No feature ${data.mode === 'nearest' ? 'within range' : 'contains your location'} here.</p>`);
+      return;
+    }
+    const name = pickFeatureName(data.feature.properties);
+    const sub = data.mode === 'nearest' && data.distance_km != null
+      ? `<p class="ls-sub"><span class="ls-dist">${data.distance_km} km${data.bearing ? ' ' + esc(data.bearing) : ''}</span></p>`
+      : '';
+    render(kicker(data.mode === 'nearest' ? 'Nearest to you' : 'You are here') +
+      `<h2 class="ls-name">${esc(name)}</h2>${sub}`);
+  }
+}
+
+export function closeLocate(sheet: HTMLElement): void {
+  sheet.classList.remove('open');
+  sheet.setAttribute('aria-hidden', 'true');
+  sheet.innerHTML = '';
+}

--- a/web/src/locate.ts
+++ b/web/src/locate.ts
@@ -5,6 +5,7 @@
 
 import { pickFeatureName } from './locate-format';
 import type { LocateConfig } from './locate-config';
+import { escapeHtml } from './util';
 
 type LocateApiResponse = {
   mode: 'contains' | 'nearest';
@@ -13,9 +14,6 @@ type LocateApiResponse = {
   bearing?: string;
   out_of_coverage?: boolean;
 };
-
-const esc = (s: string): string =>
-  s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c] as string);
 
 const PIN =
   '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/></svg>';
@@ -36,8 +34,13 @@ export function openLocate(opts: {
     sheet.innerHTML = `<button class="ls-close" type="button" aria-label="Close">×</button>${html}`;
     sheet.querySelector('.ls-close')?.addEventListener('click', onClose);
   };
-  const msg = (t: string) => `<p class="ls-msg">${esc(t)}</p>`;
-  const kicker = (t: string) => `<div class="ls-kicker">${PIN}<span>${esc(t)}</span></div>`;
+  const msg = (t: string) => `<p class="ls-msg">${escapeHtml(t)}</p>`;
+  // The result card is always kicker + name heading + optional sub line; only
+  // the copy changes (a hit, a miss, or "outside coverage"). nameHtml/subHtml
+  // are pre-escaped by the caller since each varies in what it wraps.
+  const result = (kickerText: string, nameHtml: string, subHtml = '') =>
+    render(`<div class="ls-kicker">${PIN}<span>${escapeHtml(kickerText)}</span></div>` +
+      `<h2 class="ls-name">${nameHtml}</h2>${subHtml}`);
 
   render(`<p class="ls-msg"><span class="ls-spinner"></span>Locating you…</p>`);
 
@@ -57,8 +60,7 @@ export function openLocate(opts: {
         );
         if (r.status === 400) {
           // outside India bbox — the only 400 the endpoint returns for valid coords
-          render(kicker('Outside coverage') +
-            `<h2 class="ls-name">You're outside this layer's area</h2>` +
+          result('Outside coverage', "You're outside this layer's area",
             `<p class="ls-sub">This data covers India.</p>`);
           return;
         }
@@ -78,18 +80,17 @@ export function openLocate(opts: {
   );
 
   function renderResult(data: LocateApiResponse) {
+    const isNearest = data.mode === 'nearest';
     if (!data.feature) {
-      render(kicker(data.mode === 'nearest' ? 'Nothing nearby' : 'Not found') +
-        `<h2 class="ls-name">You're outside this layer's area</h2>` +
-        `<p class="ls-sub">No feature ${data.mode === 'nearest' ? 'within range' : 'contains your location'} here.</p>`);
+      result(isNearest ? 'Nothing nearby' : 'Not found', "You're outside this layer's area",
+        `<p class="ls-sub">No feature ${isNearest ? 'within range' : 'contains your location'} here.</p>`);
       return;
     }
-    const name = pickFeatureName(data.feature.properties);
-    const sub = data.mode === 'nearest' && data.distance_km != null
-      ? `<p class="ls-sub"><span class="ls-dist">${data.distance_km} km${data.bearing ? ' ' + esc(data.bearing) : ''}</span></p>`
+    const name = escapeHtml(pickFeatureName(data.feature.properties));
+    const sub = isNearest && data.distance_km != null
+      ? `<p class="ls-sub"><span class="ls-dist">${data.distance_km} km${data.bearing ? ' ' + escapeHtml(data.bearing) : ''}</span></p>`
       : '';
-    render(kicker(data.mode === 'nearest' ? 'Nearest to you' : 'You are here') +
-      `<h2 class="ls-name">${esc(name)}</h2>${sub}`);
+    result(isNearest ? 'Nearest to you' : 'You are here', name, sub);
   }
 }
 

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -14,6 +14,7 @@ import { featureCollectionBounds, type FC } from './validate';
 import { reduceOverlay, initialOverlayState, type OverlayState, type OverlayAction, type Surface } from './view-overlays';
 import { displayTitle } from './layer-display';
 import { paddingForPanelRect, type Padding } from './map-padding';
+import { resolveLocateConfig } from './locate-config';
 
 type Layer = {
   id: string;
@@ -137,6 +138,14 @@ function registerPopover(name: Surface, btn: HTMLButtonElement, popover: HTMLEle
   };
   popover.onclick = (e) => e.stopPropagation();
   return () => dispatchOverlay({ type: 'close' });
+}
+
+// Toolbar buttons hold an icon + a .tb-label span; set the text on the span so
+// the icon survives (plain textContent would wipe it).
+function setToolLabel(btn: HTMLElement, text: string): void {
+  const label = btn.querySelector('.tb-label');
+  if (label) label.textContent = text;
+  else btn.textContent = text;
 }
 
 // ---------------------------------------------------------------------------
@@ -650,7 +659,7 @@ async function wireFilterButton(layer: Layer) {
   if (!layer.parquet?.url) return;
 
   btn.classList.add('shown');
-  btn.textContent = 'Filter & export';
+  setToolLabel(btn, 'Filter');
   btn.disabled = false;
 
   const columnsPromise = loadFilterColumns(layer, signal);
@@ -663,7 +672,7 @@ async function wireFilterButton(layer: Layer) {
 
   const resetFilterChrome = () => {
     btn.disabled = false;
-    btn.textContent = 'Filter & export';
+    setToolLabel(btn, 'Filter');
     applyActiveFilters([], null);
     flyTo(layerBounds, { padding: BASE_PADDING });
   };
@@ -700,7 +709,7 @@ async function wireFilterButton(layer: Layer) {
 
     const { columns: ranked, rowCount } = result;
     btn.disabled = true;
-    btn.textContent = 'Loading…';
+    setToolLabel(btn, 'Loading…');
     try {
       const { mountFilterPanel } = await import('./filter');
       if (signal.aborted) {
@@ -725,7 +734,7 @@ async function wireFilterButton(layer: Layer) {
       console.error('filter panel failed to load', e);
     } finally {
       btn.disabled = false;
-      btn.textContent = 'Filter & export';
+      setToolLabel(btn, 'Filter');
     }
   };
 
@@ -746,13 +755,62 @@ async function wireFilterButton(layer: Layer) {
   );
 }
 
+// Find-my-location toolbar item. Shows only on locate-enabled layers (ward
+// layers built-in for now; others opt in via level_meta.locate_label). Uses the
+// reserved `findward` overlay surface; the flow + result sheet live in locate.ts.
+function wireLocateButton(
+  layer: Layer,
+  levelMeta: { locate_label?: string; locate_mode?: string } | undefined,
+): void {
+  const btn = document.getElementById('map-locate') as HTMLButtonElement | null;
+  const sheet = document.getElementById('locate-sheet');
+  if (!btn || !sheet) return;
+
+  delete surfaceHandles.findward;
+  btn.classList.remove('shown', 'locating');
+
+  const config = resolveLocateConfig(layer, levelMeta);
+  if (!config) return; // layer not locate-enabled → no item in the bar
+
+  setToolLabel(btn, config.label);
+  btn.setAttribute('aria-label', config.label);
+  btn.classList.add('shown');
+
+  surfaceHandles.findward = {
+    btn,
+    show: () => {
+      btn.classList.add('locating');
+      import('./locate')
+        .then(({ openLocate }) =>
+          openLocate({ layerId: layer.id, config, sheet, btn, onClose: () => dispatchOverlay({ type: 'close' }) }),
+        )
+        .catch((e) => {
+          console.error('locate failed to load', e);
+          btn.classList.remove('locating');
+        });
+    },
+    hide: () => {
+      btn.classList.remove('locating');
+      import('./locate').then(({ closeLocate }) => closeLocate(sheet)).catch(() => {});
+    },
+  };
+
+  btn.onclick = (e) => {
+    e.stopPropagation();
+    dispatchOverlay({ type: 'toggle', surface: 'findward' });
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 export async function openLayer(layerId: string, opts: { titleEl: HTMLElement }) {
   resetOverlays();
-  const cat = (await getCatalog()) as { layers?: Layer[]; level_meta?: Record<string, { label?: string; seo_title?: string }> };
+  const cat = (await getCatalog()) as {
+    layers?: Layer[];
+    level_meta?: Record<string, { label?: string; seo_title?: string; locate_label?: string; locate_mode?: string }>;
+  };
   const layer = cat.layers?.find((l) => l.id === layerId);
   if (!layer) {
     opts.titleEl.textContent = `unknown layer: ${layerId}`;
@@ -774,6 +832,7 @@ export async function openLayer(layerId: string, opts: { titleEl: HTMLElement })
   wireFilterButton(layer).catch((e) => console.warn('wireFilterButton failed', e));
   wireDownloadButton(layer);
   wireBasemapButton();
+  wireLocateButton(layer, levelMeta);
 
   const container = document.getElementById('map')!;
   container.innerHTML = '';
@@ -788,11 +847,22 @@ export async function openLayer(layerId: string, opts: { titleEl: HTMLElement })
     style: buildBaseStyle(activeBasemap),
     bounds: INDIA_BOUNDS,
     fitBoundsOptions: { padding: BASE_PADDING },
-    attributionControl: { compact: true },
+    attributionControl: false,
     preserveDrawingBuffer: true,
   });
   map.addControl(new maplibregl.NavigationControl({ visualizePitch: false }), 'top-right');
-  map.addControl(new maplibregl.ScaleControl({ unit: 'metric' }));
+  // Attribution as a compact (i) docked top-left, off the bottom bar; it expands
+  // on tap (satisfies the licence). Scale is desktop-only — on mobile it just
+  // clutters the bottom edge where the toolbar now lives.
+  map.addControl(new maplibregl.AttributionControl({ compact: true }), 'top-left');
+  if (!isMobileViewport()) map.addControl(new maplibregl.ScaleControl({ unit: 'metric' }));
+  // MapLibre opens the compact attribution on load (a full-width credit strip
+  // over the map top). Collapse it to just the (i); it still expands on tap.
+  map.once('load', () => {
+    const a = container.querySelector('.maplibregl-ctrl-attrib.maplibregl-compact');
+    a?.classList.remove('maplibregl-compact-show');
+    a?.removeAttribute('open');
+  });
 
   map.on('load', async () => {
     try {
@@ -820,6 +890,10 @@ export function closeLayer() {
   resetOverlays();
   const btn = document.getElementById('map-filter') as HTMLButtonElement | null;
   if (btn) btn.classList.remove('shown');
+  const locateBtn = document.getElementById('map-locate');
+  locateBtn?.classList.remove('shown', 'locating');
+  const locateSheet = document.getElementById('locate-sheet');
+  if (locateSheet) { locateSheet.classList.remove('open'); locateSheet.innerHTML = ''; }
   document.querySelector('.filter-panel')?.remove();
   for (const p of document.querySelectorAll('.map-popover.open')) p.classList.remove('open');
 }

--- a/web/tests/locate-config.test.ts
+++ b/web/tests/locate-config.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLocateConfig } from '../src/locate-config';
+
+// Decides whether the "Find my location" item shows on a layer, its short
+// toolbar label, and the spatial mode. Explicit per-layer config (curated
+// level_meta / baked community) wins; for Step 1a ward layers are auto-enabled
+// as a built-in so the feature lights up without a catalog change.
+
+describe('resolveLocateConfig', () => {
+  it('auto-enables ward layers as contains (1a built-in)', () => {
+    expect(resolveLocateConfig({ id: 'wards_bengaluru_bbmp_2022', level: 'wards_bengaluru_bbmp_2022' }))
+      .toEqual({ label: 'My ward', mode: 'contains' });
+    expect(resolveLocateConfig({ id: 'wards_ahmedabad' }))
+      .toEqual({ label: 'My ward', mode: 'contains' });
+  });
+
+  it('returns null for a layer with no config and no ward match', () => {
+    expect(resolveLocateConfig({ id: 'lgd_states', level: 'state' })).toBeNull();
+  });
+
+  it('uses an explicit level_meta.locate_label (contains by default)', () => {
+    expect(resolveLocateConfig({ id: 'seismic_zones', level: 'seismic_zone' }, { locate_label: 'Which zone?' }))
+      .toEqual({ label: 'Which zone?', mode: 'contains' });
+  });
+
+  it('honours locate_mode=nearest', () => {
+    expect(resolveLocateConfig({ id: 'health_facilities' }, { locate_label: 'Nearby', locate_mode: 'nearest' }))
+      .toEqual({ label: 'Nearby', mode: 'nearest' });
+  });
+
+  it('explicit config wins over the ward built-in', () => {
+    expect(resolveLocateConfig({ id: 'wards_x' }, { locate_label: 'Find your ward', locate_mode: 'contains' }))
+      .toEqual({ label: 'Find your ward', mode: 'contains' });
+  });
+
+  it('treats a blank/whitespace label as absent', () => {
+    expect(resolveLocateConfig({ id: 'lgd_states' }, { locate_label: '   ' })).toBeNull();
+    expect(resolveLocateConfig({ id: 'wards_x' }, { locate_label: '' }))
+      .toEqual({ label: 'My ward', mode: 'contains' });
+  });
+});

--- a/web/tests/locate-format.test.ts
+++ b/web/tests/locate-format.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { pickFeatureName } from '../src/locate-format';
+
+// The locate result sheet needs a human title out of a generic feature's
+// properties (column names vary per layer). pickFeatureName is best-effort:
+// prefer a *name* column, then a ward number, then the first usable string.
+
+describe('pickFeatureName', () => {
+  it('prefers a name column', () => {
+    expect(pickFeatureName({ KGISWardNo: 150, KGISWardName: 'Shanthala Nagar' })).toBe('Shanthala Nagar');
+    expect(pickFeatureName({ stname: 'Karnataka', stcode: 29 })).toBe('Karnataka');
+  });
+
+  it('falls back to a ward/number column as "Ward N"', () => {
+    expect(pickFeatureName({ KGISWardNo: 150 })).toBe('Ward 150');
+    expect(pickFeatureName({ ward_no: '42' })).toBe('Ward 42');
+  });
+
+  it('falls back to the first usable string value', () => {
+    expect(pickFeatureName({ district: 'Bengaluru Urban', area_sqkm: 709 })).toBe('Bengaluru Urban');
+  });
+
+  it('ignores geometry/id/shape junk and blanks', () => {
+    expect(pickFeatureName({ OBJECTID: 7, geometry: 'x', name: 'Hosur Road' })).toBe('Hosur Road');
+    expect(pickFeatureName({ _lat: 12.9, _lng: 77.6, name: '  ' , place: 'Indiranagar' })).toBe('Indiranagar');
+  });
+
+  it('returns a sane fallback for an empty / unnamed feature', () => {
+    expect(pickFeatureName({})).toBe('Found');
+    expect(pickFeatureName({ OBJECTID: 7 })).toBe('Found');
+  });
+});

--- a/web/tests/locate-layer.test.ts
+++ b/web/tests/locate-layer.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { compassBearing, compass8, bearingLabel, pickContains } from '../functions/lib/locate-layer';
+import type { LocateResponse } from '../functions/lib/locate';
+
+// Pure helpers behind GET /api/v1/layers/{id}/locate. The endpoint composes
+// the existing `locate` (contains, point-in-polygon over PMTiles) and `nearby`
+// (nearest, parquet) engines; these helpers do the geometry-free bits:
+// the compass bearing shown on a "nearest" result, and pulling a single layer's
+// containing feature out of the aggregate locate response.
+
+describe('compass8 — degrees to an 8-point compass label', () => {
+  it('maps the cardinals', () => {
+    expect(compass8(0)).toBe('N');
+    expect(compass8(90)).toBe('E');
+    expect(compass8(180)).toBe('S');
+    expect(compass8(270)).toBe('W');
+  });
+  it('maps the intercardinals', () => {
+    expect(compass8(45)).toBe('NE');
+    expect(compass8(135)).toBe('SE');
+    expect(compass8(225)).toBe('SW');
+    expect(compass8(315)).toBe('NW');
+  });
+  it('wraps 360 back to N and normalises out-of-range / negative input', () => {
+    expect(compass8(360)).toBe('N');
+    expect(compass8(-90)).toBe('W');
+    expect(compass8(720 + 90)).toBe('E');
+  });
+});
+
+describe('compassBearing + bearingLabel — direction from point A to point B', () => {
+  it('due north: same lng, higher lat', () => {
+    expect(Math.round(compassBearing(12.9, 77.6, 13.0, 77.6))).toBe(0);
+    expect(bearingLabel(12.9, 77.6, 13.0, 77.6)).toBe('N');
+  });
+  it('due east: same lat, higher lng', () => {
+    expect(Math.round(compassBearing(12.9, 77.6, 12.9, 77.7))).toBe(90);
+    expect(bearingLabel(12.9, 77.6, 12.9, 77.7)).toBe('E');
+  });
+  it('due south and due west', () => {
+    expect(bearingLabel(13.0, 77.6, 12.9, 77.6)).toBe('S');
+    expect(bearingLabel(12.9, 77.7, 12.9, 77.6)).toBe('W');
+  });
+  it('north-east when both lat and lng increase', () => {
+    expect(bearingLabel(12.9, 77.6, 13.0, 77.7)).toBe('NE');
+  });
+});
+
+describe('pickContains — single layer feature out of the aggregate locate', () => {
+  const resp = (results: LocateResponse['results']): LocateResponse =>
+    ({ point: { lat: 0, lng: 0 }, zoom: 14, results, queried_layers: [], timing_ms: 0 });
+
+  it('returns the matching layer feature regardless of category grouping', () => {
+    const r = resp({
+      admin: [{ layer_id: 'lgd_districts', level: 'district', category: 'admin', feature: { properties: { d: 1 } } }],
+      civic: [{ layer_id: 'wards_x', level: 'wards_x', category: 'civic', feature: { properties: { ward: '150' } } }],
+    });
+    expect(pickContains(r, 'wards_x')).toEqual({ properties: { ward: '150' } });
+  });
+  it('returns null when the layer is absent', () => {
+    expect(pickContains(resp({}), 'wards_x')).toBeNull();
+  });
+});

--- a/web/tests/security-headers.test.ts
+++ b/web/tests/security-headers.test.ts
@@ -23,17 +23,21 @@ describe('Security headers — Cloudflare Pages _headers file', () => {
   });
 
   it('sets Permissions-Policy to deny sensitive capabilities by default', () => {
-    // We're a read-only map atlas. No camera, no mic, no geolocation —
-    // explicit deny keeps the user privacy floor high + improves
-    // Best Practices score.
+    // We're a read-only map atlas: camera, mic, payment etc. stay fully denied.
+    // geolocation is the exception — it's `(self)`, not `()`, so the in-app
+    // "Find my location" feature can call navigator.geolocation (first-party
+    // only; embeds/third parties still can't).
     const pp = headersFile.match(/Permissions-Policy:\s*([^\n]+)/);
     expect(pp, 'Permissions-Policy missing').not.toBeNull();
     const v = pp![1];
-    for (const feature of ['camera', 'microphone', 'geolocation', 'payment']) {
+    for (const feature of ['camera', 'microphone', 'payment']) {
       expect(v, `Permissions-Policy missing deny for ${feature}`).toMatch(
         new RegExp(`${feature}=\\(\\)`),
       );
     }
+    expect(v, 'geolocation should be (self), not (), for Find my location').toMatch(
+      /geolocation=\(self\)/,
+    );
   });
 
   it('sets Content-Security-Policy', () => {
@@ -189,7 +193,7 @@ describe('Security headers — SECURITY_HEADERS_HTML (Pages Function responses)'
     const pp = SECURITY_HEADERS_HTML['permissions-policy'];
     expect(pp).toMatch(/camera=\(\)/);
     expect(pp).toMatch(/microphone=\(\)/);
-    expect(pp).toMatch(/geolocation=\(\)/);
+    expect(pp).toMatch(/geolocation=\(self\)/);
   });
 
   it('CSP includes frame-ancestors to block clickjacking', () => {


### PR DESCRIPTION
## What

Step 1a of **find my location** — the #1 organic search intent on bharatlas is "which ward am I in" (per the GSC analysis). Generalised to **locate me in this layer**: which feature *contains* you (polygons) or which is *nearest* (lines/points).

### Backend
- **New endpoint** `GET /api/v1/layers/{id}/locate?lat=&lng=[&mode=auto|contains|nearest]` — geometry-branched, composed from the existing engines (additive; `/locate` and `/nearby` unchanged):
  - `contains` → point-in-polygon over the layer's PMTiles (reuses `lib/locate`)
  - `nearest`  → closest feature + distance + compass bearing (reuses `lib/nearby`)
  - `auto`     → contains if the layer has pmtiles, else/miss → nearest
  Result is location-specific + privacy-sensitive, so it's never cached.
- `geolocation=()` → `geolocation=(self)` in the Permissions-Policy (first-party only; camera/mic/payment/etc. stay denied).

### UI
- The mobile bottom bar becomes a flush **4-up icon row**: `Basemap · Download · Filter · Locate`. The locate item shows only on locate-enabled layers (ward layers built-in via `resolveLocateConfig`; others opt in later via `level_meta.locate_label`) with a per-layer short label ("My ward" / "Nearby" / "My zone"). Tap → geolocate → endpoint → result in the **single-open sheet** (reuses the PR #131 overlay reducer). Desktop keeps text buttons (icons hidden) and gains the locate button.
- **Map credit repositioned** off the bottom bar: a compact **ⓘ docked top-left** (collapsed on load, expands on tap). Scale control is desktop-only.

## Testing
- Red-green TDD on the pure modules: compass bearing + single-layer extraction (`locate-layer`), the config resolver (`locate-config`), feature-name extraction (`locate-format`). **629 tests passing.**
- `code-simplifier` pass applied (shared `escapeHtml`, deduped the result-card render).
- Headless-verified at 390px + desktop: 4-up bar, locate flow (permission → geolocate → endpoint → result sheet), credit ⓘ, desktop preserved, **no page errors**.
- **Perf:** the locate flow is its own lazy chunk (2.5 kB / 1.4 kB gz, loaded only on tap); initial-load bundle unchanged; map chunk +~1.8 kB. Off the initial-load path, so no CWV impact.

## Deploy note
The actual **"You're in Ward 150"** result resolves against **production R2** — local wrangler R2 is empty, so the flow correctly renders *"outside this layer's area"* (the same dependency `/api/v1/locate` and `/api/v1/nearby` already have). Confirm the happy path on the preview/prod deploy.

## Scope / follow-ons
Full plan in `supporting-docs/spec-find-my-location.md` (local). **1a** = endpoint + ward UI + credit + geolocation (this PR). 1b: extend to villages/constituencies/seismic/flood/eco via `locate_label` (no code). 1c: point/line "nearest" (hospitals/airports). 1d: MCP `locate_in_layer` (decoupled 1.1.0 release). 2: universal "what's here?" page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)