### PR TITLE
feat(locate): extend find-my-location to admin + zone layers (Step 1b)

### DIFF
--- a/web/src/locate-config.ts
+++ b/web/src/locate-config.ts
@@ -16,14 +16,34 @@ export type LocateLevelMeta =
 
 const WARD_RE = /^wards_/;
 
+// Built-in locate config keyed by the layer's `level` (mirrors the edge's
+// BUILTIN_LEVEL_META keys). These admin / zone layers partition space, so
+// "which one contains me" is meaningful, and all are point-in-polygon. `state`
+// is omitted on purpose — "which state am I in" is rarely a real question. Any
+// layer can still override via level_meta.locate_label.
+const LEVEL_LOCATE: Record<string, LocateConfig> = {
+  district: { label: 'My district', mode: 'contains' },
+  subdistrict: { label: 'My taluk', mode: 'contains' },
+  block: { label: 'My block', mode: 'contains' },
+  panchayat: { label: 'My panchayat', mode: 'contains' },
+  village: { label: 'My village', mode: 'contains' },
+  assembly_constituency: { label: 'My MLA', mode: 'contains' },
+  parliament_constituency: { label: 'My MP', mode: 'contains' },
+  seismic_zone: { label: 'Seismic zone', mode: 'contains' },
+  eco_zone: { label: 'Eco-zone', mode: 'contains' },
+};
+
 export function resolveLocateConfig(layer: LocateLayer, levelMeta?: LocateLevelMeta): LocateConfig | null {
   const label = levelMeta?.locate_label?.trim();
   if (label) {
     return { label, mode: levelMeta?.locate_mode === 'nearest' ? 'nearest' : 'contains' };
   }
-  // 1a built-in: ward layers (id or level starts with "wards_") = contains.
-  if (WARD_RE.test(layer.id) || (layer.level != null && WARD_RE.test(layer.level))) {
-    return { label: 'My ward', mode: 'contains' };
+  if (layer.level != null) {
+    const byLevel = LEVEL_LOCATE[layer.level];
+    if (byLevel) return { ...byLevel };
+    // Ward layers' level IS the layer id (e.g. "wards_bengaluru_bbmp_2022").
+    if (WARD_RE.test(layer.level)) return { label: 'My ward', mode: 'contains' };
   }
+  if (WARD_RE.test(layer.id)) return { label: 'My ward', mode: 'contains' };
   return null;
 }

--- a/web/tests/locate-config.test.ts
+++ b/web/tests/locate-config.test.ts
@@ -14,8 +14,28 @@ describe('resolveLocateConfig', () => {
       .toEqual({ label: 'My ward', mode: 'contains' });
   });
 
-  it('returns null for a layer with no config and no ward match', () => {
+  it('auto-enables admin + zone layers by their level (1b built-ins)', () => {
+    expect(resolveLocateConfig({ id: 'lgd_districts', level: 'district' })).toEqual({ label: 'My district', mode: 'contains' });
+    expect(resolveLocateConfig({ id: 'lgd_villages', level: 'village' })).toEqual({ label: 'My village', mode: 'contains' });
+    expect(resolveLocateConfig({ id: 'lgd_panchayats', level: 'panchayat' })).toEqual({ label: 'My panchayat', mode: 'contains' });
+    expect(resolveLocateConfig({ id: 'lgd_assembly', level: 'assembly_constituency' })).toEqual({ label: 'My MLA', mode: 'contains' });
+    expect(resolveLocateConfig({ id: 'lgd_parliament', level: 'parliament_constituency' })).toEqual({ label: 'My MP', mode: 'contains' });
+    expect(resolveLocateConfig({ id: 'seismic_zones', level: 'seismic_zone' })).toEqual({ label: 'Seismic zone', mode: 'contains' });
+    expect(resolveLocateConfig({ id: 'bm_eco_zones', level: 'eco_zone' })).toEqual({ label: 'Eco-zone', mode: 'contains' });
+  });
+
+  it('does NOT enable state (too obvious) or unmapped levels', () => {
     expect(resolveLocateConfig({ id: 'lgd_states', level: 'state' })).toBeNull();
+    expect(resolveLocateConfig({ id: 'airports', level: 'airport' })).toBeNull();
+  });
+
+  it('level_meta.locate_label still overrides a level built-in', () => {
+    expect(resolveLocateConfig({ id: 'lgd_districts', level: 'district' }, { locate_label: 'Find your district' }))
+      .toEqual({ label: 'Find your district', mode: 'contains' });
+  });
+
+  it('returns null for a layer with no config and no ward match', () => {
+    expect(resolveLocateConfig({ id: 'datagov_pincodes', level: 'pincode' })).toBeNull();
   });
 
   it('uses an explicit level_meta.locate_label (contains by default)', () => {


### PR DESCRIPTION
## What
Step 1b turns the **Find my location** item on for more layers — districts, sub-districts, blocks, panchayats, villages, assembly + parliament constituencies, seismic zones, and eco-zones.

These standard admin/zone layers have **no `level_meta[id]` entry** (unlike wards) but a stable `level` field + pmtiles, so the cleanest path is a **level-keyed built-in map** in `resolveLocateConfig` (mirroring the edge's `BUILTIN_LEVEL_META`):

| level | label | level | label |
|---|---|---|---|
| district | My district | village | My village |
| subdistrict | My taluk | assembly_constituency | My MLA |
| block | My block | parliament_constituency | My MP |
| panchayat | My panchayat | seismic_zone | Seismic zone |
| | | eco_zone | Eco-zone |

`state` is omitted on purpose ("which state am I in" is rarely a real question). `level_meta.locate_label` still overrides per layer.

## No other changes
The `/api/v1/layers/{id}/locate` endpoint (shipped in 1a) is generic, and 1a's UI shows the item wherever the resolver enables it — so 1b is **just the resolver + tests**. No endpoint, UI, or catalog changes.

## Testing
- Red-green: +3 cases (**632 tests**).
- Headless at 390px: locate item shows with the right per-layer label on districts / assembly / seismic / villages; stays hidden on states.
- Prod cross-check: the already-live endpoint resolves `contains` for `lgd_districts` at a Bengaluru point → **"Bengaluru Urban"**.
- Perf: no new chunks; +~15 lines in the already-loaded map chunk. Negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)