### PR TITLE
perf(nearby): rebake nic_health with flat bbox cols (3s→~1s + fixes wrong nearest)

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2245,7 +2245,7 @@
       "parquet": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/healthcare/facilities/INDIA_HEALTH_FACILITIES_NIC.parquet",
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/healthcare/facilities/INDIA_HEALTH_FACILITIES_NIC.parquet",
-        "bytes": 4999642
+        "bytes": 7792134
       },
       "pmtiles": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/healthcare/facilities/INDIA_HEALTH_FACILITIES_NIC.pmtiles",

--- a/scripts/ingest_ramseraph.py
+++ b/scripts/ingest_ramseraph.py
@@ -554,9 +554,12 @@ def rebake_flatten_bbox(src: Path, dst: Path) -> tuple[int, list[str]]:
     has_bbox_struct = 'bbox' in col_names
     has_flat_bbox = all(c in col_names for c in ('xmin', 'ymin', 'xmax', 'ymax'))
     # ramSeraph parquet stores `geometry` already typed as GEOMETRY; a few
-    # older / simpler files store it as raw BLOB (WKB). Detect which.
-    geom_type = next((c[1] for c in cols if c[0] == 'geometry'), 'BLOB')
-    geom_expr = 'geometry' if 'GEOMETRY' in geom_type else 'ST_GeomFromWKB(geometry)'
+    # older / simpler files store it as raw BLOB (WKB) or name the column
+    # `geom` / `wkb_geometry` (e.g. own-bake point layers like nic_health).
+    # Detect the column name + its type rather than assuming `geometry`.
+    geom_col = next((c[0] for c in cols if c[0] in ('geometry', 'wkb_geometry', 'geom')), 'geometry')
+    geom_type = next((c[1] for c in cols if c[0] == geom_col), 'BLOB')
+    geom_expr = geom_col if 'GEOMETRY' in geom_type else f'ST_GeomFromWKB({geom_col})'
     # India bbox; ST_Hilbert uses this as the curve's domain so the 32-bit
     # index has max resolution over the country instead of the whole world.
     india_bbox = "ST_Extent(ST_MakeEnvelope(68, 6, 98, 38))"

--- a/scripts/rebake_layer.py
+++ b/scripts/rebake_layer.py
@@ -54,7 +54,10 @@ def patch_catalog_bytes(catalog_path: Path, layer_id: str, new_bytes: int) -> No
     cat = json.loads(catalog_path.read_text())
     layer = find_layer(cat, layer_id)
     layer.setdefault('parquet', {})['bytes'] = new_bytes
-    catalog_path.write_text(json.dumps(cat, indent=2, ensure_ascii=False))
+    # Match build_catalog.py's encoding exactly (ensure_ascii default + trailing
+    # newline) so a one-field patch stays a one-line diff instead of re-encoding
+    # every \uXXXX escape in the file.
+    catalog_path.write_text(json.dumps(cat, indent=2) + '\n')
 
 
 def rebake(layer_id: str, s3) -> None:


### PR DESCRIPTION
## What
`nic_health` (1,47,957 health facilities) was the only Find-my-location layer on the slow path. Two problems, one rebake:

1. **Slow.** No flat `xmin/ymin/xmax/ymax` columns → `/api/v1/nearby` full-scanned all 147k rows (~3.2s).
2. **Wrong.** The scan path mis-parsed the GEOMETRY-typed `geom` column, returning an incorrect nearest (a Bengaluru point gave "Jayanagar colony 2.6 km", but the true nearest is "Adugodi Disp UPHC 3.3 km").

Rebaked via `scripts/rebake_layer.py nic_health` → flat bbox cols + Hilbert sort + ZSTD9, re-uploaded to the same R2 key. **Now `parquet-bbox`: ~1.1s and correct** (144 facilities within 25 km; nearest = Adugodi 3.3 km, matches a brute-force ground-truth check). Data preserved exactly — 147,957 rows, all 10 columns.

> The R2 object is already live, so prod `/locate` + `/api/v1/nearby` are **already fast + correct**. This PR is the tooling fixes + catalog metadata.

## Two tooling fixes this surfaced
- **`rebake_flatten_bbox` hardcoded a `geometry` column.** nic_health's is `geom` (GEOMETRY-typed), so the rebake would have failed. Now detects `geometry` / `wkb_geometry` / `geom`. `geometry`-named layers are unchanged (detected first — verified with a synthetic test; the existing `test_hilbert_sort.py` can't run here due to a pre-existing `vcr`/`urllib3` env incompat).
- **`rebake_layer.py` reformatted the whole catalog.** It patched `catalog.json` with `ensure_ascii=False` + no trailing newline, re-encoding every `\uXXXX` escape (78-line noise diff). Now matches `build_catalog.py`'s encoding, so a bytes patch stays a one-line diff.

## Catalog
`nic_health` `parquet.bytes` 4999642 → 7792134 (patched in place, not rebuilt — per the patch-don't-rebuild rule). Verified the diff is exactly that one line.

## Verification (prod)
- `/api/v1/nearby?layer=nic_health` → `_source: parquet-bbox`, 144 features, nearest "Adugodi Disp UPHC" 3.3 km.
- `/api/v1/layers/nic_health/locate?mode=nearest` → "Adugodi Disp UPHC · 3.3 km SE", consistent across repeats.
- Brute-force ground truth (haversine over `geom`) on both the original and rebaked parquet agree: Adugodi 3.3 km.