### PR TITLE
fix(nearby): rebake soi_forests + wris_rivers with flat bbox + Hilbert sort

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1799,7 +1799,7 @@
       "parquet": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/environment/forests/SOI_Forests.parquet",
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/environment/forests/SOI_Forests.parquet",
-        "bytes": 87007173
+        "bytes": 81409189
       },
       "pmtiles": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/environment/forests/SOI_Forests.pmtiles",
@@ -2002,7 +2002,7 @@
       "parquet": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/water/rivers/WRIS_Rivers.parquet",
         "upstream_url": "https://github.com/yashveeeeeeer/india-geodata/releases/download/water/rivers/WRIS_Rivers.parquet",
-        "bytes": 229199036
+        "bytes": 156660468
       },
       "pmtiles": {
         "url": "https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev/water/rivers/WRIS_Rivers.pmtiles",


### PR DESCRIPTION
## Why
`/api/v1/nearby` was broken for two national layers because their parquet lacked the spatial bbox columns the fast path needs, so it fell through to the WKB full-scan path:

- **soi_forests** (87 MB, 58k polygons) blew the Workers CPU budget → **HTTP 503** (Cloudflare error 1102), which read as intermittent "rate-limiting".
- **wris_rivers** (229 MB) exceeded `MAX_FULLSCAN_BYTES` → explicit **HTTP 400** "rebake with xmin/ymin/xmax/ymax".

The other water layers (wris_lakes, wris_waterbodies, wris_river_polygons, bp_wetlands) were already rebaked and worked — these two had been missed. Matches the standing "new layers need nearby bake" rule.

## What
Ran `scripts/rebake_layer.py soi_forests wris_rivers`, which synthesises flat `xmin/ymin/xmax/ymax` from each geometry's extent, Hilbert-sorts rows for tight row-group bbox stats, and re-uploads to the same R2 keys.

| | soi_forests | wris_rivers |
|---|---|---|
| Before | HTTP 503 | HTTP 400 |
| After | `parquet-bbox`, 15 rows scanned, ~0.9s | `parquet-bbox`, 12 rows scanned, ~0.9s |
| Features | 57,963 → **57,963** (exact) | 30,546 → **30,546** (exact) |
| Size | 87 → 81 MB (ZSTD-9) | 229 → 157 MB |

Faithful to source: only added the bbox helper columns and reordered rows; no column dropped or renamed.

## Scope of this diff
The R2 re-upload is already live (R2 objects aren't branchable), so `nearby` for forests and rivers is **already fixed in production**. This PR contains only the cosmetic `catalog.json` `parquet.bytes` patch (2 fields) to match the re-encoded file sizes.

## Verification
- Production `nearby` now serves both via `parquet-bbox` (verified live).
- python tests: 26 passed (rebake + catalog idempotency guards)
- nearby vitest: 24 passed
- catalog diff is exactly the two `bytes` fields (no JSON round-trip churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)