### PR TITLE
fix(seo): claim ward "area names" only where the layer has them

### DIFF
--- a/web/functions/lib/view-dataset.ts
+++ b/web/functions/lib/view-dataset.ts
@@ -133,17 +133,25 @@ function buildDistribution(layer: CatalogLayer): Array<Record<string, unknown>> 
 // "Map of N wards… download GeoJSON" that was leaking the click. `subject` is
 // the seo_title's "<City> Ward Map" prefix (split on ":"); `place` is that minus
 // "Ward Map". Kept ≤158 chars by construction so the snippet never truncates.
-export function wardSeo(seoTitle: string, count: string | null): {
+// `origDescription` is the layer's hand-authored seo_description — its
+// "boundaries and names" vs "…and numbers" wording is the only signal we have
+// (the catalog carries no column schema) for whether the layer actually has
+// area names. Only claim "name" / "area names" when it's there; never promise
+// data the layer doesn't have. Data is what it is.
+export function wardSeo(seoTitle: string, count: string | null, origDescription?: string): {
   description: string;
   howTo: Record<string, unknown>;
 } {
   const subject = seoTitle.split(':')[0].trim() || seoTitle.trim();
   const place = subject.replace(/\s*ward map\s*$/i, '').trim() || subject;
   const n = count ? `${count} ` : '';
+  const named = /\bnames?\b/i.test(origDescription || '');
+  const youGet = named ? 'ward number and name' : 'ward number';
+  const tail = named ? `${n}${place} wards with area names` : `${n}${place} wards`;
   return {
     description:
-      `Which ward is your location in? Tap the map for your ward number and name. ` +
-      `${n}${place} wards with area names, free to view or download.`,
+      `Which ward is your location in? Tap the map for your ${youGet}. ` +
+      `${tail}, free to view or download.`,
     howTo: {
       '@context': 'https://schema.org',
       '@type': 'HowTo',
@@ -151,7 +159,8 @@ export function wardSeo(seoTitle: string, count: string | null): {
       step: [
         { '@type': 'HowToStep', name: 'Open the ward map', text: `Open the ${subject} on bharatlas.` },
         { '@type': 'HowToStep', name: 'Tap your location', text: 'Tap "My ward" and allow location access.' },
-        { '@type': 'HowToStep', name: 'Read your ward', text: 'Your ward number and name appear on the map.' },
+        { '@type': 'HowToStep', name: 'Read your ward',
+          text: named ? 'Your ward number and name appear on the map.' : 'Your ward number appears on the map.' },
       ],
     },
   };
@@ -168,7 +177,7 @@ export function buildViewDataset(
   // Ward layers are the #1 search intent ("which ward am I in"); override the
   // dataset-framed snippet with a task-framed one + HowTo. Titles stay as-is —
   // they already match the dominant "<city> ward map" / "<corp> ward map" query.
-  const ward = /^wards_/.test(layer.id) ? wardSeo(title, count) : null;
+  const ward = /^wards_/.test(layer.id) ? wardSeo(title, count, levelMeta?.seo_description) : null;
   const baseDescription =
     ward?.description ??
     levelMeta?.seo_description ??

--- a/web/tests/view-dataset-ward.test.ts
+++ b/web/tests/view-dataset-ward.test.ts
@@ -2,53 +2,62 @@ import { describe, it, expect } from 'vitest';
 import { wardSeo } from '../functions/lib/view-dataset';
 
 // Ward pages are the #1 search intent. wardSeo turns the dataset-framed
-// seo_title into a task-framed snippet + HowTo that matches the real GSC
-// queries (which ward is my location / [city] ward map / ward number+name /
-// how to find my ward number in [city]). Snippet must stay ≤158 (SERP cap).
+// seo_title into a task-framed snippet + HowTo matching the real GSC queries.
+// It must NEVER promise an area name the layer doesn't carry — the original
+// seo_description's "boundaries and names" vs "…and numbers" wording is the cue.
 
-const REAL_TITLES: ReadonlyArray<[string, string]> = [
-  ['Chennai Ward Map: 200 wards (GCC)', '200'],
-  ['Mumbai Ward Map: 24 wards (BMC)', '24'],
-  ['Hyderabad Ward Map: 145 wards (GHMC)', '145'],
-  ['Kolkata Ward Map: 141 wards (KMC)', '141'],
-  ['Bengaluru Ward Map: 369 wards (GBA 2025)', '369'],
-  ['BBMP Ward Map: 243 wards (Bengaluru, 2022)', '243'],
-  ['Visakhapatnam Ward Map: 98 wards (GVMC)', '98'],
-];
+const NAMED = 'Interactive map of all 24 wards in Mumbai (BMC). View ward boundaries and names, filter by ward.';
+const NUMBERED = 'Interactive map of all 200 wards in Chennai (GCC). View ward boundaries and numbers, filter by ward.';
 
 describe('wardSeo', () => {
-  it('builds a task-framed snippet matching the real query language', () => {
-    const { description } = wardSeo('Chennai Ward Map: 200 wards (GCC)', '200');
-    expect(description).toContain('Which ward is your location in?'); // "which ward is my location"
-    expect(description).toContain('ward number and name'); // "ward no/name of my location"
-    expect(description).toContain('200 Chennai wards'); // "[city] ward" + count
-    expect(description).toContain('area names'); // "ward list area wise" / "ward N city"
-    expect(description).toContain('free to view or download');
+  it('claims area names ONLY when the layer has them', () => {
+    const named = wardSeo('Mumbai Ward Map: 24 wards (BMC)', '24', NAMED);
+    expect(named.description).toContain('your ward number and name');
+    expect(named.description).toContain('24 Mumbai wards with area names');
+
+    const numbered = wardSeo('Chennai Ward Map: 200 wards (GCC)', '200', NUMBERED);
+    expect(numbered.description).toContain('your ward number.'); // no "and name"
+    expect(numbered.description).not.toContain('and name');
+    expect(numbered.description).not.toContain('area names');
+    expect(numbered.description).toContain('200 Chennai wards,');
   });
 
-  it('keeps every real ward snippet within the 158-char SERP cap', () => {
-    for (const [title, count] of REAL_TITLES) {
-      expect(wardSeo(title, count).description.length).toBeLessThanOrEqual(158);
+  it('matches the real query language in both cases', () => {
+    for (const d of [
+      wardSeo('Mumbai Ward Map: 24 wards (BMC)', '24', NAMED).description,
+      wardSeo('Chennai Ward Map: 200 wards (GCC)', '200', NUMBERED).description,
+    ]) {
+      expect(d).toContain('Which ward is your location in?'); // which ward is my location
+      expect(d).toContain('ward number'); // ward number
     }
   });
 
-  it('emits a HowTo keyed to "how to find my ward number in <place>"', () => {
-    const { howTo } = wardSeo('Chennai Ward Map: 200 wards (GCC)', '200');
-    expect(howTo['@type']).toBe('HowTo');
-    expect(howTo.name).toBe('How to find your ward number in Chennai');
-    const steps = howTo.step as Array<{ text: string }>;
-    expect(steps).toHaveLength(3);
-    expect(steps[1].text).toContain('My ward');
-    expect(steps[0].text).toContain('Chennai Ward Map');
+  it('keeps every real ward snippet within the 158-char SERP cap', () => {
+    const cases: Array<[string, string, string]> = [
+      ['Chennai Ward Map: 200 wards (GCC)', '200', NUMBERED],
+      ['Mumbai Ward Map: 24 wards (BMC)', '24', NAMED],
+      ['BBMP Ward Map: 243 wards (Bengaluru, 2022)', '243', ''],
+      ['Visakhapatnam Ward Map: 98 wards (GVMC)', '98', NUMBERED],
+    ];
+    for (const [t, c, od] of cases) expect(wardSeo(t, c, od).description.length).toBeLessThanOrEqual(158);
   });
 
-  it('handles a corp-prefixed title (no city word) gracefully', () => {
-    const { description, howTo } = wardSeo('BBMP Ward Map: 243 wards (Bengaluru, 2022)', '243');
-    expect(description).toContain('243 BBMP wards');
-    expect(howTo.name).toBe('How to find your ward number in BBMP');
+  it('reflects names/numbers in the HowTo final step + keys it to the place', () => {
+    const named = wardSeo('Mumbai Ward Map: 24 wards (BMC)', '24', NAMED);
+    expect((named.howTo.step as Array<{ text: string }>)[2].text).toContain('ward number and name');
+    const numbered = wardSeo('Chennai Ward Map: 200 wards (GCC)', '200', NUMBERED);
+    expect((numbered.howTo.step as Array<{ text: string }>)[2].text).toBe('Your ward number appears on the map.');
+    expect(numbered.howTo.name).toBe('How to find your ward number in Chennai');
+  });
+
+  it('defaults to conservative (no name claim) when the cue is absent', () => {
+    const d = wardSeo('BBMP Ward Map: 243 wards (Bengaluru, 2022)', '243', '').description;
+    expect(d).toContain('243 BBMP wards,');
+    expect(d).not.toContain('area names');
+    expect(d).not.toContain('and name');
   });
 
   it('tolerates a missing count', () => {
-    expect(wardSeo('Chennai Ward Map', null).description).toContain('Chennai wards');
+    expect(wardSeo('Chennai Ward Map', null, NUMBERED).description).toContain('Chennai wards,');
   });
 });


### PR DESCRIPTION
Follow-up to #140. The ward snippet promised "ward number and name … with area names" on **every** ward page, but only **3 of 31** layers (mumbai/patna/surat) actually carry names — the other 26 are number-only (chennai/vadodara/…). Per data-is-what-it-is, don't promise an area name the layer doesn't have.

`wardSeo()` now reads the layer's original `seo_description` (its "boundaries and **names**" vs "…and **numbers**" wording is the only signal — the catalog has no column schema) and renders:
- **named** → "Tap the map for your ward number **and name**. {N} {city} wards **with area names**…"
- **number-only** → "Tap the map for your ward number. {N} {city} wards…"

HowTo final step matches ("…number and name appear" vs "…number appears"). The 2 Bengaluru layers carry no cue → default conservative (no name claim).

Verified rendered: Mumbai/Surat claim names (133/132 chars), Chennai/Vadodara number-only (110 chars). 648 tests, tsc clean, all ≤158.

Aside (not in this PR): `wards_vadodara` has only **12 rows** — low for VMC vs Ahmedabad 48 / Chennai 200. Snippet reflects the data faithfully; worth checking whether that layer is complete (a coverage question, not a snippet one).