### PR TITLE
fix(locate): request geolocation synchronously on tap (iOS/mobile prompt)

### DIFF
--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -15,6 +15,11 @@ import { reduceOverlay, initialOverlayState, type OverlayState, type OverlayActi
 import { displayTitle } from './layer-display';
 import { paddingForPanelRect, type Padding } from './map-padding';
 import { resolveLocateConfig } from './locate-config';
+// Static (not dynamic) import: geolocation must be requested synchronously
+// inside the tap handler. A dynamic import() pushes getCurrentPosition past the
+// user-gesture window, which mobile Chrome silently drops (no prompt, no sheet).
+// locate is tiny and folds into this already-lazy map chunk.
+import { openLocate, closeLocate } from './locate';
 
 type Layer = {
   id: string;
@@ -780,18 +785,13 @@ function wireLocateButton(
     btn,
     show: () => {
       btn.classList.add('locating');
-      import('./locate')
-        .then(({ openLocate }) =>
-          openLocate({ layerId: layer.id, config, sheet, btn, onClose: () => dispatchOverlay({ type: 'close' }) }),
-        )
-        .catch((e) => {
-          console.error('locate failed to load', e);
-          btn.classList.remove('locating');
-        });
+      // Synchronous: opens the sheet ("Locating you…") and fires
+      // getCurrentPosition in the same tap, so the prompt actually appears.
+      openLocate({ layerId: layer.id, config, sheet, btn, onClose: () => dispatchOverlay({ type: 'close' }) });
     },
     hide: () => {
       btn.classList.remove('locating');
-      import('./locate').then(({ closeLocate }) => closeLocate(sheet)).catch(() => {});
+      closeLocate(sheet);
     },
   };
 


### PR DESCRIPTION
## Bug
Tapping "locate" on **iPhone Chrome** (and likely all iOS browsers — they're all WebKit) did **nothing**: no permission prompt, no sheet.

## Cause
The locate flow was behind a dynamic `import('./locate')` fired from the tap handler. So the "Locating you…" sheet only opened — and `getCurrentPosition()` only ran — *after* the chunk finished downloading: an async gap **past the tap's user-gesture window**. iOS WebKit (and mobile Chrome) silently drop a geolocation request made outside the gesture → no prompt, and no sheet either (the sheet markup lives inside the not-yet-loaded module). It passed tests only because geolocation was mocked.

## Fix
Make `locate` a **static import** so the tap **synchronously** opens the sheet and calls `getCurrentPosition()` in-gesture — so the browser permission prompt actually fires. `locate` folds into the already-lazy map chunk (18.2 → 21.0 kB) — no initial-load cost; the separate locate chunk is gone.

Now, worst case, the user always sees *a message* (denied / can't-locate) instead of silence.

## Verification
- 635 tests; no dynamic `import('./locate')` remains.
- Headless: the sheet opens **immediately** on tap, flow completes, no page errors.
- Real-device confirmation (iPhone Chrome + Safari) to follow post-deploy.