### PR TITLE
fix(a11y): overlay-close focus + theme-aware /view SEO article

### DIFF
--- a/web/functions/lib/view-dataset.ts
+++ b/web/functions/lib/view-dataset.ts
@@ -260,9 +260,12 @@ export function buildViewContent(
     }
   }
 
-  return `<article class="view-seo" style="max-width:720px;margin:80px auto;padding:0 24px;font:15px/1.6 ui-sans-serif,system-ui,sans-serif;color:#444">
-  <p style="font-size:13px;color:#888"><a href="/" style="color:#0a58ca">bharatlas</a> / <a href="/" style="color:#0a58ca">catalog</a> / ${esc(title)}</p>
-  <h1 style="font-size:24px;font-weight:600;margin:8px 0">${esc(title)}</h1>
+  // Colors/layout live in the .view-seo CSS in index.template.html (theme-aware
+  // via tokens) — NOT inline hex, which fails contrast in dark mode and gives
+  // no-JS readers low-contrast text. Links are underlined there too.
+  return `<article class="view-seo">
+  <p class="view-seo__crumb"><a href="/">bharatlas</a> / <a href="/">catalog</a> / ${esc(title)}</p>
+  <h1>${esc(title)}</h1>
   <p>${count ? `<strong>${count}</strong> ${esc(unit)}` : ''} ${layer.source ? `· Source: ${esc(layer.source)}` : ''} ${layer.licence ? `· Licence: ${esc(layer.licence)}` : ''}</p>
   ${desc ? `<p>${esc(desc)}</p>` : ''}
   ${downloads.length ? `<p>Download: ${downloads.join(' · ')}</p>` : ''}

--- a/web/index.template.html
+++ b/web/index.template.html
@@ -414,6 +414,17 @@
         .catalog-chip { padding: 6px 13px; }
       }
 
+      /* Crawler / no-JS SEO article injected on /view/<id> (sits behind the map
+         overlay). Theme-aware tokens so it meets WCAG contrast in dark mode and
+         reads correctly for no-JS users; links underlined to be distinguishable
+         from body text (was hardcoded #444/#0a58ca inline — failed both). */
+      .view-seo { max-width: 720px; margin: 80px auto; padding: 0 24px;
+        font: 15px/1.6 ui-sans-serif, system-ui, sans-serif; color: var(--fg); }
+      .view-seo h1 { font-size: 24px; font-weight: 600; margin: 8px 0; }
+      .view-seo p { margin: 8px 0; }
+      .view-seo__crumb { font-size: 13px; color: var(--muted); }
+      .view-seo a { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; }
+
       /* Map overlay */
       #map-overlay {
         position: fixed; inset: 0; background: var(--bg); z-index: 10;

--- a/web/src/focus-utils.ts
+++ b/web/src/focus-utils.ts
@@ -1,0 +1,17 @@
+// Move focus out of a region before it's hidden from assistive tech.
+//
+// Setting `aria-hidden="true"` (or `inert`) on an ancestor of the currently
+// focused element is blocked by the browser and hides a focused control from
+// AT users ("Blocked aria-hidden on an element because its descendant retained
+// focus"). Our overlays close from a button inside themselves (#map-close, the
+// locate sheet's share button), so the focused control is always a descendant.
+// Blur it first — focus drops to <body>, and the revealed catalog is fully
+// keyboard-reachable from there.
+export function blurFocusWithin(container: Element, doc: Document = document): boolean {
+  const active = doc.activeElement as HTMLElement | null;
+  if (active && container.contains(active)) {
+    active.blur();
+    return true;
+  }
+  return false;
+}

--- a/web/src/locate.ts
+++ b/web/src/locate.ts
@@ -8,6 +8,7 @@ import { pickFeatureName } from './locate-format';
 import type { LocateConfig } from './locate-config';
 import { escapeHtml } from './util';
 import { shareUrl } from './locate-actions';
