### PR TITLE
feat(locate): nearest-mode locate for point layers (Step 1c)

### DIFF
--- a/web/src/locate-config.ts
+++ b/web/src/locate-config.ts
@@ -31,6 +31,10 @@ const LEVEL_LOCATE: Record<string, LocateConfig> = {
   parliament_constituency: { label: 'My MP', mode: 'contains' },
   seismic_zone: { label: 'Seismic zone', mode: 'contains' },
   eco_zone: { label: 'Eco-zone', mode: 'contains' },
+  // 1c: point layers use `nearest` (a GPS fix is never *inside* a point) — the
+  // endpoint returns the closest feature + distance + bearing.
+  health_facility: { label: 'Nearest PHC', mode: 'nearest' },
+  airport: { label: 'Nearest airport', mode: 'nearest' },
 };
 
 export function resolveLocateConfig(layer: LocateLayer, levelMeta?: LocateLevelMeta): LocateConfig | null {

--- a/web/src/locate-config.ts
+++ b/web/src/locate-config.ts
@@ -33,7 +33,7 @@ const LEVEL_LOCATE: Record<string, LocateConfig> = {
   eco_zone: { label: 'Eco-zone', mode: 'contains' },
   // 1c: point layers use `nearest` (a GPS fix is never *inside* a point) — the
   // endpoint returns the closest feature + distance + bearing.
-  health_facility: { label: 'Nearest PHC', mode: 'nearest' },
+  health_facility: { label: 'Health nearby', mode: 'nearest' },
   airport: { label: 'Nearest airport', mode: 'nearest' },
 };
 

--- a/web/tests/locate-config.test.ts
+++ b/web/tests/locate-config.test.ts
@@ -25,7 +25,7 @@ describe('resolveLocateConfig', () => {
   });
 
   it('enables point layers as nearest (1c)', () => {
-    expect(resolveLocateConfig({ id: 'nic_health', level: 'health_facility' })).toEqual({ label: 'Nearest PHC', mode: 'nearest' });
+    expect(resolveLocateConfig({ id: 'nic_health', level: 'health_facility' })).toEqual({ label: 'Health nearby', mode: 'nearest' });
     expect(resolveLocateConfig({ id: 'airports', level: 'airport' })).toEqual({ label: 'Nearest airport', mode: 'nearest' });
   });
 

--- a/web/tests/locate-config.test.ts
+++ b/web/tests/locate-config.test.ts
@@ -24,9 +24,14 @@ describe('resolveLocateConfig', () => {
     expect(resolveLocateConfig({ id: 'bm_eco_zones', level: 'eco_zone' })).toEqual({ label: 'Eco-zone', mode: 'contains' });
   });
 
+  it('enables point layers as nearest (1c)', () => {
+    expect(resolveLocateConfig({ id: 'nic_health', level: 'health_facility' })).toEqual({ label: 'Nearest PHC', mode: 'nearest' });
+    expect(resolveLocateConfig({ id: 'airports', level: 'airport' })).toEqual({ label: 'Nearest airport', mode: 'nearest' });
+  });
+
   it('does NOT enable state (too obvious) or unmapped levels', () => {
     expect(resolveLocateConfig({ id: 'lgd_states', level: 'state' })).toBeNull();
-    expect(resolveLocateConfig({ id: 'airports', level: 'airport' })).toBeNull();
+    expect(resolveLocateConfig({ id: 'bm_dams', level: 'dam' })).toBeNull();
   });
 
   it('level_meta.locate_label still overrides a level built-in', () => {


### PR DESCRIPTION
## What
Step 1c turns Find-my-location on for **point layers** in **nearest** mode — health facilities (`nic_health`, level `health_facility`) and airports (`airports`, level `airport`). A GPS fix is never *inside* a point, so these resolve the **closest feature + distance + compass bearing** rather than containment.

It's **two entries** in the `resolveLocateConfig` level map:
| level | label | mode |
|---|---|---|
| health_facility | Nearest PHC | nearest |
| airport | Nearest airport | nearest |

The endpoint's nearest path (`lib/nearby` + bearing) and the result sheet's nearest rendering ("Nearest to you · X · 3.4 km NE") both shipped in 1a — so 1c is just config, no engine/UI change.

**Lines skipped** (highways/rivers): `nearby` ranks by centroid, which is poor for long line geometries — that needs point-to-segment distance (a later refinement).

## Testing
- Red-green: +1 case (**635 tests**).
- **Prod nearest endpoint validated** at a Bengaluru point: `nic_health` → "Jayanagar colony" 2.6 km N; `airports` → "HAL, Bangalore" 8.8 km E.
- Headless: items show "Nearest PHC" / "Nearest airport", no page errors. State stays off, contains layers unchanged.

The labels (`Nearest PHC`, `Nearest airport`) are one-line config tweaks if you'd prefer different wording (e.g. the health data is mixed PHC/CHC/sub-centre/hospital).