### PR TITLE
feat(locate): Zoom to it + highlight + Share on the result sheet

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2245,7 +2245,7 @@
       "parquet": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/healthcare/facilities/INDIA_HEALTH_FACILITIES_NIC.parquet",
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/healthcare/facilities/INDIA_HEALTH_FACILITIES_NIC.parquet",
-        "bytes": 4999642
+        "bytes": 7792134
       },
       "pmtiles": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/healthcare/facilities/INDIA_HEALTH_FACILITIES_NIC.pmtiles",

--- a/scripts/ingest_ramseraph.py
+++ b/scripts/ingest_ramseraph.py
@@ -554,9 +554,12 @@ def rebake_flatten_bbox(src: Path, dst: Path) -> tuple[int, list[str]]:
     has_bbox_struct = 'bbox' in col_names
     has_flat_bbox = all(c in col_names for c in ('xmin', 'ymin', 'xmax', 'ymax'))
     # ramSeraph parquet stores `geometry` already typed as GEOMETRY; a few
-    # older / simpler files store it as raw BLOB (WKB). Detect which.
-    geom_type = next((c[1] for c in cols if c[0] == 'geometry'), 'BLOB')
-    geom_expr = 'geometry' if 'GEOMETRY' in geom_type else 'ST_GeomFromWKB(geometry)'
+    # older / simpler files store it as raw BLOB (WKB) or name the column
+    # `geom` / `wkb_geometry` (e.g. own-bake point layers like nic_health).
+    # Detect the column name + its type rather than assuming `geometry`.
+    geom_col = next((c[0] for c in cols if c[0] in ('geometry', 'wkb_geometry', 'geom')), 'geometry')
+    geom_type = next((c[1] for c in cols if c[0] == geom_col), 'BLOB')
+    geom_expr = geom_col if 'GEOMETRY' in geom_type else f'ST_GeomFromWKB({geom_col})'
     # India bbox; ST_Hilbert uses this as the curve's domain so the 32-bit
     # index has max resolution over the country instead of the whole world.
     india_bbox = "ST_Extent(ST_MakeEnvelope(68, 6, 98, 38))"

--- a/scripts/rebake_layer.py
+++ b/scripts/rebake_layer.py
@@ -54,7 +54,10 @@ def patch_catalog_bytes(catalog_path: Path, layer_id: str, new_bytes: int) -> No
     cat = json.loads(catalog_path.read_text())
     layer = find_layer(cat, layer_id)
     layer.setdefault('parquet', {})['bytes'] = new_bytes
-    catalog_path.write_text(json.dumps(cat, indent=2, ensure_ascii=False))
+    # Match build_catalog.py's encoding exactly (ensure_ascii default + trailing
+    # newline) so a one-field patch stays a one-line diff instead of re-encoding
+    # every \uXXXX escape in the file.
+    catalog_path.write_text(json.dumps(cat, indent=2) + '\n')
 
 
 def rebake(layer_id: str, s3) -> None:

--- a/web/functions/api/v1/layers/[id]/locate.ts
+++ b/web/functions/api/v1/layers/[id]/locate.ts
@@ -71,6 +71,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
         ...base,
         mode: 'nearest',
         feature: { properties: f.properties },
+        feature_point: { lat: f._lat, lng: f._lng }, // so the client can zoom to it
         distance_km: f._distance_km,
         bearing: bearingLabel(lat, lng, f._lat, f._lng),
       });

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -457,10 +457,14 @@
       .ls-caveat { margin: 8px 0 0; font-size: 12px; color: var(--muted);
         background: var(--card-bg); border-radius: 6px; padding: 8px 11px; }
       .ls-actions { display: flex; gap: 8px; margin-top: 14px; }
