### PR TITLE
fix(locate): pick the feature's own name on constituency layers

### DIFF
--- a/web/src/locate-format.ts
+++ b/web/src/locate-format.ts
@@ -6,14 +6,25 @@
 
 const JUNK_KEY = /^_|geom|shape_|shape\.|st_area|st_perimeter|objectid|ogc_fid|\bfid\b|^id$|simptol|simpgnflag/i;
 
+// Parent-admin name columns (st_name, dist_name, dtname, sdtname …). A feature
+// often carries these before its own name — e.g. an assembly constituency has
+// st_name="KARNATAKA" before ac_name="Shivajinagar" — and "you're in KARNATAKA"
+// is useless. Deprioritise them; only fall back to one when it IS the feature
+// (a district/state layer whose only name column is dtname/stname).
+const PARENT_NAME = /^(st|state|dt|dist|district|sdt|subdist|subdistrict)[_-]?name$/i;
+
 const clean = (v: unknown): string => (v == null ? '' : String(v)).trim();
 
 export function pickFeatureName(props: Record<string, unknown>): string {
   const entries = Object.entries(props).filter(([k, v]) => !JUNK_KEY.test(k) && clean(v) !== '');
 
-  // 1. a "name" column (textual, not a bare numeric code)
-  const named = entries.find(([k, v]) => /name/i.test(k) && typeof v !== 'number');
-  if (named) return clean(named[1]);
+  // 1. a "name" column (textual, not a bare numeric code). Prefer the feature's
+  //    own name over a parent-admin name; fall back to a parent name only if
+  //    that's all there is.
+  const named = entries.filter(([k, v]) => /name/i.test(k) && typeof v !== 'number');
+  const own = named.find(([k]) => !PARENT_NAME.test(k));
+  if (own) return clean(own[1]);
+  if (named.length) return clean(named[0][1]);
 
   // 2. a ward / number column -> "Ward N"
   const ward = entries.find(([k]) => /ward.*?(no|num|code)|^no$|number/i.test(k));

--- a/web/tests/locate-format.test.ts
+++ b/web/tests/locate-format.test.ts
@@ -11,6 +11,23 @@ describe('pickFeatureName', () => {
     expect(pickFeatureName({ stname: 'Karnataka', stcode: 29 })).toBe('Karnataka');
   });
 
+  it('prefers the feature own name over a parent admin name', () => {
+    // assembly constituency: st_name + dist_name come before the real ac_name
+    expect(pickFeatureName({
+      OBJECTID: 1, st_name: 'KARNATAKA', dist_name: 'BANGALORE',
+      ac_no: 162, ac_name: 'Shivajinagar', pc_name: 'BANGALORE CENTRAL',
+    })).toBe('Shivajinagar');
+    // parliament: st_name before pc_name
+    expect(pickFeatureName({ st_name: 'KARNATAKA', pc_no: 25, pc_name: 'BANGALORE CENTRAL' })).toBe('BANGALORE CENTRAL');
+    // village: parent admin names before vil_name
+    expect(pickFeatureName({ stname: 'KARNATAKA', dtname: 'BANGALORE', sdtname: 'Bangalore South', vil_name: 'Begur' })).toBe('Begur');
+  });
+
+  it('falls back to a parent-style name only when it IS the feature (district/state layers)', () => {
+    expect(pickFeatureName({ OBJECTID: 55, dtname: 'Bengaluru Urban', stname: 'KARNATAKA' })).toBe('Bengaluru Urban');
+    expect(pickFeatureName({ st_name: 'Karnataka', st_code: 29 })).toBe('Karnataka');
+  });
+
   it('falls back to a ward/number column as "Ward N"', () => {
     expect(pickFeatureName({ KGISWardNo: 150 })).toBe('Ward 150');
     expect(pickFeatureName({ ward_no: '42' })).toBe('Ward 42');


### PR DESCRIPTION
## Bug
After 1b enabled Find-my-location on **assembly + parliament constituencies**, the result sheet showed the parent **state** name, not the constituency. The features carry parent-admin columns before their own name:

```
lgd_assembly:   st_name="KARNATAKA"  dist_name="BANGALORE"  …  ac_name="Shivajinagar"
lgd_parliament: st_name="KARNATAKA"  …  pc_name="BANGALORE CENTRAL"
```

`pickFeatureName` returned the first `/name/i` key → `st_name` → **"You are here · KARNATAKA"** — useless for a constituency lookup.

## Fix
Deprioritise parent-admin name columns (`st_name`, `state_name`, `dt_name`, `dist_name`, `dtname`, `sdtname`, …): prefer the first `/name/i` column that *isn't* parent-admin, and fall back to a parent one only when that's genuinely the feature's name (a district/state layer whose only name column is `dtname`/`stname`).

Result: assembly → **"Shivajinagar"**, parliament → **"BANGALORE CENTRAL"**, village → its own name; wards / districts / states unchanged.

## Testing
Red-green: +2 cases built from the **real prod property sets** (assembly, parliament, village, district, state). **634 tests passing.** Pure function, no perf/bundle impact.