### PR TITLE
feat(seo): task-framed ward-page snippets + HowTo (match real GSC queries)

### DIFF
--- a/web/functions/lib/view-dataset.ts
+++ b/web/functions/lib/view-dataset.ts
@@ -43,6 +43,9 @@ export type ViewDataset = {
   ogImage: string;
   jsonLd: Record<string, unknown>;
   breadcrumbJsonLd: Record<string, unknown>;
+  /** Ward pages only: a HowTo "find your ward number" block for AEO / the
+   * "how to find my ward number in <city>" query. Omitted elsewhere. */
+  howToJsonLd?: Record<string, unknown>;
 };
 
 const META_DESC_MAX = 158;
@@ -124,6 +127,36 @@ function buildDistribution(layer: CatalogLayer): Array<Record<string, unknown>> 
   return out;
 }
 
+// Ward pages get a task-framed snippet + a HowTo, matching the real GSC
+// queries ("which ward is my location", "[city] ward map", "ward number/name",
+// "how to find my ward number in <city>") instead of the dataset-framed
+// "Map of N wards… download GeoJSON" that was leaking the click. `subject` is
+// the seo_title's "<City> Ward Map" prefix (split on ":"); `place` is that minus
+// "Ward Map". Kept ≤158 chars by construction so the snippet never truncates.
+export function wardSeo(seoTitle: string, count: string | null): {
+  description: string;
+  howTo: Record<string, unknown>;
+} {
+  const subject = seoTitle.split(':')[0].trim() || seoTitle.trim();
+  const place = subject.replace(/\s*ward map\s*$/i, '').trim() || subject;
+  const n = count ? `${count} ` : '';
+  return {
+    description:
+      `Which ward is your location in? Tap the map for your ward number and name. ` +
+      `${n}${place} wards with area names, free to view or download.`,
+    howTo: {
+      '@context': 'https://schema.org',
+      '@type': 'HowTo',
+      name: `How to find your ward number in ${place}`,
+      step: [
+        { '@type': 'HowToStep', name: 'Open the ward map', text: `Open the ${subject} on bharatlas.` },
+        { '@type': 'HowToStep', name: 'Tap your location', text: 'Tap "My ward" and allow location access.' },
+        { '@type': 'HowToStep', name: 'Read your ward', text: 'Your ward number and name appear on the map.' },
+      ],
+    },
+  };
+}
+
 export function buildViewDataset(
   layer: CatalogLayer,
   levelMeta: LevelMeta | undefined,
@@ -132,7 +165,12 @@ export function buildViewDataset(
   const title = levelMeta?.seo_title || levelMeta?.label || layer.name || layer.id.replace(/_/g, ' ');
   const unit = levelMeta?.unit || 'features';
   const count = layer.rows != null ? layer.rows.toLocaleString('en-IN') : null;
+  // Ward layers are the #1 search intent ("which ward am I in"); override the
+  // dataset-framed snippet with a task-framed one + HowTo. Titles stay as-is —
+  // they already match the dominant "<city> ward map" / "<corp> ward map" query.
+  const ward = /^wards_/.test(layer.id) ? wardSeo(title, count) : null;
   const baseDescription =
+    ward?.description ??
     levelMeta?.seo_description ??
     levelMeta?.description ??
     (layer.description || `${title} — ${count ? count + ' ' + unit + ' · ' : ''}${layer.source}.`);
@@ -181,6 +219,7 @@ export function buildViewDataset(
         { '@type': 'ListItem', position: 3, name: title, item: canonical },
       ],
     },
+    ...(ward ? { howToJsonLd: ward.howTo } : {}),
   };
 }
 

--- a/web/functions/view/[id].ts
+++ b/web/functions/view/[id].ts
@@ -44,7 +44,7 @@ export const onRequestGet: PagesFunction<unknown, keyof Params> = async (ctx) =>
   }
 
   const levelMeta = resolveLevelMeta(layer, catalog.level_meta);
