### PR TITLE
fix(seo): correct ward names/numbers labels to match the actual data

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -398,7 +398,7 @@
       "source_org": "Greater Bengaluru Authority",
       "notes": "Latest GBA delimitation. Pair with the 5-corp polygons for parent grouping.",
       "seo_title": "Bengaluru Ward Map: 369 wards (GBA 2025)",
-      "seo_description": "Map of all 369 Greater Bengaluru wards (GBA, notified Nov 2025) across 5 corporations. View boundaries and download as GeoJSON, KML or Parquet."
+      "seo_description": "Map of all 369 Greater Bengaluru wards (GBA, notified Nov 2025) across 5 corporations. View ward boundaries and names; download as GeoJSON, KML or Parquet."
     },
     "corporation_bengaluru": {
       "label": "Greater Bengaluru Corporations (2025)",
@@ -416,7 +416,7 @@
       "source_org": "BBMP",
       "notes": "Use the GBA 2025 layer for current ward boundaries.",
       "seo_title": "BBMP Ward Map: 243 wards (Bengaluru, 2022)",
-      "seo_description": "Map of 243 BBMP wards from Bengaluru's 2022 draft delimitation (historical, superseded by the 2025 GBA scheme). Download as GeoJSON or KML."
+      "seo_description": "Map of 243 BBMP wards from Bengaluru's 2022 draft delimitation (historical, superseded by the 2025 GBA scheme). View ward boundaries and names; download as GeoJSON or KML."
     },
     "bda_jurisdiction": {
       "label": "BDA Jurisdiction",
@@ -452,7 +452,7 @@
       "source_org": "Greater Hyderabad Municipal Corporation",
       "notes": "",
       "seo_title": "Hyderabad Ward Map: 145 wards (GHMC)",
-      "seo_description": "Interactive map of all 145 wards in Hyderabad (GHMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 145 wards in Hyderabad (GHMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_mumbai": {
       "label": "Mumbai (BMC) Wards",
@@ -462,7 +462,7 @@
       "source_org": "Brihanmumbai Municipal Corporation",
       "notes": "",
       "seo_title": "Mumbai Ward Map: 24 wards (BMC)",
-      "seo_description": "Interactive map of all 24 wards in Mumbai (BMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 24 wards in Mumbai (BMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "electoral_wards_mumbai_2017": {
       "label": "Mumbai Electoral Wards (2017)",
@@ -492,7 +492,7 @@
       "source_org": "Pune Municipal Corporation",
       "notes": "",
       "seo_title": "Pune Ward Map: 58 wards (PMC)",
-      "seo_description": "Interactive map of all 58 wards in Pune (PMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 58 wards in Pune (PMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_ahmedabad": {
       "label": "Ahmedabad (AMC) Wards",
@@ -502,7 +502,7 @@
       "source_org": "Ahmedabad Municipal Corporation",
       "notes": "",
       "seo_title": "Ahmedabad Ward Map: 48 wards (AMC)",
-      "seo_description": "Interactive map of all 48 wards in Ahmedabad (AMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 48 wards in Ahmedabad (AMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_jaipur": {
       "label": "Jaipur (JMC) Wards",
@@ -532,7 +532,7 @@
       "source_org": "Kochi Municipal Corporation",
       "notes": "",
       "seo_title": "Kochi Ward Map: 74 wards (KMC)",
-      "seo_description": "Interactive map of all 74 wards in Kochi (KMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 74 wards in Kochi (KMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_bhubaneshwar": {
       "label": "Bhubaneshwar (BMC) Wards",
@@ -572,7 +572,7 @@
       "source_org": "DataMeet",
       "notes": "",
       "seo_title": "Delhi Ward Map: 290 wards (MCD, NDMC, Cantt)",
-      "seo_description": "Interactive map of all 290 Delhi municipal wards (MCD, NDMC and Cantonment). View ward boundaries and numbers, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 290 Delhi municipal wards (MCD, NDMC and Cantonment). View ward boundaries and names, and download as GeoJSON, KML or Parquet."
     },
     "wards_indore": {
       "label": "Indore (IMC) Wards (2024)",
@@ -582,7 +582,7 @@
       "source_org": "Indore Municipal Corporation",
       "notes": "",
       "seo_title": "Indore Ward Map: 85 wards (IMC)",
-      "seo_description": "Interactive map of all 85 wards in Indore (IMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 85 wards in Indore (IMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_coimbatore": {
       "label": "Coimbatore (CCMC) Wards (2011)",
@@ -632,7 +632,7 @@
       "source_org": "Mysuru City Corporation",
       "notes": "",
       "seo_title": "Mysuru Ward Map: 65 wards (MCC)",
-      "seo_description": "Interactive map of all 65 wards in Mysuru (MCC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 65 wards in Mysuru (MCC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_bhopal": {
       "label": "Bhopal (BMC) Wards (2024)",
@@ -642,7 +642,7 @@
       "source_org": "Bhopal Municipal Corporation",
       "notes": "",
       "seo_title": "Bhopal Ward Map: 86 wards (BMC)",
-      "seo_description": "Interactive map of all 86 wards in Bhopal (BMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 86 wards in Bhopal (BMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_chandigarh": {
       "label": "Chandigarh (MC) Wards",
@@ -662,7 +662,7 @@
       "source_org": "Lucknow Municipal Corporation",
       "notes": "",
       "seo_title": "Lucknow Ward Map: 112 wards (LMC)",
-      "seo_description": "Interactive map of all 112 wards in Lucknow (LMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 112 wards in Lucknow (LMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_kanpur": {
       "label": "Kanpur (KMC) Wards",
@@ -672,7 +672,7 @@
       "source_org": "Kanpur Municipal Corporation",
       "notes": "",
       "seo_title": "Kanpur Ward Map: 58 wards (KMC)",
-      "seo_description": "Interactive map of all 58 wards in Kanpur (KMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 58 wards in Kanpur (KMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_patna": {
       "label": "Patna (PMC) Wards (~2019)",
@@ -682,7 +682,7 @@
       "source_org": "datta07/INDIAN-SHAPEFILES",
       "notes": "",
       "seo_title": "Patna Ward Map: 628 wards (PMC)",
-      "seo_description": "Interactive map of all 628 wards in Patna (PMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 628 wards in Patna (PMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_surat": {
       "label": "Surat (SMC) Wards (~2019)",
@@ -702,7 +702,7 @@
       "source_org": "DataMeet",
       "notes": "",
       "seo_title": "Vadodara Ward Map: 12 wards (VMC)",
-      "seo_description": "Interactive map of all 12 wards in Vadodara (VMC). View ward boundaries and numbers, filter by ward, and download as GeoJSON, KML or Parquet."
+      "seo_description": "Interactive map of all 12 wards in Vadodara (VMC). View ward boundaries and names, filter by ward, and download as GeoJSON, KML or Parquet."
     },
     "wards_faridabad": {
       "label": "Faridabad (MCF) Wards",

--- a/web/tests/view-dataset-ward.test.ts
+++ b/web/tests/view-dataset-ward.test.ts
@@ -1,19 +1,24 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { wardSeo } from '../functions/lib/view-dataset';
 
 // Ward pages are the #1 search intent. wardSeo turns the dataset-framed
 // seo_title into a task-framed snippet + HowTo matching the real GSC queries.
 // It must NEVER promise an area name the layer doesn't carry — the original
 // seo_description's "boundaries and names" vs "…and numbers" wording is the cue.
+// (Ahmedabad genuinely carries locality names like "Naroda"/"Bodakdev";
+// Mumbai/Chennai carry only letter-codes/numbers — so they are the NUMBERS case.)
 
-const NAMED = 'Interactive map of all 24 wards in Mumbai (BMC). View ward boundaries and names, filter by ward.';
+const NAMED = 'Interactive map of all 48 wards in Ahmedabad (AMC). View ward boundaries and names, filter by ward.';
 const NUMBERED = 'Interactive map of all 200 wards in Chennai (GCC). View ward boundaries and numbers, filter by ward.';
 
 describe('wardSeo', () => {
   it('claims area names ONLY when the layer has them', () => {
-    const named = wardSeo('Mumbai Ward Map: 24 wards (BMC)', '24', NAMED);
+    const named = wardSeo('Ahmedabad Ward Map: 48 wards (AMC)', '48', NAMED);
     expect(named.description).toContain('your ward number and name');
-    expect(named.description).toContain('24 Mumbai wards with area names');
+    expect(named.description).toContain('48 Ahmedabad wards with area names');
 
     const numbered = wardSeo('Chennai Ward Map: 200 wards (GCC)', '200', NUMBERED);
     expect(numbered.description).toContain('your ward number.'); // no "and name"
@@ -24,7 +29,7 @@ describe('wardSeo', () => {
 
   it('matches the real query language in both cases', () => {
     for (const d of [
-      wardSeo('Mumbai Ward Map: 24 wards (BMC)', '24', NAMED).description,
+      wardSeo('Ahmedabad Ward Map: 48 wards (AMC)', '48', NAMED).description,
       wardSeo('Chennai Ward Map: 200 wards (GCC)', '200', NUMBERED).description,
     ]) {
       expect(d).toContain('Which ward is your location in?'); // which ward is my location
@@ -32,18 +37,18 @@ describe('wardSeo', () => {
     }
   });
 
-  it('keeps every real ward snippet within the 158-char SERP cap', () => {
+  it('keeps a long-city NAMES snippet within the 158-char SERP cap', () => {
+    // Stress the longest realistic place + the (longer) "with area names" tail.
     const cases: Array<[string, string, string]> = [
-      ['Chennai Ward Map: 200 wards (GCC)', '200', NUMBERED],
-      ['Mumbai Ward Map: 24 wards (BMC)', '24', NAMED],
-      ['BBMP Ward Map: 243 wards (Bengaluru, 2022)', '243', ''],
-      ['Visakhapatnam Ward Map: 98 wards (GVMC)', '98', NUMBERED],
+      ['Pimpri-Chinchwad Ward Map: 66 wards (PCMC)', '66', NAMED],
+      ['Visakhapatnam Ward Map: 98 wards (GVMC)', '98', NAMED],
+      ['Bhubaneshwar Ward Map: 67 wards (BMC)', '67', NAMED],
     ];
     for (const [t, c, od] of cases) expect(wardSeo(t, c, od).description.length).toBeLessThanOrEqual(158);
   });
 
   it('reflects names/numbers in the HowTo final step + keys it to the place', () => {
-    const named = wardSeo('Mumbai Ward Map: 24 wards (BMC)', '24', NAMED);
+    const named = wardSeo('Ahmedabad Ward Map: 48 wards (AMC)', '48', NAMED);
     expect((named.howTo.step as Array<{ text: string }>)[2].text).toContain('ward number and name');
     const numbered = wardSeo('Chennai Ward Map: 200 wards (GCC)', '200', NUMBERED);
     expect((numbered.howTo.step as Array<{ text: string }>)[2].text).toBe('Your ward number appears on the map.');
@@ -59,5 +64,46 @@ describe('wardSeo', () => {
 
   it('tolerates a missing count', () => {
     expect(wardSeo('Chennai Ward Map', null, NUMBERED).description).toContain('Chennai wards,');
+  });
+});
+
+// Catalog-driven guards: these run wardSeo over the REAL catalog so a future
+// new city (long name) or a re-introduced mislabel fails the build, not GSC.
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const catalog = JSON.parse(readFileSync(resolve(ROOT, 'catalog.json'), 'utf8')) as {
+  layers: Array<{ id: string; level?: string; name?: string; rows?: number }>;
+  level_meta: Record<string, { seo_title?: string; label?: string; seo_description?: string }>;
+};
+const wardLayers = catalog.layers.filter((l) => /^wards_/.test(l.id));
+const descFor = (l: (typeof wardLayers)[number]): string => {
+  const m = catalog.level_meta[l.level || l.id] || {};
+  const title = m.seo_title || m.label || l.name || l.id;
+  const count = l.rows != null ? l.rows.toLocaleString('en-IN') : null;
+  return wardSeo(title, count, m.seo_description).description;
+};
+
+describe('wardSeo over the real catalog', () => {
+  it('every ward layer snippet stays within the 158-char SERP cap', () => {
+    expect(wardLayers.length).toBeGreaterThan(20); // catalog actually loaded
+    for (const l of wardLayers) {
+      const d = descFor(l);
+      expect(d.length, `${l.id}: "${d}" is ${d.length} chars`).toBeLessThanOrEqual(158);
+    }
+  });
+
+  it('classification matches the data (no over/under-claims)', () => {
+    const cls = (id: string) => {
+      const l = wardLayers.find((x) => x.id === id);
+      if (!l) throw new Error(`missing ward layer ${id}`);
+      return /with area names/.test(descFor(l)) ? 'NAMES' : 'NUMBERS';
+    };
+    // Layers whose data carries real localities → must advertise area names.
+    for (const id of ['wards_ahmedabad', 'wards_vadodara', 'wards_indore', 'wards_hyderabad',
+      'wards_lucknow', 'wards_kochi', 'wards_pune', 'wards_bengaluru_gba', 'wards_bengaluru_bbmp_2022'])
+      expect(cls(id), id).toBe('NAMES');
+    // Layers carrying only ward numbers / letter-codes → must NOT claim names.
+    for (const id of ['wards_mumbai', 'wards_patna', 'wards_chennai', 'wards_vizag',
+      'wards_gurugram', 'wards_pcmc', 'wards_thane'])
+      expect(cls(id), id).toBe('NUMBERS');
   });
 });


### PR DESCRIPTION
## Why

GSC shows ward pages are the #1 organic surface, and CTR is the bottleneck (not ranking). On `/view/wards_ahmedabad` last week: impressions ~3x'd (113 → 328) while CTR collapsed to **0.61%** at a stable pos ~9.3. Every Ahmedabad query is a number→**area-name** lookup ("ward 23 ahmedabad area name", "ward 42 which area", "amc ward numbar and ward nsme") — but the snippet wasn't advertising names.

Root cause: the conditional-names snippet (#141) decides "names vs numbers" from each layer's hand-authored `seo_description` wording. Auditing all 31 ward layers against their **real schemas** found 15 of those strings wrong vs the data.

## What

In-place `catalog.json` metadata patch (one-word `seo_description` swap each):

**13 under-claims → NAMES** (data carries real localities, snippet was hiding them):
`ahmedabad` (Naroda, Bodakdev), `vadodara` (Fatehgunj, Akota), `hyderabad`, `indore`, `kanpur`, `kochi`, `lucknow`, `mysuru`, `pune`, `delhi`, `bhopal`, `bengaluru_gba` (Jalahalli, Yamalur), `bengaluru_bbmp_2022` (Malleswaram, Peenya).

**2 over-claims → NUMBERS** (only codes, no localities):
- `wards_patna` — `wardname` is literally "Ward 1"/"Ward 12".
- `wards_mumbai` — `Name` is the BMC letter-codes "B"/"E"/"F/N", not localities. (Judgment call: those codes *are* how Mumbai wards are referenced, but the snippet promises locality "area names", which the data doesn't carry.)

Final: **14 NAMES / 17 NUMBERS**. The other 16 layers are unchanged.

Directly targets the two pages reindexed this week (Ahmedabad, Vadodara) plus 11 more high-intent ward pages.

## Verification

- **650/650 tests pass.** Two new catalog-driven guards: every ward snippet stays ≤158-char SERP cap, and classification matches the data (a future new city or re-introduced mislabel fails the build, not GSC).
- End-to-end via `buildViewDataset`: Ahmedabad "…ward number and name. 48 Ahmedabad wards with area names" (136 chars), Vadodara (135), Hyderabad (137); Mumbai/Patna/Chennai clean "…ward number" (108/108/110). Worst case 137.
- No runtime/bundle change (metadata + tests only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)