+import { blurFocusWithin } from './focus-utils';
 
 type LocateApiResponse = {
   mode: 'contains' | 'nearest';
@@ -139,6 +140,9 @@ export function openLocate(opts: {
 }
 
 export function closeLocate(sheet: HTMLElement): void {
+  // Blur the focused control (share/close button) before hiding the sheet from
+  // assistive tech — same browser block as the map overlay (see focus-utils).
+  blurFocusWithin(sheet);
   sheet.classList.remove('open');
   sheet.setAttribute('aria-hidden', 'true');
   sheet.innerHTML = '';

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -2,6 +2,7 @@
 // Map code is in a separate chunk; only loaded when the user opens a map.
 import { isEmbedPath, isViewPath, nextStateOnClose, shouldRestoreCategory } from './embed-snippet';
 import { filterCards, cardVisibility, type CardLike } from './catalog-filter';
+import { blurFocusWithin } from './focus-utils';
 
 // The crawler-only `.view-seo` article that /view/<id>'s Pages Function
 // injects is NOT removed on hydrate — doing so shrank the body and was the
@@ -67,6 +68,10 @@ async function hideMap() {
   // resulting shift is excluded from CLS — which is why we restore here rather
   // than on the /view/<id> load (that would shift content Chrome still counts).
   restoreSavedCategory?.();
+  // Move focus out of the overlay BEFORE hiding it from assistive tech — closing
+  // via #map-close leaves focus on a descendant, and aria-hidden on its ancestor
+  // is blocked by the browser (see focus-utils).
+  blurFocusWithin(overlay);
   overlay.classList.remove('open');
   overlay.setAttribute('aria-hidden', 'true');
   document.body.style.overflow = '';

--- a/web/tests/view-dataset.test.ts
+++ b/web/tests/view-dataset.test.ts
@@ -264,6 +264,15 @@ describe('buildViewContent', () => {
     expect(html).toContain('&lt;script&gt;');
   });
 
+  it('uses theme-aware .view-seo classes, never hardcoded inline colors', () => {
+    // Hardcoded light-theme hex (color:#444 / #0a58ca) failed WCAG contrast in
+    // dark mode and gave no-JS readers low-contrast text. Styling now lives in
+    // the .view-seo CSS (var(--fg)/--muted/--accent). Guard against regressing.
+    const html = buildViewContent(layer, { label: 'X', description: 'd' }, ORIGIN);
+    expect(html).toContain('class="view-seo"');
+    expect(html).not.toMatch(/color:\s*#/i);
+  });
+
   it('includes canonical link to the view page', () => {
     const html = buildViewContent(layer, undefined, ORIGIN);
     expect(html).toContain(`${ORIGIN}/view/lgd_villages`);


### PR DESCRIPTION
Bundles the two accessibility issues surfaced on `/view/wards_bengaluru_gba` (the `aria-hidden` console violation + the Lighthouse a11y gaps) into one change.

## 1. Focus trapped under `aria-hidden` on close
Closing the map overlay (`#map-close`) or the locate sheet set `aria-hidden="true"` on the region while a button *inside* still held focus → the browser blocks it (`Blocked aria-hidden on an element because its descendant retained focus`) and hides a focused control from assistive tech.

Fix: a shared `blurFocusWithin()` helper (`src/focus-utils.ts`) moves focus to `<body>` **before** hiding, wired into `hideMap()` (`main.ts`) and `closeLocate()` (`locate.ts`). Only behavior change: after close, focus is on `<body>` instead of a hidden button. Opening/using/filtering/downloading/locating are untouched.

## 2. `.view-seo` article failed contrast in dark mode
The crawler/no-JS SEO article injected on `/view` hardcoded light-theme inline hex (`#444` text, `#0a58ca` links) → contrast **2.03** on the dark background (Lighthouse `color-contrast` + `link-in-text-block` failures) and low-contrast for no-JS dark-mode readers.

Fix: styling moved to a scoped `.view-seo` CSS block using theme tokens (`var(--fg)`/`--muted`/`--accent`), links underlined. **JS users never see this article** (the map overlay covers it and `hideMap` removes it), so the restyle changes nothing for normal users — it only fixes crawlers / no-JS / Lighthouse.

## Verification
- **Lighthouse Accessibility 92 → 100** on a forced-dark local render of `/view` — `color-contrast` and `link-in-text-block` both pass, **0 failing nodes**, no remaining a11y failures.
- Light + dark screenshots confirm the article reads correctly in both themes (light unchanged-or-better, dark now readable).
- Home page baseline stays 99/100/100/100; the `/view` perf score (56, map-page) is unaffected and is a MapLibre/lab-throttling artifact (field CWV are green).
- **651 tests pass**, `tsc --noEmit` clean. Added a guard test: `buildViewContent` must not emit inline hex colors.

Scope: `.view-seo` CSS is scoped to `.view-seo …` selectors (no leakage); the focus helper only blurs when focus is inside the closing region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)