### PR TITLE
fix(r2): decode percent-encoded path segments so spaced filenames serve

### DIFF
--- a/web/functions/api/r2/[[path]].ts
+++ b/web/functions/api/r2/[[path]].ts
@@ -18,9 +18,23 @@ type Params = { path: string[] };
 // via the bharatlas-branded same-origin path.
 const ALLOWED_PREFIX = /^community\//;
 
+// Pages delivers catch-all segments still percent-encoded: a space in a
+// community filename (e.g. "TEMPLE IN AHMEDABAD JDSM.kml") arrives as "%20".
+// Decode each segment so the reconstructed key matches the literal R2 object
+// key — otherwise env.R2.get() misses and every spaced filename 404s. Returns
+// null on a malformed escape (a lone '%' throws in decodeURIComponent).
+export function reconstructKey(segs: string[]): string | null {
+  try {
+    return segs.map((s) => decodeURIComponent(s)).join('/');
+  } catch {
+    return null;
+  }
+}
+
 export const onRequestGet: PagesFunction<Env, keyof Params> = async (ctx) => {
   const segs = (ctx.params.path as string[]) || [];
-  const key = segs.join('/');
+  const key = reconstructKey(segs);
+  if (key === null) return new Response('bad key', { status: 400 });
   if (!key) return new Response('missing key', { status: 400 });
   if (!ALLOWED_PREFIX.test(key)) return new Response('not found', { status: 404 });
 

--- a/web/tests/r2-path.test.ts
+++ b/web/tests/r2-path.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { reconstructKey } from '../functions/api/r2/[[path]]';
+
+describe('reconstructKey (/api/r2 catch-all)', () => {
+  it('joins plain segments unchanged', () => {
+    expect(reconstructKey(['community', 'nL7zNStsW3', '39A.geojson']))
+      .toBe('community/nL7zNStsW3/39A.geojson');
+  });
+
+  it('decodes %20 so spaced filenames match the literal R2 key', () => {
+    // Regression: the accepted "Temples of Ahmedabad" submission is stored at
+    // community/mNBkWTEHMP/TEMPLE IN AHMEDABAD JDSM.kml (literal spaces). Pages
+    // hands us the segment percent-encoded; without decoding, env.R2.get()
+    // misses and the preview 404s.
+    expect(reconstructKey(['community', 'mNBkWTEHMP', 'TEMPLE%20IN%20AHMEDABAD%20JDSM.kml']))
+      .toBe('community/mNBkWTEHMP/TEMPLE IN AHMEDABAD JDSM.kml');
+  });
+
+  it('decodes other percent-encoded characters (parens, plus, hash)', () => {
+    expect(reconstructKey(['community', 'abc', 'a%20(b)%2Bc%23.kml']))
+      .toBe('community/abc/a (b)+c#.kml');
+  });
+
+  it('returns null on a malformed escape rather than throwing', () => {
+    expect(reconstructKey(['community', 'abc', 'bad%zz.kml'])).toBeNull();
+    expect(reconstructKey(['community', 'abc', '100%.kml'])).toBeNull();
+  });
+
+  it('returns empty string for no segments (handler maps to 400)', () => {
+    expect(reconstructKey([])).toBe('');
+  });
+});


### PR DESCRIPTION
## What
`/api/r2/[[path]]` rebuilt the R2 key with `segs.join('/')`, leaving request `%20` escapes intact. `env.R2.get()` then missed the literal key, so any community file whose name contains spaces 404'd.

This is why the accepted **Temples of Ahmedabad** submission (`community/mNBkWTEHMP/TEMPLE IN AHMEDABAD JDSM.kml`) never rendered in `/preview` or "view on map" — every other layer's filename happens to be space-free.

## Fix
Decode each path segment before joining (`reconstructKey`), with a guard that returns `null` → 400 on a malformed escape (a lone `%`).

## Tests
- New `web/tests/r2-path.test.ts` (5 cases): red against `join('/')`, green now — covers plain keys, `%20` spaces, other percent-encoded chars, malformed escapes, and empty input.
- Full suite: 672/672 green.

## Notes
- The missing R2 object itself was already restored out-of-band (copied from its byte-identical rejected-duplicate twin); this PR fixes the serving path so the restored file actually resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)