### PR TITLE
fix(catalog): category pills not filtering on iOS Chrome (hover trap)

### DIFF
--- a/web/index.template.html
+++ b/web/index.template.html
@@ -81,10 +81,16 @@
         background: transparent;
         color: var(--muted);
         cursor: pointer;
+        touch-action: manipulation;
         transition: all 120ms ease;
         white-space: nowrap;
       }
-      .catalog-chip:hover { color: var(--fg); border-color: var(--fg); }
+      /* :hover only on real pointers. On iOS the first tap lands as a hover, not
+         a click, so the pill highlighted (white outline) but never filtered —
+         the click was swallowed. Removing touch :hover lets the first tap fire. */
+      @media (hover: hover) {
+        .catalog-chip:hover { color: var(--fg); border-color: var(--fg); }
+      }
       .catalog-chip.active { background: var(--fg); color: var(--bg); border-color: var(--fg); }
       .catalog-chip[data-count="0"] { opacity: .4; cursor: not-allowed; }
       .catalog-chip .count { color: inherit; margin-left: 4px; font-variant-numeric: tabular-nums; font-weight: 500; }


### PR DESCRIPTION
## Bug
On **iPhone Chrome**, tapping a category pill highlighted it but didn't filter the list. Worked on iPhone Safari + laptop.

## Cause
iOS (every browser is WebKit) treats the **first tap on a `:hover`-styled element as a hover, not a click**. The pill got its hover outline, but the `click` handler (which sets `.active` + runs the filter) never fired — so `.active` stayed on "All" and the list didn't change. iOS Safari fired the click anyway; iOS Chrome's WKWebView wrapper didn't. Card "View map" buttons were fine because they *navigate*.

Confirmed from a device screenshot: tapped "City wards" showed the hover outline, but "All" stayed the filled/active pill and the list stayed on Boundaries.

## Fix
- Guard `.catalog-chip:hover` behind `@media (hover: hover)` → touch devices never enter the hover state, so the **first tap fires the click**.
- Add `touch-action: manipulation` to the chips → immediate, delay-free tap.
- Desktop hover behaviour unchanged.

## Verification
- 635 tests; fix present in the prerendered `dist/index.html`.
- Real-device confirmation (iPhone Chrome) to follow post-deploy.