-      .ls-actions button { flex: 1; min-height: 44px; cursor: pointer;
+      .ls-actions button { flex: 1; min-height: 44px; cursor: pointer; touch-action: manipulation;
         font: 600 13px/1 ui-sans-serif, system-ui, sans-serif; border-radius: 6px;
         border: 1px solid var(--line); background: var(--bg); color: var(--fg); }
-      .ls-actions button:hover { border-color: var(--accent); color: var(--accent); }
+      /* :hover only on real pointers — on iOS the first tap would land as hover,
+         not a click (same trap that broke the catalog pills). */
+      @media (hover: hover) {
+        .ls-actions button:hover { border-color: var(--accent); color: var(--accent); }
+      }
       .ls-actions button.primary { background: var(--accent-fill); border-color: var(--accent-fill); color: #fff; }
       .ls-close { position: absolute; top: 8px; right: 12px; background: none; border: none;
         color: var(--muted); font-size: 20px; line-height: 1; cursor: pointer; }

--- a/web/src/db.ts
+++ b/web/src/db.ts
@@ -47,7 +47,7 @@ export async function exportFilteredParquet(selectSql: string, basename: string)
     await conn.query(`COPY (${selectSql}) TO '${tmp}' (FORMAT PARQUET, COMPRESSION ZSTD)`);
     const buf = await db.copyFileToBuffer(tmp);
     await db.dropFile(tmp);
-    return new Blob([buf], { type: 'application/octet-stream' });
+    return new Blob([buf as BlobPart], { type: 'application/octet-stream' });
   } finally {
     await conn.close();
   }

--- a/web/src/filter-schema.ts
+++ b/web/src/filter-schema.ts
@@ -85,7 +85,7 @@ export function pickAffordance(col: ColumnStats, rowCount: number): Affordance {
 
   // High-precision floats that are unique per row are computed geometry
   // stats (area, length, perimeter) regardless of column name.
-  if ((col.type === 'float' || col.type === 'double') && rowCount >= 10) {
+  if (col.type === 'float' && rowCount >= 10) {
     const nonNull = rowCount * (1 - col.nullFrac);
     if (nonNull > 0 && col.distinct / nonNull > 0.9) {
       return { kind: 'drop', reason: 'per-row float (likely computed stat)' };

--- a/web/src/locate-actions.ts
+++ b/web/src/locate-actions.ts
@@ -1,0 +1,36 @@
+// Pure helpers for the Find-my-location result-sheet actions (Zoom / Highlight
+// / Share). No DOM, no map — just data in, data out, so they're unit-testable.
+
+// A MapLibre filter that matches exactly the located feature. The locate result
+// and the rendered vector tiles come from the *same* pmtiles, so asserting every
+// scalar property the result carries uniquely picks that one feature out of its
+// neighbours (extra tile-only props don't break an `all` match). Returns null
+// when there's nothing usable to match on (caller should skip highlighting
+// rather than match-all).
+export function buildFeatureFilter(props: Record<string, unknown>): unknown[] | null {
+  const conds = Object.entries(props)
+    .filter(([, v]) => typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
+    .map(([k, v]) => ['==', ['get', k], v]);
+  return conds.length ? ['all', ...conds] : null;
+}
+
+// Shareable link that reopens this located view: /view/<id>?at=<lat>,<lng>.
+// 5 decimals ≈ 1 m — enough to land back in the same feature without leaking a
+// more precise coordinate than necessary.
+export function shareUrl(origin: string, layerId: string, lat: number, lng: number): string {
+  return `${origin}/view/${encodeURIComponent(layerId)}?at=${lat.toFixed(5)},${lng.toFixed(5)}`;
+}
+
+// Parse the ?at=lat,lng deep-link back into coords. Rejects anything outside the
+// India bbox (same gate as the endpoint) so a malformed/hostile param can't
+// drive the map somewhere nonsensical.
+export function parseAtParam(raw: string | null): { lat: number; lng: number } | null {
+  if (!raw) return null;
+  const parts = raw.split(',');
+  if (parts.length !== 2) return null;
+  const lat = parseFloat(parts[0]);
+  const lng = parseFloat(parts[1]);
+  if (!isFinite(lat) || !isFinite(lng)) return null;
+  if (lat < 6 || lat > 38 || lng < 68 || lng > 98) return null;
+  return { lat, lng };
+}

--- a/web/src/locate.ts
+++ b/web/src/locate.ts
@@ -1,15 +1,18 @@
-// Find-my-location flow: geolocate -> GET /api/v1/layers/{id}/locate -> render
-// the result in the #locate-sheet. Lazy-loaded by map.ts when the user taps the
-// Locate toolbar item; the result sheet is governed by the single-open overlay
-// controller (scrim + close), so this module only owns its own content.
+// Find-my-location flow: geolocate (or a shared ?at= coord) -> GET
+// /api/v1/layers/{id}/locate -> render the result in the #locate-sheet, with
+// Zoom-to-it (highlight + frame, via the onZoom callback into map.ts) and Share
+// actions. The sheet is governed by the single-open overlay controller (scrim +
+// close), so this module only owns its own content.
 
 import { pickFeatureName } from './locate-format';
 import type { LocateConfig } from './locate-config';
 import { escapeHtml } from './util';
+import { shareUrl } from './locate-actions';
 
 type LocateApiResponse = {
   mode: 'contains' | 'nearest';
   feature: { properties: Record<string, unknown> } | null;
+  feature_point?: { lat: number; lng: number };
   distance_km?: number;
   bearing?: string;
   out_of_coverage?: boolean;
@@ -23,9 +26,11 @@ export function openLocate(opts: {
   config: LocateConfig;
   sheet: HTMLElement;
   btn: HTMLElement;
+  onZoom?: (props: Record<string, unknown>, lng: number, lat: number) => void;
+  coords?: { lat: number; lng: number };
   onClose: () => void;
 }): void {
-  const { layerId, config, sheet, btn, onClose } = opts;
+  const { layerId, config, sheet, btn, onZoom, coords, onClose } = opts;
   sheet.classList.add('open');
   sheet.setAttribute('aria-hidden', 'false');
   const stopPulse = () => btn.classList.remove('locating');
@@ -44,6 +49,12 @@ export function openLocate(opts: {
 
   render(`<p class="ls-msg"><span class="ls-spinner"></span>Locating you…</p>`);
 
+  // Shared ?at= link: skip geolocation, use the supplied coords, auto-zoom.
+  if (coords) {
+    run(coords.lat, coords.lng, true);
+    return;
+  }
+
   if (!('geolocation' in navigator)) {
     stopPulse();
     render(msg("Your browser doesn't support location."));
@@ -51,25 +62,7 @@ export function openLocate(opts: {
   }
 
   navigator.geolocation.getCurrentPosition(
-    async (pos) => {
-      stopPulse();
-      const { latitude: lat, longitude: lng } = pos.coords;
-      try {
-        const r = await fetch(
-          `/api/v1/layers/${encodeURIComponent(layerId)}/locate?lat=${lat}&lng=${lng}&mode=${config.mode}`,
-        );
-        if (r.status === 400) {
-          // outside India bbox — the only 400 the endpoint returns for valid coords
-          result('Outside coverage', "You're outside this layer's area",
-            `<p class="ls-sub">This data covers India.</p>`);
-          return;
-        }
-        if (!r.ok) throw new Error(String(r.status));
-        renderResult((await r.json()) as LocateApiResponse);
-      } catch {
-        render(msg("Couldn't look that up — try again."));
-      }
-    },
+    (pos) => run(pos.coords.latitude, pos.coords.longitude, false),
     (err) => {
       stopPulse();
       render(msg(err.code === err.PERMISSION_DENIED
@@ -79,18 +72,69 @@ export function openLocate(opts: {
     { enableHighAccuracy: true, timeout: 10000, maximumAge: 30000 },
   );
 
-  function renderResult(data: LocateApiResponse) {
+  async function run(lat: number, lng: number, autoZoom: boolean) {
+    stopPulse();
+    try {
+      const r = await fetch(
+        `/api/v1/layers/${encodeURIComponent(layerId)}/locate?lat=${lat}&lng=${lng}&mode=${config.mode}`,
+      );
+      if (r.status === 400) {
+        // outside India bbox — the only 400 the endpoint returns for valid coords
+        result('Outside coverage', "You're outside this layer's area",
+          `<p class="ls-sub">This data covers India.</p>`);
+        return;
+      }
+      if (!r.ok) throw new Error(String(r.status));
+      renderResult((await r.json()) as LocateApiResponse, lat, lng, autoZoom);
+    } catch {
+      render(msg("Couldn't look that up — try again."));
+    }
+  }
+
+  function renderResult(data: LocateApiResponse, lat: number, lng: number, autoZoom: boolean) {
     const isNearest = data.mode === 'nearest';
     if (!data.feature) {
       result(isNearest ? 'Nothing nearby' : 'Not found', "You're outside this layer's area",
         `<p class="ls-sub">No feature ${isNearest ? 'within range' : 'contains your location'} here.</p>`);
       return;
     }
-    const name = escapeHtml(pickFeatureName(data.feature.properties));
+    const props = data.feature.properties;
+    const name = pickFeatureName(props);
     const sub = isNearest && data.distance_km != null
       ? `<p class="ls-sub"><span class="ls-dist">${data.distance_km} km${data.bearing ? ' ' + escapeHtml(data.bearing) : ''}</span></p>`
       : '';
-    result(isNearest ? 'Nearest to you' : 'You are here', name, sub);
+    // Zoom target: the feature for nearest (it's elsewhere); the user for
+    // contains (they're inside it).
+    const zp = isNearest && data.feature_point ? data.feature_point : { lat, lng };
+    const actions = '<div class="ls-actions">' +
+      (onZoom ? '<button type="button" class="ls-act ls-zoom primary">Zoom to it</button>' : '') +
+      '<button type="button" class="ls-act ls-share">Share</button></div>';
+    result(isNearest ? 'Nearest to you' : 'You are here', escapeHtml(name), sub + actions);
+
+    const zoom = () => onZoom?.(props, zp.lng, zp.lat);
+    sheet.querySelector('.ls-zoom')?.addEventListener('click', zoom);
+    sheet.querySelector('.ls-share')?.addEventListener('click', () => share(lat, lng, name));
+    if (autoZoom) zoom();
+  }
+
+  async function share(lat: number, lng: number, name: string) {
+    const url = shareUrl(location.origin, layerId, lat, lng);
+    // navigator.share / clipboard must run in this click gesture; call them
+    // synchronously (the awaited promise resolving later is fine).
+    if (navigator.share) {
+      try { await navigator.share({ title: 'bharatlas', text: `${name} — bharatlas`, url }); }
+      catch { /* user cancelled the share sheet */ }
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(url);
+      const b = sheet.querySelector<HTMLElement>('.ls-share');
+      if (b) {
+        const prev = b.textContent;
+        b.textContent = 'Link copied';
+        setTimeout(() => { if (b.textContent === 'Link copied') b.textContent = prev; }, 1600);
+      }
+    } catch { /* clipboard blocked — nothing else to offer */ }
   }
 }
 

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -333,8 +333,8 @@ if (searchInput && grid) {
 // always current (no catalog.json drift). Patches the prerendered
 // count spans in-place; if the fetch fails, baked values remain.
 fetch('/api/dl/counts')
-  .then((r) => (r.ok ? r.json() : null))
-  .then((counts: Record<string, Record<string, number> | number> | null) => {
+  .then((r) => (r.ok ? (r.json() as Promise<Record<string, Record<string, number> | number>>) : null))
+  .then((counts) => {
     if (!counts) return;
 
     // Patch per-format badges: <span class="count" title="N downloads">N</span>
@@ -365,7 +365,7 @@ fetch('/api/dl/counts')
           span.textContent = fmtCount(n);
           // Insert after the size span (link → size-span → count-span)
           const sizeSpan = link.nextElementSibling;
-          if (sizeSpan) sizeSpan.after(span);
+          if (sizeSpan) sizeSpan.insertAdjacentElement('afterend', span);
         }
       }
     }
@@ -390,8 +390,8 @@ fetch('/api/dl/counts')
 // without waiting for the next prerender. Missing entries mean 0 votes —
 // leave the baked default alone.
 fetch('/api/c/useful-counts')
-  .then((r) => (r.ok ? r.json() : null))
-  .then((counts: Record<string, number> | null) => {
+  .then((r) => (r.ok ? (r.json() as Promise<Record<string, number>>) : null))
+  .then((counts) => {
     if (!counts) return;
     for (const card of document.querySelectorAll<HTMLElement>('.comm-card[data-id]')) {
       const id = card.dataset.id || '';

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -69,8 +69,13 @@ const LEVEL_ZOOM: Record<string, number> = {
   assembly_constituency: 9, parliament_constituency: 8, seismic_zone: 7, eco_zone: 7,
   health_facility: 14, airport: 11,
 };
-const arrivalZoom = (level: string | null): number =>
-  (level && LEVEL_ZOOM[level]) || (level && /^wards_/.test(level) ? 13 : 11);
+function arrivalZoom(level: string | null): number {
+  if (!level) return 11;
+  const z = LEVEL_ZOOM[level]; // own-prop number, or inherited junk like toString
+  if (typeof z === 'number') return z;
+  if (/^wards_/.test(level)) return 13; // ward layers aren't in the table
+  return 11;
+}
 
 // ---------------------------------------------------------------------------
 // Single-open overlay controller
@@ -336,8 +341,8 @@ function highlightAndZoom(props: Record<string, unknown>, lng: number, lat: numb
         'circle-radius': ['interpolate', ['linear'], ['zoom'], 8, 6, 14, 11] } });
   }
 
-  const z = arrivalZoom(currentLayerLevel);
-  map.flyTo({ center: [lng, lat], zoom: Math.max(map.getZoom(), z), duration: 700 });
+  const targetZoom = Math.max(map.getZoom(), arrivalZoom(currentLayerLevel));
+  map.flyTo({ center: [lng, lat], zoom: targetZoom, duration: 700 });
 
   // Best-effort tighten to the feature's real bounds once tiles settle.
   // querySourceFeatures returns tile-clipped geometry, but the union bbox frames

--- a/web/src/map.ts
+++ b/web/src/map.ts
@@ -20,6 +20,7 @@ import { resolveLocateConfig } from './locate-config';
 // user-gesture window, which mobile Chrome silently drops (no prompt, no sheet).
 // locate is tiny and folds into this already-lazy map chunk.
 import { openLocate, closeLocate } from './locate';
+import { buildFeatureFilter, parseAtParam } from './locate-actions';
 
 type Layer = {
   id: string;
@@ -52,6 +53,24 @@ let map: MlMap | null = null;
 let filterAbort: AbortController | null = null;
 let activeBasemap: BasemapId = 'minimal';
 let layerBounds: [number, number, number, number] = INDIA_BOUNDS;
+// Source-layer + level of the open layer, used by the locate "Zoom to it"
+// highlight (filter the same source; pick a sensible arrival zoom by level).
+let currentSourceLayer: string | undefined;
+let currentLayerLevel: string | null = null;
+// Coords from a shared ?at=lat,lng link, consumed by the next locate show()
+// so the deep-link reproduces the result without the visitor's own GPS.
+let pendingLocateCoords: { lat: number; lng: number } | null = null;
+
+// Arrival zoom for "Zoom to it", keyed by layer level. A best-effort fitBounds
+// then tightens to the actual feature; this just gets us close enough that the
+// feature's tiles are loaded for that fit. Wards default to 13, else 11.
+const LEVEL_ZOOM: Record<string, number> = {
+  state: 6, district: 9, subdistrict: 10, block: 11, panchayat: 12, village: 13,
+  assembly_constituency: 9, parliament_constituency: 8, seismic_zone: 7, eco_zone: 7,
+  health_facility: 14, airport: 11,
+};
+const arrivalZoom = (level: string | null): number =>
+  (level && LEVEL_ZOOM[level]) || (level && /^wards_/.test(level) ? 13 : 11);
 
 // ---------------------------------------------------------------------------
 // Single-open overlay controller
@@ -181,7 +200,7 @@ function asBounds(b: [number, number, number, number]): [[number, number], [numb
 
 function flyTo(
   bounds: [number, number, number, number],
-  opts?: { padding?: Record<string, number>; duration?: number },
+  opts?: { padding?: Padding; duration?: number },
 ): void {
   if (!map) return;
   map.fitBounds(asBounds(bounds), {
@@ -283,6 +302,65 @@ function addDataLayers(sourceId: string, sourceLayer?: string) {
 }
 
 // ---------------------------------------------------------------------------
+// Locate "Zoom to it" — highlight the located feature + frame it
+// ---------------------------------------------------------------------------
+
+const HL_LAYERS = ['locate-hl-fill', 'locate-hl-line', 'locate-hl-circle'];
+const HL_ACCENT = '#f59e0b'; // amber — stands out against the blue data layers
+
+function clearLocateHighlight(): void {
+  if (!map) return;
+  for (const id of HL_LAYERS) if (map.getLayer(id)) map.removeLayer(id);
+}
+
+// Highlight the located feature in accent so it reads as "this one" among its
+// neighbours (which stay rendered normally), then fly to it. Polygon → fill +
+// line; point → circle (whichever the geometry matches paints; the others are
+// no-ops). Called from the result sheet's "Zoom to it" with the user's point
+// (contains) or the feature's point (nearest).
+function highlightAndZoom(props: Record<string, unknown>, lng: number, lat: number): void {
+  if (!map) return;
+  clearLocateHighlight();
+  const filter = buildFeatureFilter(props);
+  const common = currentSourceLayer ? { 'source-layer': currentSourceLayer } : {};
+  if (filter) {
+    map.addLayer({ id: 'locate-hl-fill', type: 'fill', source: 'layer', ...common, filter: filter as never,
+      paint: { 'fill-color': HL_ACCENT, 'fill-opacity': 0.3 } });
+    map.addLayer({ id: 'locate-hl-line', type: 'line', source: 'layer', ...common, filter: filter as never,
+      paint: { 'line-color': HL_ACCENT, 'line-opacity': 1,
+        'line-width': ['interpolate', ['linear'], ['zoom'], 6, 2, 12, 3.5] } });
+    // Circle only for point geometries — otherwise it beads every polygon vertex.
+    map.addLayer({ id: 'locate-hl-circle', type: 'circle', source: 'layer', ...common,
+      filter: ['all', POINT_GEOM_FILTER, ...filter.slice(1)] as never,
+      paint: { 'circle-color': HL_ACCENT, 'circle-stroke-width': 2, 'circle-stroke-color': '#fff',
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 8, 6, 14, 11] } });
+  }
+
+  const z = arrivalZoom(currentLayerLevel);
+  map.flyTo({ center: [lng, lat], zoom: Math.max(map.getZoom(), z), duration: 700 });
+
+  // Best-effort tighten to the feature's real bounds once tiles settle.
+  // querySourceFeatures returns tile-clipped geometry, but the union bbox frames
+  // the feature well when its tiles are loaded (they are, after the flyTo). A
+  // point's bbox is ~zero-area, so we leave the flyTo zoom in that case.
+  if (!filter) return;
+  map.once('idle', () => {
+    if (!map) return;
+    try {
+      const feats = map.querySourceFeatures('layer', {
+        ...(currentSourceLayer ? { sourceLayer: currentSourceLayer } : {}),
+        filter: filter as never,
+      });
+      if (!feats.length) return;
+      const b = featureCollectionBounds({ type: 'FeatureCollection', features: feats } as unknown as FC);
+      if (!b) return;
+      if (b[2] - b[0] < 1e-4 && b[3] - b[1] < 1e-4) return; // a point — already framed
+      map.fitBounds(asBounds(b), { padding: panelAwarePadding(), maxZoom: 15, duration: 500 });
+    } catch { /* query/fit is best-effort */ }
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Popup
 // ---------------------------------------------------------------------------
 
@@ -357,6 +435,7 @@ async function attachData(layer: Layer) {
     const vlayers = (metadata as { vector_layers?: Array<{ id: string }> }).vector_layers || [];
     if (!vlayers.length) throw new Error('pmtiles has no vector_layers');
     const sourceLayer = vlayers[0].id;
+    currentSourceLayer = sourceLayer;
 
     map.addSource('layer', {
       type: 'vector',
@@ -387,6 +466,7 @@ async function attachData(layer: Layer) {
     } catch {
       // network/parse failure → fall back to the URL load + India bounds
     }
+    currentSourceLayer = undefined;
     map.addSource('layer', { type: 'geojson', data: data as never, attribution: layer.source });
     addDataLayers('layer');
   } else {
@@ -495,7 +575,7 @@ function applyActiveFilters(
   for (const id of DATA_LAYERS) {
     if (!map.getLayer(id)) continue;
     if (id === 'point') {
-      map.setFilter(id, mapFilter ? ['all', POINT_GEOM_FILTER, mapFilter as maplibregl.FilterSpecification] : POINT_GEOM_FILTER);
+      map.setFilter(id, mapFilter ? (['all', POINT_GEOM_FILTER, mapFilter] as unknown as maplibregl.FilterSpecification) : POINT_GEOM_FILTER);
     } else {
       map.setFilter(id, (mapFilter as maplibregl.FilterSpecification | null) ?? null);
     }
@@ -787,7 +867,13 @@ function wireLocateButton(
       btn.classList.add('locating');
       // Synchronous: opens the sheet ("Locating you…") and fires
       // getCurrentPosition in the same tap, so the prompt actually appears.
-      openLocate({ layerId: layer.id, config, sheet, btn, onClose: () => dispatchOverlay({ type: 'close' }) });
+      openLocate({
+        layerId: layer.id, config, sheet, btn,
+        onZoom: highlightAndZoom,
+        coords: pendingLocateCoords ?? undefined,
+        onClose: () => dispatchOverlay({ type: 'close' }),
+      });
+      pendingLocateCoords = null;
     },
     hide: () => {
       btn.classList.remove('locating');
@@ -832,6 +918,7 @@ export async function openLayer(layerId: string, opts: { titleEl: HTMLElement })
   wireFilterButton(layer).catch((e) => console.warn('wireFilterButton failed', e));
   wireDownloadButton(layer);
   wireBasemapButton();
+  currentLayerLevel = layer.level;
   wireLocateButton(layer, levelMeta);
 
   const container = document.getElementById('map')!;
@@ -868,7 +955,17 @@ export async function openLayer(layerId: string, opts: { titleEl: HTMLElement })
     try {
       await attachData(layer);
       await addLgdOverlay(cat.layers ?? [], layer.id);
-      map.once('idle', () => loader.dismiss());
+      if (!map) return; // closeLayer may have run during the awaits
+      map.once('idle', () => {
+        loader.dismiss();
+        // ?at=lat,lng deep-link (from Share): reproduce the located result and
+        // zoom/highlight using the shared coords, not the visitor's own GPS.
+        const at = parseAtParam(new URLSearchParams(location.search).get('at'));
+        if (at && surfaceHandles.findward) {
+          pendingLocateCoords = at;
+          dispatchOverlay({ type: 'toggle', surface: 'findward' });
+        }
+      });
     } catch (e) {
       console.error('attachData failed', e);
       const c = document.getElementById('map')!;

--- a/web/src/preview.ts
+++ b/web/src/preview.ts
@@ -216,7 +216,7 @@ async function maybeFetchUrlParam(): Promise<void> {
 {
   const cat = new URLSearchParams(location.search).get('category');
   if (cat) {
-    const select = document.getElementById('f-cat') as HTMLSelectElement;
+    const select = document.getElementById('f-cat') as HTMLSelectElement | null;
     if (select && [...select.options].some((o) => o.value === cat)) select.value = cat;
   }
 }

--- a/web/tests/locate-actions.test.ts
+++ b/web/tests/locate-actions.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { buildFeatureFilter, shareUrl, parseAtParam } from '../src/locate-actions';
+
+describe('buildFeatureFilter', () => {
+  it('matches a feature on all its scalar properties', () => {
+    expect(buildFeatureFilter({ KGISWardNo: 150, KGISWardName: 'Shanthala Nagar' })).toEqual([
+      'all',
+      ['==', ['get', 'KGISWardNo'], 150],
+      ['==', ['get', 'KGISWardName'], 'Shanthala Nagar'],
+    ]);
+  });
+
+  it('skips non-scalar / object values', () => {
+    const f = buildFeatureFilter({ name: 'X', bbox: [1, 2, 3, 4], meta: { a: 1 }, n: 7 }) as unknown[];
+    expect(f).toEqual(['all', ['==', ['get', 'name'], 'X'], ['==', ['get', 'n'], 7]]);
+  });
+
+  it('returns null when there is nothing to match on (never match-all)', () => {
+    expect(buildFeatureFilter({})).toBeNull();
+    expect(buildFeatureFilter({ geom: [1, 2], meta: {} })).toBeNull();
+  });
+});
+
+describe('shareUrl', () => {
+  it('builds a /view/<id>?at= link at ~1m precision', () => {
+    expect(shareUrl('https://bharatlas.com', 'wards_bengaluru_bbmp_2022', 12.97161, 77.59456))
+      .toBe('https://bharatlas.com/view/wards_bengaluru_bbmp_2022?at=12.97161,77.59456');
+  });
+  it('encodes the layer id', () => {
+    expect(shareUrl('https://bharatlas.com', 'c_a/b', 12.5, 77.5)).toContain('/view/c_a%2Fb?at=');
+  });
+});
+
+describe('parseAtParam', () => {
+  it('parses a valid in-India coord', () => {
+    expect(parseAtParam('12.9716,77.5946')).toEqual({ lat: 12.9716, lng: 77.5946 });
+  });
+  it('rejects malformed / out-of-India / missing', () => {
+    expect(parseAtParam(null)).toBeNull();
+    expect(parseAtParam('12.9716')).toBeNull();
+    expect(parseAtParam('abc,def')).toBeNull();
+    expect(parseAtParam('51.5,-0.12')).toBeNull(); // London, outside India bbox
+    expect(parseAtParam('12.9716,77.5946,5')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What
After **"You are here → Ward N"**, the locate result sheet now has the actions from the mockup (Details dropped — it's already in the polygon hover):

- **Zoom to it** — flies to the feature and **highlights it in amber** so it reads as "this one" among its neighbours, which stay rendered normally. The highlight is a *filter layer on the same vector source* (fill+line for polygons, circle for points), so there's no geometry round-trip and no tile-clipping issue. A best-effort `fitBounds` tightens to the feature once tiles settle.
- **Share** — native share / clipboard of a `/view/<id>?at=lat,lng` deep-link that reopens this located view (zoom + highlight) using the **shared** coords, not the visitor's own GPS. `share()`/clipboard run in the tap gesture (iOS-safe).

The endpoint returns `feature_point` for nearest so Zoom can target the feature (vs the user for contains).

## Also
- **Cleared every pre-existing `tsc` error** (`tsc --noEmit` is now clean): 3 in map.ts (flyTo padding type, post-await map null-guard, setFilter cast) + db.ts / filter-schema.ts / preview.ts / main.ts ×3. All behaviour-preserving (see the `fix(types)` commit).
- Result-sheet buttons get the same iOS hover guard + `touch-action` as the catalog-pills fix.

## Verification
- Pure helpers (filter builder, share URL, `?at=` parser) red-green tested. **642 tests**, build clean, **tsc clean**.
- Headless end-to-end (mocked endpoint, real public-R2 tiles): actions render, **Zoom highlights the ward cleanly** (amber fill+outline, no vertex beading), **Share** builds the right link, and the **`?at=` deep-link** auto-locates + auto-zooms with no GPS. Screenshots confirm.
- The live highlight against prod R2 confirms on deploy (same dependency as the rest of locate).