### PR TITLE
fix(submit): hard-reject byte-identical duplicate submissions

### DIFF
--- a/web/functions/api/submit.ts
+++ b/web/functions/api/submit.ts
@@ -31,6 +31,7 @@ const codeForReason = (reason: string): number => {
   if (/rate/i.test(reason)) return 429;
   if (/size/i.test(reason)) return 413;
   if (/format/i.test(reason)) return 415;
+  if (/duplicate/i.test(reason)) return 409;
   return 400;
 };
 

--- a/web/functions/lib/validate-server.ts
+++ b/web/functions/lib/validate-server.ts
@@ -183,12 +183,16 @@ export async function validateSubmission(
     info: { outsideIndia: v.outsideIndia, bbox: v.bbox },
   };
 
+  // A byte-identical file already accepted => hard reject. Keys on content_hash,
+  // so a double-tap / retry can't create a second community entry, while an
+  // edited dataset (new bytes => new hash) still lands. matchId is kept on the
+  // report so the client can point the user at the existing submission.
   const matchId = await deps.findDuplicate(input.contentHash);
-  report.duplicate = {
-    ok: true,
-    warn: !!matchId,
-    info: matchId ? { matchId } : undefined,
-  };
+  if (matchId) {
+    report.duplicate = { ok: false, info: { matchId } };
+    return reject(report, 'duplicate', 'duplicate of an already-accepted submission');
+  }
+  report.duplicate = { ok: true };
 
   return { accept: true, report };
 }

--- a/web/tests/validate-server.test.ts
+++ b/web/tests/validate-server.test.ts
@@ -137,6 +137,18 @@ describe('validateSubmission — hard reject gates', () => {
     expect(r.accept).toBe(false);
     if (!r.accept) expect(r.reason).toMatch(/filename/i);
   });
+
+  it('rejects a byte-identical duplicate of an already-accepted submission', async () => {
+    // The same file submitted twice (a double-tap, or a retry) must not create a
+    // second community entry. The guard keys on content_hash, so it fires only on
+    // truly identical bytes — an updated dataset gets a new hash and still lands.
+    const r = await validateSubmission(input(), deps({ findDuplicate: async () => 'ABC123XYZ0' }));
+    expect(r.accept).toBe(false);
+    if (!r.accept) {
+      expect(r.reason).toMatch(/duplicate/i);
+      expect(r.report.duplicate?.info?.matchId).toBe('ABC123XYZ0');
+    }
+  });
 });
 
 describe('validateSubmission — original-creator path', () => {
@@ -184,13 +196,10 @@ describe('validateSubmission — soft warnings (accept with flags)', () => {
     if (r.accept) expect(r.report.extent?.warn).toBe(true);
   });
 
-  it('accepts but warns when a duplicate content_hash exists', async () => {
-    const r = await validateSubmission(input(), deps({ findDuplicate: async () => 'ABC123XYZ0' }));
+  it('records duplicate=ok on the report when no content_hash match exists', async () => {
+    const r = await validateSubmission(input(), deps({ findDuplicate: async () => null }));
     expect(r.accept).toBe(true);
-    if (r.accept) {
-      expect(r.report.duplicate?.warn).toBe(true);
-      expect(r.report.duplicate?.info?.matchId).toBe('ABC123XYZ0');
-    }
+    if (r.accept) expect(r.report.duplicate?.ok).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Why

The `content_hash` dedup check existed but was **advisory only** — `validate-server.ts` recorded `report.duplicate.warn` and still returned `accept: true`. So a double-tap or retry created a **second, byte-identical community entry**. That is exactly how "Temples of Ahmedabad City" landed twice: same `content_hash` `18eabdb3`, same 267,587 bytes, 556 features, 28 seconds apart, both auto-accepted.

## What

- When `findDuplicate` matches an **already-accepted** submission, the validator now **hard-rejects with HTTP 409** instead of accepting-with-warn.
- Keys on `content_hash`, so a genuine re-submit is blocked, while an **edited** dataset (new bytes → new hash) still lands.
- `matchId` is preserved on `report.duplicate.info` so the client can point the user at the existing entry.
- `codeForReason` maps `/duplicate/` → **409 Conflict**.

## Tests (TDD)

Flipped the `validate-server` test from *accept-with-warn* to a **hard reject** (red → green). Full suite green: **667 tests**.

## Cleanup (out of band, not in this diff)

The one duplicate row already in production (`q4coKU4Uju`) was un-listed (`status='rejected'`) and is being hard-purged separately (D1 rows + R2 object). The original `mNBkWTEHMP` stays as the accepted community submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)