### PR TITLE
fix(seo): real 404 for unknown paths + sitemap lastmod from fetched_at

### DIFF
--- a/web/functions/_middleware.ts
+++ b/web/functions/_middleware.ts
@@ -1,0 +1,18 @@
+// Root middleware: turn Cloudflare Pages' single-page-app fallback (index.html
+// served at HTTP 200 for any unmatched path) into a real 404 for unknown page
+// URLs, so search engines don't index bogus or stale paths as duplicates of
+// the home page. Known routes — prerendered pages, static assets, /view, /c,
+// /api, /embed, and the _redirects stubs — pass straight through untouched.
+// See lib/routes.ts for the allowlist (kept in sync with the build by a test).
+import { isKnownRoute } from './lib/routes';
+import { SECURITY_HEADERS_HTML } from './lib/security-headers';
+
+const NOT_FOUND_HTML = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Not found · bharatlas</title><meta name="robots" content="noindex"><style>:root{color-scheme:light dark}body{font:15px/1.6 ui-sans-serif,system-ui,sans-serif;max-width:600px;margin:80px auto;padding:0 24px;color:#0a0a0a;background:#fff}h1{font-size:22px;margin:0 0 8px}a{color:#4f46e5}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}a{color:#818cf8}}</style></head><body><h1>404 — page not found</h1><p>This page doesn't exist on bharatlas.</p><p><a href="/">← back to the catalog</a></p></body></html>`;
+
+export const onRequest: PagesFunction = async (ctx) => {
+  if (isKnownRoute(new URL(ctx.request.url).pathname)) return ctx.next();
+  return new Response(NOT_FOUND_HTML, {
+    status: 404,
+    headers: { 'content-type': 'text/html; charset=utf-8', ...SECURITY_HEADERS_HTML },
+  });
+};

--- a/web/functions/lib/routes.ts
+++ b/web/functions/lib/routes.ts
@@ -1,0 +1,36 @@
+// Which top-level routes the site actually serves. Cloudflare Pages is
+// configured to serve index.html (HTTP 200) for any unmatched path — a
+// single-page-app fallback that turns every typo'd or stale URL into a soft
+// 404 (a 200 that just duplicates the home page). The root _middleware uses
+// this allowlist to convert those into real 404s so crawlers don't index
+// bogus paths as duplicate home pages.
+//
+// Keep STATIC_PAGES in lockstep with the *.template.html files prerender
+// emits — tests/routes.test.ts asserts the two never drift.
+
+/** Prerendered single-page routes (one <name>.template.html each). '' = "/". */
+export const STATIC_PAGES = new Set<string>([
+  '', 'about', 'docs', 'mcp', 'preview', 'privacy', 'terms',
+]);
+
+/** First path segment owned by a Pages Function or a _redirects rule. These
+ *  resolve themselves — the function returns its own status (including its own
+ *  404 for a bad /view/<id>), the redirect returns 301 — so never police them. */
+export const ROUTE_PREFIXES = new Set<string>([
+  'view', 'c', 'api', 'embed',          // functions/view, functions/c, functions/api, _redirects /embed/*
+  'verify', 'submit', 'contribute',     // _redirects → /preview (301)
+]);
+
+/** True when the site genuinely serves `pathname`, so the soft-404 guard must
+ *  leave it alone. Any path whose final segment carries a file extension is
+ *  treated as a static asset (Google never indexes those as pages). Only
+ *  extensionless, unknown top-level paths — the SPA fallback's soft-404
+ *  surface — return false. */
+export function isKnownRoute(pathname: string): boolean {
+  const segs = pathname.split('/').filter(Boolean);
+  if (segs.length === 0) return true;                               // "/"
+  if (segs[segs.length - 1].includes('.')) return true;            // file asset (*.js, *.png, robots.txt …)
+  if (ROUTE_PREFIXES.has(segs[0])) return true;                    // a function / redirect owns this subtree
+  if (segs.length === 1 && STATIC_PAGES.has(segs[0])) return true; // a prerendered page
+  return false;
+}

--- a/web/functions/sitemap.xml.ts
+++ b/web/functions/sitemap.xml.ts
@@ -23,6 +23,15 @@ const STATIC: Array<{ loc: string; changefreq: string; priority: string }> = [
 const escXml = (s: string) =>
   s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;');
 
+/** A <lastmod> line (leading newline + indent) when `date` is an ISO-ish date
+ *  we can trust, else ''. Only ~a third of curated layers carry fetched_at;
+ *  emitting lastmod only where it's real keeps the sitemap honest — a
+ *  fabricated date erodes crawl trust more than an absent one does. */
+export function lastmodLine(date?: string | null): string {
+  const d = (date || '').slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(d) ? `\n    <lastmod>${d}</lastmod>` : '';
+}
+
 export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   let community: Array<{ id: string; created_at: string; updated_at: string | null }> = [];
   try {
@@ -37,13 +46,13 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
 
   // Curated layers come from catalog.json (fetched same-origin). v4.7 introduced
   // /view/<id> as the canonical share URL with layer-specific OG cards.
-  let curated: Array<string> = [];
+  let curated: Array<{ id: string; fetched_at?: string }> = [];
   try {
     const origin = new URL(ctx.request.url).origin;
     const r = await fetch(`${origin}/catalog.json`);
     if (r.ok) {
-      const cat = (await r.json()) as { layers?: Array<{ id: string }> };
-      curated = (cat.layers || []).map((l) => l.id);
+      const cat = (await r.json()) as { layers?: Array<{ id: string; fetched_at?: string }> };
+      curated = (cat.layers || []).map((l) => ({ id: l.id, fetched_at: l.fetched_at }));
     }
   } catch {
     // curated /view URLs are nice-to-have for sitemap; fall through quietly
@@ -58,8 +67,8 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   </url>`,
     ),
     ...curated.map(
-      (id) => `  <url>
-    <loc>${escXml(ORIGIN + '/view/' + id)}</loc>
+      (l) => `  <url>
+    <loc>${escXml(ORIGIN + '/view/' + l.id)}</loc>${lastmodLine(l.fetched_at)}
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>`,

--- a/web/tests/routes.test.ts
+++ b/web/tests/routes.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { isKnownRoute, STATIC_PAGES } from '../functions/lib/routes';
+
+const WEB = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('isKnownRoute', () => {
+  it('passes the prerendered single-page routes', () => {
+    for (const p of ['/', '/about', '/docs', '/mcp', '/preview', '/privacy', '/terms']) {
+      expect(isKnownRoute(p), p).toBe(true);
+    }
+  });
+
+  it('passes function- and redirect-owned subtrees', () => {
+    for (const p of [
+      '/view/wards_ahmedabad', '/view', '/c/abc123', '/api/v1/nearby',
+      '/embed/wards_pune', '/verify', '/submit', '/contribute',
+    ]) {
+      expect(isKnownRoute(p), p).toBe(true);
+    }
+  });
+
+  it('passes any path ending in a file (static assets)', () => {
+    for (const p of [
+      '/assets/index-abc123.js', '/assets/index-abc.css', '/assets/fonts/x.woff2',
+      '/og-india.png', '/robots.txt', '/sitemap.xml', '/llms.txt',
+      '/catalog.json', '/india-boundary.geojson', '/favicon.ico',
+    ]) {
+      expect(isKnownRoute(p), p).toBe(true);
+    }
+  });
+
+  it('rejects extensionless unknown paths (the soft-404 surface)', () => {
+    for (const p of [
+      '/nonexistent', '/foo', '/wards', '/ward-map', '/abouts',
+      '/random/deep/path', '/preview/extra', '/terms/old', '/xyz123',
+    ]) {
+      expect(isKnownRoute(p), p).toBe(false);
+    }
+  });
+
+  it('STATIC_PAGES stays in lockstep with the prerendered templates', () => {
+    const templatePages = readdirSync(WEB)
+      .filter((f) => f.endsWith('.template.html'))
+      .map((f) => f.replace('.template.html', ''))
+      .map((n) => (n === 'index' ? '' : n))
+      .sort();
+    expect(templatePages).toEqual([...STATIC_PAGES].sort());
+  });
+});

--- a/web/tests/sitemap-lastmod.test.ts
+++ b/web/tests/sitemap-lastmod.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { lastmodLine } from '../functions/sitemap.xml';
+
+describe('lastmodLine', () => {
+  it('emits a <lastmod> from an ISO date or datetime', () => {
+    expect(lastmodLine('2024-03-15')).toBe('\n    <lastmod>2024-03-15</lastmod>');
+    expect(lastmodLine('2024-03-15T08:30:00Z')).toBe('\n    <lastmod>2024-03-15</lastmod>');
+  });
+
+  it('emits nothing when fetched_at is missing or unparseable', () => {
+    for (const v of [undefined, null, '', 'today', '2024', '15-03-2024']) {
+      expect(lastmodLine(v as string | null | undefined)).toBe('');
+    }
+  });
+});


### PR DESCRIPTION
Two SEO-hygiene fixes from the live-site audit (the only two concrete defects found; the rest of on-page SEO scored A−).

## 1. Soft-404 → real 404
The Pages project serves `index.html` (HTTP **200**) for any unmatched path — an SPA fallback that turns every typo'd or stale URL into a 200 duplicate of the home page (crawl-budget waste + duplicate-content risk).

A root `functions/_middleware.ts` now converts those into real **404 + noindex** responses, using an allowlist (`lib/routes.ts`) of routes the site actually serves:
- 7 prerendered pages (`/`, `/about`, `/docs`, `/mcp`, `/preview`, `/privacy`, `/terms`)
- any path ending in a file extension → static asset (Google never indexes those as pages)
- the `/view`, `/c`, `/api`, `/embed`, `/verify`, `/submit`, `/contribute` subtrees (functions / redirects resolve their own status)

`/view/<bad-id>` already 404s via its own function — unchanged. A test keeps `STATIC_PAGES` in lockstep with the prerendered `*.template.html` files so the allowlist can't silently drift when a page is added.

## 2. Sitemap lastmod
Only the single community submission carried `<lastmod>`. Curated `/view` URLs now emit `<lastmod>` from each layer's `fetched_at` when it's a trustworthy ISO date — coverage **1 → 44** URLs. Omitted where `fetched_at` is absent (a fabricated date erodes crawl trust more than a missing one).

## Verification
- **TDD**: 7 new vitest cases (route classifier + lastmod helper). Full suite **660 pass**.
- **Live, via `wrangler pages dev`**:
  - `/nonexistent`, `/foo`, `/ward-map`, `/random/deep/path` → **404 + noindex**
  - all 7 pages, `/view/wards_ahmedabad`, `/robots.txt`, `/catalog.json`, `/assets/*.js` → **200**
  - `/view/bogus_layer` → **404** (its own function)
  - sitemap `<lastmod>` count **1 → 44**, matching the 44 catalog layers with `fetched_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)