-  const { title, description, canonical, ogImage, jsonLd, breadcrumbJsonLd } = buildViewDataset(
+  const { title, description, canonical, ogImage, jsonLd, breadcrumbJsonLd, howToJsonLd } = buildViewDataset(
     layer,
     levelMeta,
     CANONICAL_ORIGIN,
@@ -69,6 +69,10 @@ export const onRequestGet: PagesFunction<unknown, keyof Params> = async (ctx) =>
         el.setInnerContent(JSON.stringify(jsonLd).replace(/</g, '\\u003c'), { html: true });
         const bc = JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c');
         el.after(`\n    <script type="application/ld+json">${bc}</script>`, { html: true });
+        if (howToJsonLd) {
+          const ht = JSON.stringify(howToJsonLd).replace(/</g, '\\u003c');
+          el.after(`\n    <script type="application/ld+json">${ht}</script>`, { html: true });
+        }
       },
     })
     .on('body', {

--- a/web/tests/view-dataset-ward.test.ts
+++ b/web/tests/view-dataset-ward.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { wardSeo } from '../functions/lib/view-dataset';
+
+// Ward pages are the #1 search intent. wardSeo turns the dataset-framed
+// seo_title into a task-framed snippet + HowTo that matches the real GSC
+// queries (which ward is my location / [city] ward map / ward number+name /
+// how to find my ward number in [city]). Snippet must stay ≤158 (SERP cap).
+
+const REAL_TITLES: ReadonlyArray<[string, string]> = [
+  ['Chennai Ward Map: 200 wards (GCC)', '200'],
+  ['Mumbai Ward Map: 24 wards (BMC)', '24'],
+  ['Hyderabad Ward Map: 145 wards (GHMC)', '145'],
+  ['Kolkata Ward Map: 141 wards (KMC)', '141'],
+  ['Bengaluru Ward Map: 369 wards (GBA 2025)', '369'],
+  ['BBMP Ward Map: 243 wards (Bengaluru, 2022)', '243'],
+  ['Visakhapatnam Ward Map: 98 wards (GVMC)', '98'],
+];
+
+describe('wardSeo', () => {
+  it('builds a task-framed snippet matching the real query language', () => {
+    const { description } = wardSeo('Chennai Ward Map: 200 wards (GCC)', '200');
+    expect(description).toContain('Which ward is your location in?'); // "which ward is my location"
+    expect(description).toContain('ward number and name'); // "ward no/name of my location"
+    expect(description).toContain('200 Chennai wards'); // "[city] ward" + count
+    expect(description).toContain('area names'); // "ward list area wise" / "ward N city"
+    expect(description).toContain('free to view or download');
+  });
+
+  it('keeps every real ward snippet within the 158-char SERP cap', () => {
+    for (const [title, count] of REAL_TITLES) {
+      expect(wardSeo(title, count).description.length).toBeLessThanOrEqual(158);
+    }
+  });
+
+  it('emits a HowTo keyed to "how to find my ward number in <place>"', () => {
+    const { howTo } = wardSeo('Chennai Ward Map: 200 wards (GCC)', '200');
+    expect(howTo['@type']).toBe('HowTo');
+    expect(howTo.name).toBe('How to find your ward number in Chennai');
+    const steps = howTo.step as Array<{ text: string }>;
+    expect(steps).toHaveLength(3);
+    expect(steps[1].text).toContain('My ward');
+    expect(steps[0].text).toContain('Chennai Ward Map');
+  });
+
+  it('handles a corp-prefixed title (no city word) gracefully', () => {
+    const { description, howTo } = wardSeo('BBMP Ward Map: 243 wards (Bengaluru, 2022)', '243');
+    expect(description).toContain('243 BBMP wards');
+    expect(howTo.name).toBe('How to find your ward number in BBMP');
+  });
+
+  it('tolerates a missing count', () => {
+    expect(wardSeo('Chennai Ward Map', null).description).toContain('Chennai wards');
+  });
+});


### PR DESCRIPTION
## Why
Ward pages are ~the entire organic surface but **leak the click** — `wards_ahmedabad` 440 impr @ **1.14% CTR**, and several page-1 wards at **0% CTR**. The snippet was *dataset-framed* ("Map of N wards… download GeoJSON"), and `wards_bengaluru_bbmp_2022` even front-loaded "historical, superseded" (a CTR-killer). It didn't answer the searcher's question or advertise the locate feature we just shipped.

## What people actually search (28-day GSC, impression-weighted)
- **"[city] ward map"** — 191 impr (bmc / bbmp / vmc / pcmc / mumbai / bangalore…)
- **"ward number / name **of my location**"** — 95 impr
- **"which ward is my location"** — 17 impr
- **"how to find my ward number in [city]"**

Nobody searches "find my ward" / "ward near me" (3 / 1 impr).

## Change (templated, all ~31 ward pages + future ones)
`wardSeo()` in `view-dataset.ts`, for `/^wards_/` layers:
- **Description** → `Which ward is your location in? Tap the map for your ward number and name. {N} {city} wards with area names, free to view or download.`
- **HowTo JSON-LD** → `How to find your ward number in {city}` (3 steps) — for the AEO / featured-snippet intent.
- **Titles kept as-is** — they already match the dominant "[city]/[corp] ward map" pattern; changing them risks dropping the corp keyword (BMC/GCC/GHMC).

## Length-safe (per the indexing caps)
Rendered descriptions: **Chennai 135 / Mumbai 133 / BBMP 132 chars** — all under Google's 158 cap, no truncation. `buildViewDataset`'s `.slice(158)` is the hard backstop; a test asserts ≤158 across cities.

## Verification
- Red-green: +5 cases (incl. the ≤158 guard). **647 tests, tsc clean.**
- Verified rendered `<head>` for Chennai / Mumbai / BBMP via the edge function: title kept, task-framed description, **3 JSON-LD blocks** (Dataset · HowTo · Breadcrumb).

(Logged separately: municipal **zones** as a coverage candidate — the one non-ward search cluster, but a data/ingest task, not a metadata fix.)