### PR TITLE
feat(collect): Phase 1 — the thin loop (create → contribute → publish)

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -1,0 +1,45 @@
+name: collect
+
+# Separate from ci.yml (which builds/deploys the geodata/web project) so a
+# collect change never rebuilds web and vice versa — the deploy isolation the
+# subdomain exists for. Path-filtered to collect's own tree.
+on:
+  push:
+    branches: [main]
+    paths: ['collect/**', 'shared/**', '.github/workflows/collect.yml']
+  pull_request:
+    branches: [main]
+    paths: ['collect/**', 'shared/**', '.github/workflows/collect.yml']
+  workflow_dispatch:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: collect
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: collect/package-lock.json
+
+      - name: install
+        run: npm ci
+
+      - name: build (vitest + typecheck + vite)
+        env:
+          # Public sitekey; the default is the live collect widget key.
+          VITE_TURNSTILE_SITEKEY: ${{ secrets.COLLECT_TURNSTILE_SITEKEY || '0x4AAAAAAEUVQ4gS3xN4W2l1' }}
+        run: npm run build
+
+      # Deploy only on push-to-main / manual. PRs build but don't deploy.
+      - name: deploy to cloudflare pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler pages deploy dist --project-name=collect --branch=main

--- a/collect/.gitignore
+++ b/collect/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.wrangler/
+.dev.vars

--- a/collect/c.html
+++ b/collect/c.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="robots" content="noindex" />
+  <title>collect · bharatlas</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/app.ts"></script>
+</body>
+</html>

--- a/collect/functions/api/collect/[[path]].ts
+++ b/collect/functions/api/collect/[[path]].ts
@@ -1,0 +1,57 @@
+// Catch-all router for /api/collect/v1/*. A single function file keeps the
+// (deep) reuse imports in one place and centralises routing + method handling.
+// Route → handler mapping mirrors the spec's API table.
+
+import type { Env } from '../../types';
+import { bad } from '../../lib/http';
+import * as h from '../../lib/handlers';
+
+const CORS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET,POST,PATCH,DELETE,OPTIONS',
+  'access-control-allow-headers': 'authorization,content-type',
+};
+
+export const onRequest: PagesFunction<Env> = async (ctx) => {
+  const method = ctx.request.method.toUpperCase();
+  if (method === 'OPTIONS') return new Response(null, { status: 204, headers: CORS });
+
+  let segs: string[];
+  try {
+    segs = ((ctx.params.path as string[]) || []).map((s) => decodeURIComponent(s));
+  } catch {
+    return bad(400, 'bad path');
+  }
+
+  if (segs[0] !== 'v1') return bad(404, 'not found');
+  const p = segs.slice(1);
+  const { env, request } = ctx;
+
+  // /v1/collections
+  if (p.length === 1 && p[0] === 'collections') {
+    return method === 'POST' ? h.createCollection(env, request) : bad(405, 'method not allowed');
+  }
+
+  // /v1/collections/:id[/records|/publish]
+  if (p[0] === 'collections' && p[1]) {
+    const id = p[1];
+    if (p.length === 2) {
+      return method === 'GET' ? h.getCollectionMeta(env, request, id) : bad(405, 'method not allowed');
+    }
+    if (p.length === 3 && p[2] === 'records') {
+      if (method === 'GET') return h.listRecords(env, request, id);
+      if (method === 'POST') return h.addRecord(env, request, id);
+      return bad(405, 'method not allowed');
+    }
+    if (p.length === 3 && p[2] === 'publish') {
+      return method === 'POST' ? h.publish(env, request, id) : bad(405, 'method not allowed');
+    }
+  }
+
+  // /v1/records/:id/moderate
+  if (p[0] === 'records' && p[1] && p[2] === 'moderate' && p.length === 3) {
+    return method === 'POST' ? h.moderateRecord(env, request, p[1]) : bad(405, 'method not allowed');
+  }
+
+  return bad(404, 'not found');
+};

--- a/collect/functions/c/[[path]].ts
+++ b/collect/functions/c/[[path]].ts
@@ -1,0 +1,7 @@
+// Serve the SPA shell (c.html) for every /c/<id>[/admin|/view] route. The client
+// reads the id from the path and the token from the fragment.
+import type { Env } from '../types';
+
+export const onRequest: PagesFunction<Env & { ASSETS: Fetcher }> = async (ctx) => {
+  return ctx.env.ASSETS.fetch(new URL('/c.html', ctx.request.url));
+};

--- a/collect/functions/lib/auth.ts
+++ b/collect/functions/lib/auth.ts
@@ -1,0 +1,31 @@
+// token → permission on one collection (spec → "The three links"). The token
+// rides the Authorization header; we look it up by prefix within the target
+// collection and constant-time verify the hash.
+
+import { tokenPrefix, verifyToken, type Permission } from './tokens';
+import { tokensForCollection } from './db';
+
+const RANK: Record<Permission, number> = { view: 1, edit: 2, admin: 3 };
+
+export function bearer(req: Request): string | null {
+  const h = req.headers.get('Authorization') || '';
+  const m = h.match(/^Bearer\s+(.+)$/i);
+  return m ? m[1].trim() : null;
+}
+
+export async function permissionFor(
+  db: Pick<D1Database, 'prepare'>,
+  collectionId: string,
+  token: string | null,
+): Promise<Permission | null> {
+  if (!token) return null;
+  const rows = await tokensForCollection(db, collectionId, tokenPrefix(token));
+  for (const r of rows) {
+    if (r.is_active && (await verifyToken(token, r.token_hash))) return r.permission;
+  }
+  return null;
+}
+
+export function atLeast(have: Permission | null, need: Permission): boolean {
+  return have !== null && RANK[have] >= RANK[need];
+}

--- a/collect/functions/lib/collect-log.ts
+++ b/collect/functions/lib/collect-log.ts
@@ -1,0 +1,28 @@
+// Funnel instrumentation: outcome of every create / contribute / publish
+// attempt (spec → Deployment checklist item 8). Coarse facts only — no field
+// values, no names. Best-effort; never blocks the request.
+
+export type CollectEvent = 'create' | 'contribute' | 'publish';
+
+export interface CollectAttempt {
+  event: CollectEvent;
+  outcome: 'ok' | 'rejected';
+  gate?: string | null;
+  reason?: string | null;
+  collection_id?: string | null;
+  ip_hash?: string | null;
+}
+
+export async function logCollectAttempt(db: D1Database, row: CollectAttempt): Promise<void> {
+  try {
+    await db
+      .prepare(
+        `INSERT INTO collect_attempts (event, outcome, gate, reason, collection_id, ip_hash)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(row.event, row.outcome, row.gate ?? null, row.reason ?? null, row.collection_id ?? null, row.ip_hash ?? null)
+      .run();
+  } catch {
+    // instrumentation must never break a request
+  }
+}

--- a/collect/functions/lib/db.ts
+++ b/collect/functions/lib/db.ts
@@ -1,0 +1,209 @@
+// D1 helpers for the collect tables (migration 0007). Tiny and mockable, like
+// web/functions/lib/submissions.ts. Geometry / properties / admin_ctx are stored
+// as JSON TEXT; callers stringify on write and parse on read.
+
+type DB = Pick<D1Database, 'prepare'>;
+
+const now = () => new Date().toISOString();
+
+// ---- collections -----------------------------------------------------------
+
+export interface CollectionRow {
+  id: string;
+  created_at: string;
+  updated_at: string | null;
+  status: 'open' | 'closed';
+  name: string;
+  description: string | null;
+  data_year: number | null;
+  purpose: string;
+  schema_doc: string;
+  license: string;
+  moderation: number;
+  ip_hash: string;
+}
+
+export interface NewCollectionRow {
+  id: string;
+  name: string;
+  purpose: string;
+  license: string;
+  description: string | null;
+  data_year: number | null;
+  schema_doc: string;
+  moderation: number;
+  ip_hash: string;
+}
+
+export async function createCollection(db: DB, c: NewCollectionRow): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO collections
+       (id, created_at, updated_at, status, name, description, data_year, purpose, schema_doc, license, moderation, ip_hash)
+       VALUES (?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(c.id, now(), now(), c.name, c.description, c.data_year, c.purpose, c.schema_doc, c.license, c.moderation, c.ip_hash)
+    .run();
+}
+
+export async function getCollection(db: DB, id: string): Promise<CollectionRow | null> {
+  return (await db.prepare(`SELECT * FROM collections WHERE id = ?`).bind(id).first()) as CollectionRow | null;
+}
+
+export async function touchCollection(db: DB, id: string): Promise<void> {
+  await db.prepare(`UPDATE collections SET updated_at = ? WHERE id = ?`).bind(now(), id).run();
+}
+
+// ---- tokens ----------------------------------------------------------------
+
+export async function addCollectionToken(
+  db: DB,
+  t: { collectionId: string; prefix: string; hash: string; permission: 'admin' | 'edit' | 'view' },
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO collection_tokens (id, collection_id, token_prefix, token_hash, permission, is_active, created_at)
+       VALUES (?, ?, ?, ?, ?, 1, ?)`,
+    )
+    .bind(crypto.randomUUID(), t.collectionId, t.prefix, t.hash, t.permission, now())
+    .run();
+}
+
+export async function tokensForCollection(
+  db: DB,
+  collectionId: string,
+  prefix: string,
+): Promise<{ token_hash: string; permission: 'admin' | 'edit' | 'view'; is_active: number }[]> {
+  const res = await db
+    .prepare(
+      `SELECT token_hash, permission, is_active FROM collection_tokens
+       WHERE collection_id = ? AND token_prefix = ? AND is_active = 1`,
+    )
+    .bind(collectionId, prefix)
+    .all();
+  return (res.results ?? []) as unknown as { token_hash: string; permission: 'admin' | 'edit' | 'view'; is_active: number }[];
+}
+
+// ---- records ---------------------------------------------------------------
+
+export interface NewRecordRow {
+  id: string;
+  collectionId: string;
+  status: 'pending' | 'published';
+  geometry: string;
+  properties: string;
+  admin_ctx: string | null;
+  contributor: string | null;
+  edit_token_hash: string;
+  ip_hash: string;
+}
+
+export async function insertRecord(db: DB, r: NewRecordRow): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO records
+       (id, collection_id, created_at, status, geometry, properties, admin_ctx, contributor, edit_token_hash, ip_hash)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(r.id, r.collectionId, now(), r.status, r.geometry, r.properties, r.admin_ctx, r.contributor, r.edit_token_hash, r.ip_hash)
+    .run();
+}
+
+export interface RecordRow {
+  id: string;
+  collection_id: string;
+  created_at: string;
+  status: 'pending' | 'published' | 'rejected';
+  geometry: string;
+  properties: string;
+  admin_ctx: string | null;
+  contributor: string | null;
+  edit_token_hash: string | null;
+}
+
+export async function listRecords(
+  db: DB,
+  collectionId: string,
+  opts: { status?: string; limit: number; offset: number },
+): Promise<RecordRow[]> {
+  const parts = [`SELECT * FROM records WHERE collection_id = ?`];
+  const binds: unknown[] = [collectionId];
+  if (opts.status) {
+    parts.push(`AND status = ?`);
+    binds.push(opts.status);
+  }
+  parts.push(`ORDER BY created_at DESC LIMIT ? OFFSET ?`);
+  binds.push(opts.limit, opts.offset);
+  const res = await db.prepare(parts.join(' ')).bind(...binds).all();
+  return (res.results ?? []) as unknown as RecordRow[];
+}
+
+export async function statusCounts(
+  db: DB,
+  collectionId: string,
+): Promise<{ total: number; pending: number; published: number; rejected: number }> {
+  const res = await db
+    .prepare(`SELECT status, COUNT(*) AS n FROM records WHERE collection_id = ? GROUP BY status`)
+    .bind(collectionId)
+    .all();
+  const out = { total: 0, pending: 0, published: 0, rejected: 0 };
+  for (const row of (res.results ?? []) as unknown as { status: string; n: number }[]) {
+    if (row.status in out) (out as Record<string, number>)[row.status] = row.n;
+    out.total += row.n;
+  }
+  return out;
+}
+
+export async function getRecord(db: DB, id: string): Promise<RecordRow | null> {
+  return (await db.prepare(`SELECT * FROM records WHERE id = ?`).bind(id).first()) as RecordRow | null;
+}
+
+export async function setRecordStatus(
+  db: DB,
+  id: string,
+  status: 'pending' | 'published' | 'rejected',
+  reason: string | null = null,
+): Promise<void> {
+  await db.prepare(`UPDATE records SET status = ?, rejection_reason = ? WHERE id = ?`).bind(status, reason, id).run();
+}
+
+// ---- publications ----------------------------------------------------------
+
+export async function nextVersion(db: DB, collectionId: string): Promise<number> {
+  const row = (await db
+    .prepare(`SELECT COALESCE(MAX(version), 0) AS v FROM publications WHERE collection_id = ?`)
+    .bind(collectionId)
+    .first()) as { v: number } | null;
+  return (row?.v ?? 0) + 1;
+}
+
+export async function insertPublication(
+  db: DB,
+  p: {
+    id: string;
+    collectionId: string;
+    version: number;
+    submissionId: string;
+    featureCount: number;
+    contentHash: string;
+    attributionSnapshot: string;
+    r2Key: string;
+  },
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO publications
+       (id, collection_id, version, submission_id, published_at, feature_count, content_hash, attribution_snapshot, r2_key)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(p.id, p.collectionId, p.version, p.submissionId, now(), p.featureCount, p.contentHash, p.attributionSnapshot, p.r2Key)
+    .run();
+}
+
+/** Link the produced submission back to its collection + version (0007 columns). */
+export async function linkSubmission(db: DB, submissionId: string, collectionId: string, version: number): Promise<void> {
+  await db
+    .prepare(`UPDATE submissions SET collection_id = ?, collection_version = ? WHERE id = ?`)
+    .bind(collectionId, version, submissionId)
+    .run();
+}

--- a/collect/functions/lib/handlers.ts
+++ b/collect/functions/lib/handlers.ts
@@ -1,0 +1,334 @@
+// Handler functions for the collect API. The catch-all router ([[path]].ts)
+// parses the route and calls these. Each returns a Response.
+//
+// Phase 1 scope: create → contribute → (moderate) → publish, plus scoped reads.
+// Enrichment (admin_ctx) is Phase 4 → stored null here. Edit/delete/de-identify
+// endpoints are Phase 3.
+
+import type { Env } from '../types';
+import { bad, json } from './http';
+import { generateToken, tokenPrefix, hashToken, generateRecordToken } from './tokens';
+import { bearer, permissionFor, atLeast } from './auth';
+import { checkCreateRate, checkRecordRate } from './ratelimit';
+import { logCollectAttempt } from './collect-log';
+import { nanoid, sha256Hex, ipHashFor, verifyTurnstile, insertSubmission, insertToken } from './reuse';
+import * as db from './db';
+import { validateNewCollection } from '../../src/schema/validate-collection';
+import { validateRecordProperties, type Field } from '../../src/schema/validate-record';
+import { checkIndiaBounds } from '../../src/geo/bounds';
+import { composeAttribution } from '../../src/publish/attribution';
+
+const BHARATLAS_ORIGIN = 'https://bharatlas.com';
+
+const salt = (env: Env) => env.IP_SALT || 'collect-v1';
+
+// Turnstile: verify when a secret is configured (prod); skip in local dev.
+async function turnstileOk(env: Env, token: unknown): Promise<boolean> {
+  if (!env.TURNSTILE_SECRET) return true;
+  return typeof token === 'string' && (await verifyTurnstile(token, env.TURNSTILE_SECRET));
+}
+
+function geomBucket(type: string): 'point' | 'line' | 'polygon' | null {
+  if (type === 'Point' || type === 'MultiPoint') return 'point';
+  if (type === 'LineString' || type === 'MultiLineString') return 'line';
+  if (type === 'Polygon' || type === 'MultiPolygon') return 'polygon';
+  return null;
+}
+
+async function readJson(req: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const b = await req.json();
+    return b && typeof b === 'object' && !Array.isArray(b) ? (b as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---- POST /collections -----------------------------------------------------
+
+export async function createCollection(env: Env, req: Request): Promise<Response> {
+  const ipHash = await ipHashFor(req, salt(env));
+  const body = await readJson(req);
+  if (!body) return bad(400, 'invalid JSON body');
+
+  if (!(await turnstileOk(env, body.turnstile_token))) {
+    void logCollectAttempt(env.DB, { event: 'create', outcome: 'rejected', gate: 'captcha', ip_hash: ipHash });
+    return bad(403, 'captcha failed');
+  }
+  if (!(await checkCreateRate(env.DB, ipHash))) {
+    void logCollectAttempt(env.DB, { event: 'create', outcome: 'rejected', gate: 'rateLimit', ip_hash: ipHash });
+    return bad(429, 'rate limit: 5 collections per day');
+  }
+
+  const v = validateNewCollection(body);
+  if (!v.ok) {
+    void logCollectAttempt(env.DB, { event: 'create', outcome: 'rejected', gate: 'schema', reason: v.error, ip_hash: ipHash });
+    return bad(400, v.error);
+  }
+
+  const moderation = body.moderation === 0 || body.moderation === false ? 0 : 1;
+  const id = nanoid(10);
+  await db.createCollection(env.DB, { id, ...v.value, moderation, ip_hash: ipHash });
+
+  const tokens = { admin: generateToken('admin'), edit: generateToken('edit'), view: generateToken('view') } as const;
+  for (const [perm, tok] of Object.entries(tokens)) {
+    await db.addCollectionToken(env.DB, {
+      collectionId: id,
+      prefix: tokenPrefix(tok),
+      hash: await hashToken(tok),
+      permission: perm as 'admin' | 'edit' | 'view',
+    });
+  }
+
+  void logCollectAttempt(env.DB, { event: 'create', outcome: 'ok', collection_id: id, ip_hash: ipHash });
+  const origin = new URL(req.url).origin;
+  return json(200, {
+    id,
+    links: {
+      edit: `${origin}/c/${id}#${tokens.edit}`,
+      admin: `${origin}/c/${id}/admin#${tokens.admin}`,
+      view: `${origin}/c/${id}/view#${tokens.view}`,
+    },
+    tokens, // shown once
+  });
+}
+
+// ---- GET /collections/:id --------------------------------------------------
+
+export async function getCollectionMeta(env: Env, req: Request, id: string): Promise<Response> {
+  const perm = await permissionFor(env.DB, id, bearer(req));
+  if (!perm) return bad(401, 'unauthorised');
+  const c = await db.getCollection(env.DB, id);
+  if (!c) return bad(404, 'not found');
+  const counts = await db.statusCounts(env.DB, id);
+  return json(200, {
+    id: c.id,
+    name: c.name,
+    description: c.description,
+    purpose: c.purpose,
+    license: c.license,
+    data_year: c.data_year,
+    status: c.status,
+    moderation: c.moderation,
+    schema: JSON.parse(c.schema_doc),
+    counts,
+  });
+}
+
+// ---- GET /collections/:id/records ------------------------------------------
+
+export async function listRecords(env: Env, req: Request, id: string): Promise<Response> {
+  const perm = await permissionFor(env.DB, id, bearer(req));
+  if (!perm) return bad(401, 'unauthorised');
+
+  const url = new URL(req.url);
+  const wanted = url.searchParams.get('status') || '';
+  // Read scope: only admin may see pending/rejected; others get published only.
+  let status: string | undefined = 'published';
+  if (atLeast(perm, 'admin')) status = wanted || undefined;
+  else if (wanted && wanted !== 'published') return bad(403, 'only admin can read un-moderated records');
+
+  const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') || '500', 10) || 500, 1), 2000);
+  const offset = Math.max(parseInt(url.searchParams.get('offset') || '0', 10) || 0, 0);
+  const rows = await db.listRecords(env.DB, id, { status, limit, offset });
+
+  const features = rows.map((r) => ({
+    type: 'Feature' as const,
+    id: r.id,
+    geometry: JSON.parse(r.geometry),
+    properties: {
+      ...JSON.parse(r.properties),
+      _status: r.status,
+      _contributor: r.contributor,
+      _created_at: r.created_at,
+    },
+  }));
+  return json(200, { type: 'FeatureCollection', features });
+}
+
+// ---- POST /collections/:id/records -----------------------------------------
+
+export async function addRecord(env: Env, req: Request, id: string): Promise<Response> {
+  const ipHash = await ipHashFor(req, salt(env));
+  const perm = await permissionFor(env.DB, id, bearer(req));
+  if (!atLeast(perm, 'edit')) return bad(401, 'unauthorised — need the edit or admin link');
+
+  const c = await db.getCollection(env.DB, id);
+  if (!c) return bad(404, 'not found');
+  if (c.status === 'closed') return bad(403, 'this collection is closed to new records');
+
+  const body = await readJson(req);
+  if (!body) return bad(400, 'invalid JSON body');
+
+  if (!(await turnstileOk(env, body.turnstile_token))) {
+    void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'rejected', gate: 'captcha', collection_id: id, ip_hash: ipHash });
+    return bad(403, 'captcha failed');
+  }
+  if (!(await checkRecordRate(env.DB, ipHash))) {
+    void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'rejected', gate: 'rateLimit', collection_id: id, ip_hash: ipHash });
+    return bad(429, 'rate limit: 200 records per hour');
+  }
+
+  const geometry = body.geometry;
+  const bounds = checkIndiaBounds(geometry);
+  if (!bounds.ok) {
+    void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'rejected', gate: 'bounds', reason: bounds.error, collection_id: id, ip_hash: ipHash });
+    return bad(400, bounds.error);
+  }
+
+  const schema = JSON.parse(c.schema_doc) as { geometry: string[]; fields: Field[] };
+  const bucket = geomBucket((geometry as { type: string }).type);
+  if (!bucket || !schema.geometry.includes(bucket)) {
+    return bad(400, `this collection accepts ${schema.geometry.join(', ')} geometry`);
+  }
+
+  const validated = validateRecordProperties(schema.fields, body.properties);
+  if (!validated.ok) {
+    void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'rejected', gate: 'schema', reason: validated.error, collection_id: id, ip_hash: ipHash });
+    return bad(400, validated.error);
+  }
+
+  const contributor = typeof body.contributor === 'string' && body.contributor.trim() !== '' ? body.contributor.trim() : null;
+  const status: 'pending' | 'published' = c.moderation ? 'pending' : 'published';
+  const recId = nanoid(10);
+  const recToken = generateRecordToken();
+
+  await db.insertRecord(env.DB, {
+    id: recId,
+    collectionId: id,
+    status,
+    geometry: JSON.stringify(geometry),
+    properties: JSON.stringify(validated.properties),
+    admin_ctx: null, // enrichment is Phase 4
+    contributor,
+    edit_token_hash: await hashToken(recToken),
+    ip_hash: ipHash,
+  });
+  await db.touchCollection(env.DB, id);
+
+  void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'ok', collection_id: id, ip_hash: ipHash });
+  return json(200, { id: recId, status, edit_token: recToken });
+}
+
+// ---- POST /records/:id/moderate --------------------------------------------
+
+export async function moderateRecord(env: Env, req: Request, recordId: string): Promise<Response> {
+  const rec = await db.getRecord(env.DB, recordId);
+  if (!rec) return bad(404, 'not found');
+  const perm = await permissionFor(env.DB, rec.collection_id, bearer(req));
+  if (!atLeast(perm, 'admin')) return bad(401, 'unauthorised');
+
+  const body = await readJson(req);
+  const status = body?.status;
+  if (status !== 'published' && status !== 'rejected' && status !== 'pending') {
+    return bad(400, 'status must be published, rejected, or pending');
+  }
+  const reason = typeof body?.reason === 'string' ? body.reason : null;
+  await db.setRecordStatus(env.DB, recordId, status, reason);
+  return json(200, { id: recordId, status });
+}
+
+// ---- POST /collections/:id/publish -----------------------------------------
+
+export async function publish(env: Env, req: Request, id: string): Promise<Response> {
+  const perm = await permissionFor(env.DB, id, bearer(req));
+  if (!atLeast(perm, 'admin')) return bad(401, 'unauthorised');
+
+  const c = await db.getCollection(env.DB, id);
+  if (!c) return bad(404, 'not found');
+
+  const rows = await db.listRecords(env.DB, id, { status: 'published', limit: 100000, offset: 0 });
+  if (rows.length === 0) {
+    void logCollectAttempt(env.DB, { event: 'publish', outcome: 'rejected', gate: 'empty', collection_id: id });
+    return bad(409, 'nothing approved to publish yet');
+  }
+
+  const features = rows.map((r) => ({
+    type: 'Feature' as const,
+    geometry: JSON.parse(r.geometry),
+    properties: JSON.parse(r.properties),
+  }));
+  const fc = { type: 'FeatureCollection', features };
+  const bytes = new TextEncoder().encode(JSON.stringify(fc));
+  const contentHash = await sha256Hex(bytes.buffer);
+
+  // R6: refuse a republish with byte-identical content ("nothing new since v{N}").
+  const version = await db.nextVersion(env.DB, id);
+  if (version > 1) {
+    const prev = (await env.DB
+      .prepare(`SELECT content_hash FROM publications WHERE collection_id = ? AND version = ?`)
+      .bind(id, version - 1)
+      .first()) as { content_hash: string } | null;
+    if (prev?.content_hash === contentHash) return bad(409, `nothing new since v${version - 1}`);
+  }
+
+  const attribution = composeAttribution(c.name, c.license, rows.map((r) => r.contributor));
+  const geomTypes = [...new Set(rows.map((r) => (JSON.parse(r.geometry) as { type: string }).type))].join(',');
+
+  const submissionId = nanoid(10);
+  const r2Key = `community/${submissionId}/${submissionId}.geojson`;
+  const contributorsKey = `community/${submissionId}/contributors.json`;
+  const adminToken = generateToken('admin');
+
+  await env.R2.put(r2Key, bytes, {
+    httpMetadata: { contentType: 'application/geo+json', contentDisposition: `attachment; filename="${submissionId}.geojson"` },
+  });
+  await env.R2.put(
+    contributorsKey,
+    JSON.stringify({
+      attribution: attribution.line,
+      contributors: attribution.contributors,
+      collection_url: `${new URL(req.url).origin}/c/${id}`,
+      version,
+    }),
+    { httpMetadata: { contentType: 'application/json' } },
+  );
+
+  await insertSubmission(env.DB, {
+    id: submissionId,
+    status: 'accepted',
+    name: c.name,
+    description: c.description,
+    category: 'other', // collections carry no category in v1
+    license: c.license,
+    attribution: attribution.line,
+    source_url: `https://collect.bharatlas.com/c/${id}`,
+    data_year: c.data_year,
+    is_original: 1,
+    format: 'geojson',
+    bytes: bytes.byteLength,
+    feature_count: features.length,
+    geometry_types: geomTypes,
+    content_hash: contentHash,
+    ip_hash: c.ip_hash,
+    validation_report: null,
+    r2_key: r2Key,
+  });
+  await insertToken(env.DB, {
+    submissionId,
+    tokenPrefix: tokenPrefix(adminToken),
+    tokenHash: await hashToken(adminToken),
+    permission: 'admin',
+  });
+  await db.linkSubmission(env.DB, submissionId, id, version);
+  await db.insertPublication(env.DB, {
+    id: nanoid(10),
+    collectionId: id,
+    version,
+    submissionId,
+    featureCount: features.length,
+    contentHash,
+    attributionSnapshot: attribution.line,
+    r2Key,
+  });
+
+  void logCollectAttempt(env.DB, { event: 'publish', outcome: 'ok', collection_id: id });
+  return json(200, {
+    version,
+    submission_id: submissionId,
+    feature_count: features.length,
+    attribution: attribution.line,
+    share_url: `${BHARATLAS_ORIGIN}/c/${submissionId}`,
+    admin_token: adminToken,
+  });
+}

--- a/collect/functions/lib/handlers.ts
+++ b/collect/functions/lib/handlers.ts
@@ -250,7 +250,7 @@ export async function publish(env: Env, req: Request, id: string): Promise<Respo
   }));
   const fc = { type: 'FeatureCollection', features };
   const bytes = new TextEncoder().encode(JSON.stringify(fc));
-  const contentHash = await sha256Hex(bytes.buffer);
+  const contentHash = await sha256Hex(bytes.buffer as ArrayBuffer);
 
   // R6: refuse a republish with byte-identical content ("nothing new since v{N}").
   const version = await db.nextVersion(env.DB, id);

--- a/collect/functions/lib/http.ts
+++ b/collect/functions/lib/http.ts
@@ -1,0 +1,14 @@
+// JSON response helpers. Same-origin in practice (collect calls its own /api),
+// but tag permissive CORS so tools can read too.
+
+export const json = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'access-control-allow-origin': '*',
+    },
+  });
+
+export const ok = (body: unknown): Response => json(200, body);
+export const bad = (status: number, error: string): Response => json(status, { error });

--- a/collect/functions/lib/ratelimit.ts
+++ b/collect/functions/lib/ratelimit.ts
@@ -1,0 +1,60 @@
+// Per-hashed-IP rate limits on the shared rate_limits table (spec → Anti-abuse:
+// 5 collections/day, 200 records/hour). collect uses a DISTINCT IP_SALT from web,
+// so its rows never collide with submit's. Records use the hour window; creates
+// use the day window — independent columns on the same row.
+
+type DB = Pick<D1Database, 'prepare'>;
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+
+interface RLRow {
+  hour_window_start: string;
+  hour_count: number;
+  day_window_start: string;
+  day_count: number;
+}
+
+async function bump(db: DB, ipHash: string, window: 'hour' | 'day', limit: number): Promise<boolean> {
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+
+  const row = (await db
+    .prepare(`SELECT hour_window_start, hour_count, day_window_start, day_count FROM rate_limits WHERE ip_hash = ?`)
+    .bind(ipHash)
+    .first()) as RLRow | null;
+
+  if (!row) {
+    await db
+      .prepare(
+        `INSERT INTO rate_limits (ip_hash, hour_window_start, hour_count, day_window_start, day_count)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .bind(ipHash, nowIso, window === 'hour' ? 1 : 0, nowIso, window === 'day' ? 1 : 0)
+      .run();
+    return true;
+  }
+
+  let { hour_window_start, hour_count, day_window_start, day_count } = row;
+  if (nowMs - Date.parse(hour_window_start) >= HOUR_MS) { hour_window_start = nowIso; hour_count = 0; }
+  if (nowMs - Date.parse(day_window_start) >= DAY_MS) { day_window_start = nowIso; day_count = 0; }
+
+  const count = window === 'hour' ? hour_count : day_count;
+  const allowed = count < limit;
+  if (allowed) {
+    if (window === 'hour') hour_count += 1;
+    else day_count += 1;
+  }
+
+  await db
+    .prepare(
+      `UPDATE rate_limits SET hour_window_start = ?, hour_count = ?, day_window_start = ?, day_count = ? WHERE ip_hash = ?`,
+    )
+    .bind(hour_window_start, hour_count, day_window_start, day_count, ipHash)
+    .run();
+
+  return allowed;
+}
+
+export const checkRecordRate = (db: DB, ipHash: string): Promise<boolean> => bump(db, ipHash, 'hour', 200);
+export const checkCreateRate = (db: DB, ipHash: string): Promise<boolean> => bump(db, ipHash, 'day', 5);

--- a/collect/functions/lib/reuse.ts
+++ b/collect/functions/lib/reuse.ts
@@ -1,0 +1,8 @@
+// Single bridge to the web libs collect reuses unchanged (Phase 1 → promote to
+// shared/ at Phase 2). Keeping the deep relative paths in one place means the
+// route/handler files import at a stable, shallow depth.
+
+export { nanoid, sha256Hex, ipHashFor } from '../../../web/functions/lib/submit-helpers';
+export { verifyTurnstile } from '../../../web/functions/lib/turnstile';
+export { insertSubmission, insertToken } from '../../../web/functions/lib/submissions';
+export type { SubmissionRow } from '../../../web/functions/lib/submissions';

--- a/collect/functions/lib/tokens.ts
+++ b/collect/functions/lib/tokens.ts
@@ -1,0 +1,17 @@
+// Reuse web's token primitives unchanged (Phase 1 → promote to shared/ at
+// Phase 2). Adds the record-scoped `rec_` token used for edit / delete /
+// de-identify of one's own contribution.
+
+export { generateToken, tokenPrefix, hashToken, verifyToken } from '../../../web/functions/lib/tokens';
+export type { Permission } from '../../../web/functions/lib/tokens';
+
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+/** `rec_` + 32 URL-safe chars (~192 bits), same shape as the collection tokens. */
+export function generateRecordToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let out = '';
+  for (const b of bytes) out += ALPHABET[b & 0x3f];
+  return `rec_${out}`;
+}

--- a/collect/functions/types.ts
+++ b/collect/functions/types.ts
@@ -1,0 +1,10 @@
+// Bindings for the collect Pages project (collect/wrangler.toml). D1 + R2 are
+// the SAME shared resources web binds; the origin differs, the data is shared.
+
+export interface Env {
+  DB: D1Database;
+  R2: R2Bucket;
+  TURNSTILE_SECRET?: string;
+  PUBLIC_TURNSTILE_SITEKEY?: string;
+  IP_SALT?: string;
+}

--- a/collect/index.html
+++ b/collect/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="robots" content="noindex" />
+  <title>collect · bharatlas</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/landing.ts"></script>
+</body>
+</html>

--- a/collect/package-lock.json
+++ b/collect/package-lock.json
@@ -1,0 +1,1460 @@
+{
+  "name": "collect",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "collect",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260520.1",
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.9"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/collect/package-lock.json
+++ b/collect/package-lock.json
@@ -5,9 +5,13 @@
   "packages": {
     "": {
       "name": "collect",
+      "dependencies": {
+        "maplibre-gl": "^4.7.1"
+      },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260520.1",
         "typescript": "^5.6.3",
+        "vite": "^5.4.10",
         "vitest": "^2.1.9"
       }
     },
@@ -416,6 +420,90 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "license": "ISC",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
+      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
@@ -790,6 +878,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/mapbox__point-geometry": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mapbox__vector-tile": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/mapbox__point-geometry": "*",
+        "@types/pbf": "*"
+      }
+    },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -978,6 +1113,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -1059,6 +1200,103 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.3.tgz",
+      "integrity": "sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA==",
+      "license": "ISC"
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
+    "node_modules/global-prefix": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^4.1.3",
+        "kind-of": "^6.0.3",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
+    "node_modules/kdbush": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "license": "ISC"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -1076,11 +1314,67 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/maplibre-gl": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
+      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^3.0.0",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.3",
+        "global-prefix": "^4.0.0",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.3.0",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0",
+        "vt-pbf": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1119,6 +1413,19 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1153,6 +1460,33 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/rollup": {
@@ -1201,6 +1535,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1232,6 +1572,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -1255,6 +1604,12 @@
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",
@@ -1437,6 +1792,32 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/why-is-node-running": {

--- a/collect/package.json
+++ b/collect/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "collect",
+  "private": true,
+  "type": "module",
+  "description": "collect.bharatlas.com — crowd map-capture, publishes to the bharatlas catalogue",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260520.1",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.9"
+  }
+}

--- a/collect/package.json
+++ b/collect/package.json
@@ -6,11 +6,17 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.functions.json",
+    "dev": "vite",
+    "build": "vitest run && npm run typecheck && vite build"
+  },
+  "dependencies": {
+    "maplibre-gl": "^4.7.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260520.1",
     "typescript": "^5.6.3",
+    "vite": "^5.4.10",
     "vitest": "^2.1.9"
   }
 }

--- a/collect/public/index.html
+++ b/collect/public/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>collect · bharatlas</title></head>
+<body><p>collect placeholder — the create-a-map landing replaces this in the UI increment.</p></body>
+</html>

--- a/collect/public/index.html
+++ b/collect/public/index.html
@@ -1,5 +1,0 @@
-<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><title>collect · bharatlas</title></head>
-<body><p>collect placeholder — the create-a-map landing replaces this in the UI increment.</p></body>
-</html>

--- a/collect/public/schema/v1.json
+++ b/collect/public/schema/v1.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://collect.bharatlas.com/schema/v1.json",
+  "title": "collect field-definition (schema document) v1",
+  "type": "object",
+  "required": ["version", "geometry", "fields"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "const": 1 },
+    "geometry": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "enum": ["point", "line", "polygon"] }
+    },
+    "reference_layers": {
+      "type": "array",
+      "maxItems": 3,
+      "items": { "type": "string" }
+    },
+    "fields": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "type": "object",
+        "required": ["key", "label", "type"],
+        "properties": {
+          "key": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+          "label": { "type": "string", "minLength": 1 },
+          "type": { "enum": ["text", "paragraph", "number", "select", "multiselect", "date", "url"] },
+          "required": { "type": "boolean" },
+          "options": { "type": "array", "items": { "type": "string" } },
+          "min": { "type": "number" },
+          "max": { "type": "number" },
+          "integer": { "type": "boolean" },
+          "maxLength": { "type": "number" },
+          "deleted": { "type": "boolean" },
+          "render": { "enum": ["chips"] }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "type": { "enum": ["select", "multiselect"] } } },
+            "then": { "required": ["options"], "properties": { "options": { "minItems": 1 } } }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/collect/src/api.ts
+++ b/collect/src/api.ts
@@ -1,0 +1,34 @@
+// Client-side helpers: parse the collection id + mode + token from the URL
+// (token rides the fragment, never sent in a request line), and call the API.
+
+export type Mode = 'capture' | 'admin' | 'view';
+
+export interface Ctx {
+  id: string;
+  mode: Mode;
+  token: string;
+}
+
+export function parseCtx(): Ctx | null {
+  const m = location.pathname.match(/^\/c\/([A-Za-z0-9_-]{6,})(?:\/(admin|view))?\/?$/);
+  if (!m) return null;
+  const token = location.hash.replace(/^#/, '');
+  let mode: Mode = 'capture';
+  if (m[2] === 'admin' || token.startsWith('adm_')) mode = 'admin';
+  else if (m[2] === 'view' || token.startsWith('viw_')) mode = 'view';
+  return { id: m[1], mode, token };
+}
+
+export async function api(path: string, token: string, init?: RequestInit): Promise<Response> {
+  const headers = new Headers(init?.headers);
+  if (token) headers.set('authorization', `Bearer ${token}`);
+  if (init?.body) headers.set('content-type', 'application/json');
+  return fetch(`/api/collect/v1${path}`, { ...init, headers });
+}
+
+export async function apiJson<T = unknown>(path: string, token: string, init?: RequestInit): Promise<T> {
+  const res = await api(path, token, init);
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error((body as { error?: string }).error || `HTTP ${res.status}`);
+  return body as T;
+}

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -1,0 +1,228 @@
+// The /c/<id>[/admin|/view] app: a full-bleed map with a fixed crosshair for
+// pin-drop, an "Use my location" button (geolocation called synchronously in the
+// tap handler), a bottom-sheet form generated from the collection's schema, and
+// — for admin — a review queue + publish. Mobile-first.
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { BASEMAP, INDIA_CENTER } from './basemap';
+import { parseCtx, apiJson, type Ctx } from './api';
+
+interface Field {
+  key: string; label: string; type: string; required?: boolean; options?: string[]; deleted?: boolean;
+}
+interface Counts { pending: number; published: number; total: number; rejected: number; }
+interface Meta {
+  id: string; name: string; purpose: string; status: string; moderation: number;
+  schema: { geometry: string[]; fields: Field[] }; counts: Counts;
+}
+interface Feature { id: string; geometry: { type: string; coordinates: number[] }; properties: Record<string, unknown>; }
+
+const app = document.getElementById('app')!;
+let map: maplibregl.Map;
+let meta: Meta;
+let ctx: Ctx;
+
+function toast(msg: string): void {
+  const t = document.createElement('div');
+  t.className = 'toast';
+  t.textContent = msg;
+  document.body.appendChild(t);
+  requestAnimationFrame(() => t.classList.add('show'));
+  setTimeout(() => { t.classList.remove('show'); setTimeout(() => t.remove(), 300); }, 2400);
+}
+
+function marker(coords: number[], color = '#1a7f5a'): void {
+  if (coords.length >= 2) new maplibregl.Marker({ color }).setLngLat([coords[0], coords[1]]).addTo(map);
+}
+
+async function boot(): Promise<void> {
+  ctx = parseCtx()!;
+  meta = await apiJson<Meta>(`/collections/${ctx.id}`, ctx.token);
+  const isView = ctx.mode === 'view';
+  const isAdmin = ctx.mode === 'admin';
+
+  app.innerHTML = `
+    <div class="topbar">
+      <a href="/">←</a><span>${meta.name}</span>
+      <span class="muted" style="margin-left:auto">${isAdmin ? 'admin' : isView ? 'view' : ''}</span>
+    </div>
+    <div class="map">
+      <div id="map"></div>
+      <div class="crosshair" ${isView ? 'style="display:none"' : ''}></div>
+      ${isView ? '' : '<button class="locate" id="locate" title="Use my location">◎</button>'}
+      ${isAdmin ? '<button class="locate" id="manage" style="left:12px;right:auto;bottom:76px">⚙</button>' : ''}
+    </div>
+    <div id="panel"></div>`;
+
+  map = new maplibregl.Map({
+    container: 'map', style: BASEMAP, center: INDIA_CENTER, zoom: 4,
+    attributionControl: { compact: true },
+  });
+  map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
+  map.on('load', loadRecords);
+
+  if (!isView) {
+    const locate = document.getElementById('locate') as HTMLButtonElement;
+    locate.onclick = () => {
+      if (!navigator.geolocation) return toast('Location not available');
+      navigator.geolocation.getCurrentPosition(
+        (pos) => map.flyTo({ center: [pos.coords.longitude, pos.coords.latitude], zoom: 16 }),
+        () => toast("Couldn't get your location"),
+        { enableHighAccuracy: true, timeout: 8000 },
+      );
+    };
+    captureSheet();
+  }
+  if (isAdmin) {
+    (document.getElementById('manage') as HTMLButtonElement).onclick = manageSheet;
+  }
+}
+
+async function loadRecords(): Promise<void> {
+  try {
+    const fc = await apiJson<{ features: Feature[] }>(`/collections/${ctx.id}/records`, ctx.token);
+    for (const f of fc.features || []) if (f.geometry?.type === 'Point') marker(f.geometry.coordinates);
+  } catch { /* map still usable */ }
+}
+
+function fieldInput(f: Field): string {
+  switch (f.type) {
+    case 'paragraph': return `<textarea data-k="${f.key}"></textarea>`;
+    case 'number': return `<input data-k="${f.key}" inputmode="decimal" />`;
+    case 'date': return `<input data-k="${f.key}" type="date" />`;
+    case 'url': return `<input data-k="${f.key}" inputmode="url" placeholder="https://" />`;
+    case 'select':
+      return `<select data-k="${f.key}"><option value=""></option>${(f.options || []).map((o) => `<option>${o}</option>`).join('')}</select>`;
+    case 'multiselect':
+      return `<div class="row" data-k="${f.key}" data-multi>${(f.options || []).map((o) => `<button type="button" class="chip" data-v="${o}">${o}</button>`).join('')}</div>`;
+    default: return `<input data-k="${f.key}" />`;
+  }
+}
+
+function captureSheet(): void {
+  const fields = meta.schema.fields.filter((f) => !f.deleted);
+  const panel = document.getElementById('panel')!;
+  panel.innerHTML = `<div class="sheet">
+    <div class="body">
+      <strong>Add a point</strong>
+      <p class="hint">Move the map so the crosshair sits on the spot.</p>
+      ${fields.map((f) => `<label>${f.label}${f.required ? ' *' : ''}</label>${fieldInput(f)}`).join('')}
+      <label>Your name <span class="hint">(optional — published with the data)</span></label>
+      <input id="contributor" />
+    </div>
+    <div class="foot"><button class="primary" id="add">Add point</button></div>
+  </div>`;
+  panel.querySelectorAll<HTMLElement>('[data-multi] .chip').forEach((c) => { c.onclick = () => c.classList.toggle('on'); });
+
+  (document.getElementById('add') as HTMLButtonElement).onclick = async (ev) => {
+    const btn = ev.currentTarget as HTMLButtonElement;
+    btn.disabled = true;
+    try {
+      const props: Record<string, unknown> = {};
+      for (const f of fields) {
+        const el = panel.querySelector(`[data-k="${f.key}"]`);
+        if (!el) continue;
+        if (f.type === 'multiselect') {
+          const on = [...el.querySelectorAll('.chip.on')].map((c) => (c as HTMLElement).dataset.v);
+          if (on.length) props[f.key] = on;
+        } else if (f.type === 'number') {
+          const v = (el as HTMLInputElement).value; if (v) props[f.key] = Number(v);
+        } else {
+          const v = (el as HTMLInputElement).value; if (v) props[f.key] = v;
+        }
+      }
+      const c = map.getCenter();
+      const contributor = (document.getElementById('contributor') as HTMLInputElement).value;
+      await apiJson(`/collections/${ctx.id}/records`, ctx.token, {
+        method: 'POST',
+        body: JSON.stringify({ geometry: { type: 'Point', coordinates: [c.lng, c.lat] }, properties: props, contributor }),
+      });
+      marker([c.lng, c.lat]);
+      toast(meta.moderation ? 'Added — pending review ✓' : 'Added ✓');
+      panel.querySelectorAll('input,textarea,select').forEach((el) => { (el as HTMLInputElement).value = ''; });
+      panel.querySelectorAll('.chip.on').forEach((c) => c.classList.remove('on'));
+    } catch (e) {
+      toast((e as Error).message);
+    }
+    btn.disabled = false;
+  };
+}
+
+async function manageSheet(): Promise<void> {
+  const fresh = await apiJson<Meta>(`/collections/${ctx.id}`, ctx.token).catch(() => meta);
+  const counts = fresh.counts;
+  const panel = document.getElementById('panel')!;
+  panel.innerHTML = `<div class="sheet">
+    <div class="body">
+      <strong>Manage map</strong>
+      <p class="hint">${counts.published} approved · ${counts.pending} pending · ${counts.total} total</p>
+      <div id="queue"><p class="hint">Loading pending…</p></div>
+    </div>
+    <div class="foot row">
+      <button id="back">← Capture</button>
+      <button class="primary" id="publish" style="flex:1">Publish v${'?'} → atlas</button>
+    </div>
+  </div>`;
+  (document.getElementById('back') as HTMLButtonElement).onclick = captureSheet;
+  (document.getElementById('publish') as HTMLButtonElement).onclick = doPublish;
+  renderQueue();
+}
+
+async function renderQueue(): Promise<void> {
+  const q = document.getElementById('queue');
+  if (!q) return;
+  try {
+    const fc = await apiJson<{ features: Feature[] }>(`/collections/${ctx.id}/records?status=pending&limit=25`, ctx.token);
+    const feats = fc.features || [];
+    if (!feats.length) { q.innerHTML = '<p class="hint">Nothing pending.</p>'; return; }
+    q.innerHTML = feats.map((f) => `<div class="card" data-id="${f.id}">
+        <div>${String((f.properties as { name?: string }).name ?? '(no name)')}</div>
+        <div class="hint">${(f.properties as { _contributor?: string })._contributor || 'anonymous'}</div>
+        <div class="row" style="margin-top:8px">
+          <button data-act="rejected" style="flex:1">✗ Reject</button>
+          <button class="primary" data-act="published" style="flex:1">✓ Approve</button>
+        </div></div>`).join('');
+    q.querySelectorAll<HTMLButtonElement>('button[data-act]').forEach((b) => {
+      b.onclick = async () => {
+        const card = b.closest('.card') as HTMLElement;
+        try {
+          await apiJson(`/records/${card.dataset.id}/moderate`, ctx.token, {
+            method: 'POST', body: JSON.stringify({ status: b.dataset.act }),
+          });
+          card.remove();
+        } catch (e) { toast((e as Error).message); }
+      };
+    });
+  } catch (e) {
+    q.innerHTML = `<p class="warn">${(e as Error).message}</p>`;
+  }
+}
+
+async function doPublish(ev: Event): Promise<void> {
+  const btn = ev.currentTarget as HTMLButtonElement;
+  btn.disabled = true;
+  try {
+    const res = await apiJson<{ version: number; share_url: string; feature_count: number }>(
+      `/collections/${ctx.id}/publish`, ctx.token, { method: 'POST' },
+    );
+    toast(`Published v${res.version} · ${res.feature_count} features`);
+    const panel = document.getElementById('panel')!;
+    panel.innerHTML = `<div class="sheet"><div class="body">
+      <strong>Published to the atlas 🎉</strong>
+      <p class="hint">Version ${res.version} · ${res.feature_count} features.</p>
+      <a class="btn primary" href="${res.share_url}" target="_blank" rel="noopener">View on bharatlas →</a>
+      </div><div class="foot"><button id="back">← Back to capture</button></div></div>`;
+    (document.getElementById('back') as HTMLButtonElement).onclick = captureSheet;
+  } catch (e) {
+    toast((e as Error).message);
+    btn.disabled = false;
+  }
+}
+
+if (!parseCtx()?.token) {
+  app.innerHTML = `<div class="pad"><h1>Invalid link</h1><p class="hint">Open a collect link (with its token in the URL) to continue.</p></div>`;
+} else {
+  boot().catch((e) => {
+    app.innerHTML = `<div class="pad"><h1>Couldn't load</h1><p class="warn">${(e as Error).message}</p></div>`;
+  });
+}

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -6,6 +6,7 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { BASEMAP, INDIA_CENTER } from './basemap';
 import { parseCtx, apiJson, type Ctx } from './api';
+import { turnstileToken } from './turnstile';
 
 interface Field {
   key: string; label: string; type: string; required?: boolean; options?: string[]; deleted?: boolean;
@@ -133,9 +134,10 @@ function captureSheet(): void {
       }
       const c = map.getCenter();
       const contributor = (document.getElementById('contributor') as HTMLInputElement).value;
+      const turnstile_token = await turnstileToken();
       await apiJson(`/collections/${ctx.id}/records`, ctx.token, {
         method: 'POST',
-        body: JSON.stringify({ geometry: { type: 'Point', coordinates: [c.lng, c.lat] }, properties: props, contributor }),
+        body: JSON.stringify({ geometry: { type: 'Point', coordinates: [c.lng, c.lat] }, properties: props, contributor, turnstile_token }),
       });
       marker([c.lng, c.lat]);
       toast(meta.moderation ? 'Added — pending review ✓' : 'Added ✓');

--- a/collect/src/basemap.ts
+++ b/collect/src/basemap.ts
@@ -1,0 +1,20 @@
+import type { StyleSpecification } from 'maplibre-gl';
+
+// CARTO Positron raster (same source web's positron basemap uses) — no API key.
+export const BASEMAP: StyleSpecification = {
+  version: 8,
+  sources: {
+    carto: {
+      type: 'raster',
+      tiles: [
+        'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+        'https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+      ],
+      tileSize: 256,
+      attribution: '© CARTO · © OpenStreetMap contributors',
+    },
+  },
+  layers: [{ id: 'carto', type: 'raster', source: 'carto' }],
+};
+
+export const INDIA_CENTER: [number, number] = [78.9, 22];

--- a/collect/src/config.ts
+++ b/collect/src/config.ts
@@ -1,0 +1,4 @@
+// Public Turnstile sitekey for the collect widget (managed mode). Overridable
+// at build via VITE_TURNSTILE_SITEKEY; the default is the live public key.
+export const TURNSTILE_SITEKEY =
+  ((import.meta.env?.VITE_TURNSTILE_SITEKEY as string) || '').trim() || '0x4AAAAAAEUVQ4gS3xN4W2l1';

--- a/collect/src/geo/bounds.ts
+++ b/collect/src/geo/bounds.ts
@@ -1,0 +1,63 @@
+// Reject any geometry with a vertex outside India. Mirrors web's check in
+// api/v1/locate (lat 6-38, lng 68-98); a record is rejected whole on any
+// out-of-range vertex (spec → "POST /collections/:id/records", step 1).
+
+export const INDIA_BBOX = [68, 6, 98, 38] as const; // [minLng, minLat, maxLng, maxLat]
+const [MIN_LNG, MIN_LAT, MAX_LNG, MAX_LAT] = INDIA_BBOX;
+
+export type BoundsResult = { ok: true } | { ok: false; error: string };
+
+const OUT_OF_RANGE = 'lat must be 6-38, lng must be 68-98 (India bounding box)';
+const MALFORMED = 'invalid geometry';
+
+const SIMPLE = new Set([
+  'Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon',
+]);
+
+function isPair(node: unknown): node is [number, number, ...number[]] {
+  return Array.isArray(node) && node.length >= 2
+    && typeof node[0] === 'number' && typeof node[1] === 'number';
+}
+
+export function checkIndiaBounds(geometry: unknown): BoundsResult {
+  if (!geometry || typeof geometry !== 'object') return { ok: false, error: MALFORMED };
+  const g = geometry as { type?: unknown; coordinates?: unknown; geometries?: unknown };
+  if (typeof g.type !== 'string') return { ok: false, error: MALFORMED };
+
+  if (g.type === 'GeometryCollection') {
+    if (!Array.isArray(g.geometries) || g.geometries.length === 0) return { ok: false, error: MALFORMED };
+    for (const sub of g.geometries) {
+      const r = checkIndiaBounds(sub);
+      if (!r.ok) return r;
+    }
+    return { ok: true };
+  }
+
+  if (!SIMPLE.has(g.type)) return { ok: false, error: MALFORMED };
+  if (!Array.isArray(g.coordinates)) return { ok: false, error: MALFORMED };
+
+  let sawPair = false;
+  let malformed = false;
+  let outOfRange = false;
+
+  const walk = (node: unknown): void => {
+    if (malformed) return;
+    if (isPair(node)) {
+      sawPair = true;
+      const [lng, lat] = node;
+      if (lng < MIN_LNG || lng > MAX_LNG || lat < MIN_LAT || lat > MAX_LAT) outOfRange = true;
+      return;
+    }
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    malformed = true; // a non-array, non-pair leaf — not valid GeoJSON coordinates
+  };
+
+  walk(g.coordinates);
+
+  if (malformed || !sawPair) return { ok: false, error: MALFORMED };
+  if (outOfRange) return { ok: false, error: OUT_OF_RANGE };
+  return { ok: true };
+}

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -1,6 +1,7 @@
 // Create-a-map landing. Phase 1 uses a fixed 2-field schema (the schema builder
 // is Phase 2); the author picks name / purpose / geometry / licence.
 import { apiJson } from './api';
+import { turnstileToken } from './turnstile';
 
 const OPEN_LICENCES: [string, string][] = [
   ['CC-BY-4.0', 'CC BY 4.0 (credit required)'],
@@ -62,6 +63,7 @@ function render() {
     btn.disabled = true;
     const year = (app.querySelector<HTMLInputElement>('#year')!.value || '').trim();
     try {
+      const turnstile_token = await turnstileToken();
       const links = (await apiJson<{ id: string; links: Record<string, string> }>('/collections', '', {
         method: 'POST',
         body: JSON.stringify({
@@ -70,6 +72,7 @@ function render() {
           license: app.querySelector<HTMLSelectElement>('#license')!.value,
           data_year: year ? Number(year) : undefined,
           schema_doc: defaultSchema([...geom]),
+          turnstile_token,
         }),
       })).links;
       done(links);

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -1,0 +1,119 @@
+// Create-a-map landing. Phase 1 uses a fixed 2-field schema (the schema builder
+// is Phase 2); the author picks name / purpose / geometry / licence.
+import { apiJson } from './api';
+
+const OPEN_LICENCES: [string, string][] = [
+  ['CC-BY-4.0', 'CC BY 4.0 (credit required)'],
+  ['CC0-1.0', 'CC0 (public domain)'],
+  ['CC-BY-SA-4.0', 'CC BY-SA 4.0'],
+  ['ODbL-1.0', 'ODbL 1.0'],
+  ['ODC-PDDL-1.0', 'PDDL 1.0'],
+  ['GODL-India', 'GODL India'],
+  ['CDLA-Permissive-2.0', 'CDLA Permissive 2.0'],
+];
+
+const defaultSchema = (geometry: string[]) => ({
+  version: 1,
+  geometry,
+  fields: [
+    { key: 'name', label: 'Name of the place', type: 'text', required: true },
+    { key: 'notes', label: 'Notes', type: 'paragraph' },
+  ],
+});
+
+const app = document.getElementById('app')!;
+
+function render() {
+  app.innerHTML = `
+    <div class="topbar"><span>New map</span><span class="muted" style="margin-left:auto">collect · bharatlas</span></div>
+    <div class="pad">
+      <label>Name your map</label>
+      <input id="name" maxlength="120" placeholder="Bengaluru footpath survey" />
+      <label>What's it for? <span class="hint">(shown to contributors)</span></label>
+      <textarea id="purpose" maxlength="2000" placeholder="Mapping footpath condition across the ward"></textarea>
+      <label>Contributors add</label>
+      <div class="row" id="geom">
+        <button type="button" class="chip on" data-g="point">Points</button>
+        <button type="button" class="chip" data-g="line">Lines</button>
+        <button type="button" class="chip" data-g="polygon">Areas</button>
+      </div>
+      <label>Licence <span class="hint">(open licences only — the map publishes openly)</span></label>
+      <select id="license">${OPEN_LICENCES.map(([id, l]) => `<option value="${id}">${l}</option>`).join('')}</select>
+      <label>Data year <span class="hint">(optional)</span></label>
+      <input id="year" inputmode="numeric" placeholder="2026" />
+      <div style="height:16px"></div>
+      <button class="primary" id="create">Create map</button>
+      <p id="err" class="warn"></p>
+    </div>`;
+
+  const geom = new Set(['point']);
+  app.querySelectorAll<HTMLButtonElement>('#geom .chip').forEach((c) => {
+    c.onclick = () => {
+      const g = c.dataset.g!;
+      if (geom.has(g)) { if (geom.size > 1) { geom.delete(g); c.classList.remove('on'); } }
+      else { geom.add(g); c.classList.add('on'); }
+    };
+  });
+
+  app.querySelector<HTMLButtonElement>('#create')!.onclick = async (ev) => {
+    const btn = ev.currentTarget as HTMLButtonElement;
+    const err = app.querySelector('#err')!;
+    err.textContent = '';
+    btn.disabled = true;
+    const year = (app.querySelector<HTMLInputElement>('#year')!.value || '').trim();
+    try {
+      const links = (await apiJson<{ id: string; links: Record<string, string> }>('/collections', '', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: app.querySelector<HTMLInputElement>('#name')!.value,
+          purpose: app.querySelector<HTMLTextAreaElement>('#purpose')!.value,
+          license: app.querySelector<HTMLSelectElement>('#license')!.value,
+          data_year: year ? Number(year) : undefined,
+          schema_doc: defaultSchema([...geom]),
+        }),
+      })).links;
+      done(links);
+    } catch (e) {
+      err.textContent = (e as Error).message;
+      btn.disabled = false;
+    }
+  };
+}
+
+function linkRow(label: string, url: string): string {
+  return `<label>${label}</label><div class="link-box"><code>${url}</code><button data-copy="${encodeURIComponent(url)}">Copy</button></div>`;
+}
+
+function done(links: Record<string, string>) {
+  try {
+    const store = JSON.parse(localStorage.getItem('collect:maps') || '[]');
+    store.unshift({ links, at: new Date().toISOString() });
+    localStorage.setItem('collect:maps', JSON.stringify(store.slice(0, 50)));
+  } catch { /* per-device convenience only */ }
+
+  app.innerHTML = `
+    <div class="topbar"><span>Your map is live</span></div>
+    <div class="pad">
+      ${linkRow('🔗 Collect link — share this', links.edit)}
+      <p class="hint">Anyone with this can add points. No login.</p>
+      ${linkRow('👁 View-only', links.view)}
+      ${linkRow('🔑 Admin — keep secret', links.admin)}
+      <p class="warn">⚠ Shown once. Lose the admin link, lose the map.</p>
+      <button id="dl">⬇ Download my links</button>
+      <div style="height:10px"></div>
+      <a class="btn primary" href="${links.edit}">Open the map →</a>
+    </div>`;
+
+  app.querySelectorAll<HTMLButtonElement>('[data-copy]').forEach((b) => {
+    b.onclick = () => { navigator.clipboard?.writeText(decodeURIComponent(b.dataset.copy!)); b.textContent = '✓'; };
+  });
+  app.querySelector<HTMLButtonElement>('#dl')!.onclick = () => {
+    const text = `collect.bharatlas.com links\n\nCollect (share): ${links.edit}\nView-only: ${links.view}\nAdmin (secret): ${links.admin}\n`;
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([text], { type: 'text/plain' }));
+    a.download = 'collect-links.txt';
+    a.click();
+  };
+}
+
+render();

--- a/collect/src/publish/attribution.ts
+++ b/collect/src/publish/attribution.ts
@@ -1,0 +1,47 @@
+// Compose the single credit line + the contributors.json breakdown at publish
+// (spec → "Attribution", the OpenStreetMap model). The headline counts distinct
+// *named* contributors and notes anonymous separately, because distinct
+// anonymous people can't be counted; every anonymous record is tallied into one
+// bucket in the breakdown.
+
+export interface ContributorTally {
+  name: string;
+  records: number;
+}
+
+export interface ComposedAttribution {
+  line: string;
+  contributors: ContributorTally[];
+}
+
+export function composeAttribution(
+  projectName: string,
+  license: string,
+  contributorNames: readonly (string | null | undefined)[],
+): ComposedAttribution {
+  const counts = new Map<string, number>();
+  let anon = 0;
+  for (const raw of contributorNames) {
+    const name = typeof raw === 'string' ? raw.trim() : '';
+    if (name === '') anon += 1;
+    else counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+
+  const named: ContributorTally[] = [...counts.entries()]
+    .map(([name, records]) => ({ name, records }))
+    .sort((a, b) => b.records - a.records || a.name.localeCompare(b.name));
+
+  const contributors: ContributorTally[] = [...named];
+  if (anon > 0) contributors.push({ name: 'anonymous', records: anon });
+
+  const n = named.length;
+  let who = '';
+  if (n === 0 && anon > 0) who = 'anonymous contributors';
+  else if (n > 0) {
+    who = `${n} contributor${n === 1 ? '' : 's'}`;
+    if (anon > 0) who += ' + anonymous';
+  }
+
+  const line = who ? `${projectName} — ${who} (${license})` : projectName;
+  return { line, contributors };
+}

--- a/collect/src/schema/validate-collection.ts
+++ b/collect/src/schema/validate-collection.ts
@@ -1,0 +1,98 @@
+// Validate a new collection's metadata + its schema document (the "meta-schema"
+// check). Licence must be in the bharatlas-acceptable open set; the schema doc's
+// "geometry" array is the single source of truth for allowed geometry types.
+// Phase 1 imports isOpenLicence straight from web (promote to shared/ at Phase 2).
+
+import { isOpenLicence } from '../../../web/functions/lib/licenses';
+
+export const FIELD_TYPES = [
+  'text', 'paragraph', 'number', 'select', 'multiselect', 'date', 'url',
+] as const;
+export const GEOMETRY_TYPES = ['point', 'line', 'polygon'] as const;
+
+const KEY_RE = /^[a-z][a-z0-9_]*$/;
+const MAX_FIELDS = 20;
+const MAX_REF_LAYERS = 3;
+
+export type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+export interface NewCollection {
+  name: string;
+  purpose: string;
+  license: string;
+  description: string | null;
+  data_year: number | null;
+  schema_doc: string; // canonical JSON string
+}
+
+const isStr = (v: unknown): v is string => typeof v === 'string';
+const fail = (error: string): { ok: false; error: string } => ({ ok: false, error });
+
+export function validateSchemaDoc(input: unknown): Result<Record<string, unknown>> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return fail('schema_doc must be an object');
+  const doc = input as Record<string, unknown>;
+  if (doc.version !== 1) return fail('schema_doc.version must be 1');
+
+  const geom = doc.geometry;
+  if (!Array.isArray(geom) || geom.length === 0) return fail('schema_doc.geometry must be a non-empty array');
+  for (const g of geom) {
+    if (!GEOMETRY_TYPES.includes(g as (typeof GEOMETRY_TYPES)[number])) return fail(`unknown geometry type: ${String(g)}`);
+  }
+
+  const fields = doc.fields;
+  if (!Array.isArray(fields)) return fail('schema_doc.fields must be an array');
+  if (fields.length > MAX_FIELDS) return fail(`too many fields (max ${MAX_FIELDS})`);
+
+  const keys = new Set<string>();
+  for (const f of fields) {
+    if (!f || typeof f !== 'object') return fail('each field must be an object');
+    const fd = f as Record<string, unknown>;
+    if (!isStr(fd.key) || !KEY_RE.test(fd.key)) return fail(`invalid field key: ${String(fd.key)}`);
+    if (keys.has(fd.key)) return fail(`duplicate field key: ${fd.key}`);
+    keys.add(fd.key);
+    if (!isStr(fd.label) || fd.label.trim() === '') return fail(`field ${fd.key} needs a label`);
+    if (!FIELD_TYPES.includes(fd.type as (typeof FIELD_TYPES)[number])) return fail(`field ${fd.key} has invalid type: ${String(fd.type)}`);
+    if (fd.type === 'select' || fd.type === 'multiselect') {
+      if (!Array.isArray(fd.options) || fd.options.length === 0 || !fd.options.every(isStr)) {
+        return fail(`field ${fd.key} needs a non-empty options list`);
+      }
+    }
+  }
+
+  const refs = doc.reference_layers;
+  if (refs !== undefined) {
+    if (!Array.isArray(refs) || !refs.every(isStr)) return fail('reference_layers must be a string array');
+    if (refs.length > MAX_REF_LAYERS) return fail(`too many reference layers (max ${MAX_REF_LAYERS})`);
+  }
+  return { ok: true, value: doc };
+}
+
+export function validateNewCollection(input: unknown): Result<NewCollection> {
+  if (!input || typeof input !== 'object') return fail('body must be an object');
+  const b = input as Record<string, unknown>;
+
+  const name = isStr(b.name) ? b.name.trim() : '';
+  if (name.length < 3 || name.length > 120) return fail('name must be 3-120 characters');
+
+  const purpose = isStr(b.purpose) ? b.purpose.trim() : '';
+  if (purpose.length < 1 || purpose.length > 2000) return fail('purpose is required');
+
+  if (!isStr(b.license) || !isOpenLicence(b.license)) return fail('license must be an accepted open licence');
+
+  let dataYear: number | null = null;
+  if (b.data_year !== undefined && b.data_year !== null && b.data_year !== '') {
+    const y = typeof b.data_year === 'number' ? b.data_year : Number(b.data_year);
+    if (!Number.isInteger(y) || y < 1800 || y > 2100) return fail('data_year must be a year 1800-2100');
+    dataYear = y;
+  }
+
+  const description = isStr(b.description) && b.description.trim() !== '' ? b.description.trim() : null;
+
+  const sd = validateSchemaDoc(b.schema_doc);
+  if (!sd.ok) return sd;
+
+  return {
+    ok: true,
+    value: { name, purpose, license: b.license, description, data_year: dataYear, schema_doc: JSON.stringify(sd.value) },
+  };
+}

--- a/collect/src/schema/validate-record.ts
+++ b/collect/src/schema/validate-record.ts
@@ -1,0 +1,123 @@
+// Validate a contributor's submitted properties against a collection's field
+// definition (spec → "POST /collections/:id/records", step 2). Required fields
+// present, select ∈ options, number numeric, url http(s), date valid; unknown
+// keys dropped; soft-deleted fields omitted. Returns the cleaned properties.
+
+export type FieldType =
+  | 'text' | 'paragraph' | 'number' | 'select' | 'multiselect' | 'date' | 'url';
+
+export interface Field {
+  key: string;
+  label: string;
+  type: FieldType;
+  required?: boolean;
+  options?: string[];   // select / multiselect
+  min?: number;         // number
+  max?: number;         // number
+  integer?: boolean;    // number
+  maxLength?: number;   // text / paragraph
+  deleted?: boolean;    // soft-deleted → never read or written
+}
+
+export type ValidateResult =
+  | { ok: true; properties: Record<string, unknown> }
+  | { ok: false; error: string };
+
+const DEFAULT_MAXLEN: Record<string, number> = { text: 500, paragraph: 5000 };
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isEmpty(v: unknown): boolean {
+  if (v === undefined || v === null) return true;
+  if (typeof v === 'string') return v.trim() === '';
+  if (Array.isArray(v)) return v.length === 0;
+  return false; // numbers (incl. 0), booleans, objects are "present"
+}
+
+function validDate(s: string): boolean {
+  if (!DATE_RE.test(s)) return false;
+  const [y, m, d] = s.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+}
+
+function validUrl(s: string): boolean {
+  try {
+    const u = new URL(s);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+const err = (msg: string): ValidateResult => ({ ok: false, error: msg });
+
+export function validateRecordProperties(fields: Field[], input: unknown): ValidateResult {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return err('properties must be an object');
+  }
+  const src = input as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+
+  for (const f of fields) {
+    if (f.deleted) continue;                 // soft-deleted → omit entirely
+    const v = src[f.key];
+
+    if (isEmpty(v)) {
+      if (f.required) return err(`${f.label} is required`);
+      continue;                              // optional + empty → omit
+    }
+
+    switch (f.type) {
+      case 'text':
+      case 'paragraph': {
+        if (typeof v !== 'string') return err(`${f.label} must be text`);
+        const cap = f.maxLength ?? DEFAULT_MAXLEN[f.type];
+        if (v.length > cap) return err(`${f.label} is too long (max ${cap})`);
+        out[f.key] = v;
+        break;
+      }
+      case 'number': {
+        const n = typeof v === 'number' ? v : typeof v === 'string' ? Number(v) : NaN;
+        if (!Number.isFinite(n)) return err(`${f.label} must be a number`);
+        if (f.integer && !Number.isInteger(n)) return err(`${f.label} must be a whole number`);
+        if (f.min !== undefined && n < f.min) return err(`${f.label} must be at least ${f.min}`);
+        if (f.max !== undefined && n > f.max) return err(`${f.label} must be at most ${f.max}`);
+        out[f.key] = n;
+        break;
+      }
+      case 'select': {
+        if (typeof v !== 'string' || !(f.options ?? []).includes(v)) {
+          return err(`${f.label}: "${String(v)}" is not an allowed option`);
+        }
+        out[f.key] = v;
+        break;
+      }
+      case 'multiselect': {
+        if (!Array.isArray(v)) return err(`${f.label} must be a list`);
+        const opts = f.options ?? [];
+        for (const item of v) {
+          if (typeof item !== 'string' || !opts.includes(item)) {
+            return err(`${f.label}: "${String(item)}" is not an allowed option`);
+          }
+        }
+        out[f.key] = v;
+        break;
+      }
+      case 'date': {
+        if (typeof v !== 'string' || !validDate(v)) {
+          return err(`${f.label} must be a valid date (YYYY-MM-DD)`);
+        }
+        out[f.key] = v;
+        break;
+      }
+      case 'url': {
+        if (typeof v !== 'string' || !validUrl(v)) return err(`${f.label} must be an http(s) URL`);
+        out[f.key] = v;
+        break;
+      }
+      default:
+        return err(`${f.label}: unknown field type`);
+    }
+  }
+  return { ok: true, properties: out };
+}

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -1,0 +1,98 @@
+/* collect — mobile-first, reuses the bharatlas token system. Light default;
+   dark via prefers-color-scheme. 44px touch targets; safe-area insets. */
+:root {
+  --bg: #ffffff;
+  --fg: #16181d;
+  --line: #e3e6ea;
+  --muted: #6b7280;
+  --accent: #1a7f5a;
+  --accent-fill: #eaf6f0;
+  --sheet: #ffffff;
+  --shadow: 0 -6px 24px rgba(0, 0, 0, 0.12);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0e1013;
+    --fg: #e8eaed;
+    --line: #2a2e35;
+    --muted: #9aa1ab;
+    --accent: #3ecf8e;
+    --accent-fill: #10261d;
+    --sheet: #14171c;
+    --shadow: 0 -6px 24px rgba(0, 0, 0, 0.5);
+  }
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; height: 100%; }
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font: 16px/1.45 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  -webkit-text-size-adjust: 100%;
+}
+#app { height: 100dvh; display: flex; flex-direction: column; }
+
+.topbar {
+  display: flex; align-items: center; gap: 10px;
+  padding: max(8px, env(safe-area-inset-top)) 14px 8px;
+  border-bottom: 1px solid var(--line);
+  font-weight: 600;
+}
+.topbar a { color: var(--fg); text-decoration: none; font-size: 22px; }
+.topbar .muted { color: var(--muted); font-weight: 400; font-size: 13px; }
+
+/* buttons + inputs */
+button, .btn {
+  min-height: 44px; padding: 0 16px; border-radius: 12px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--fg);
+  font-size: 16px; font-weight: 600; cursor: pointer;
+}
+button.primary, .btn.primary {
+  background: var(--accent); border-color: var(--accent); color: #fff; width: 100%;
+}
+button.ghost { background: transparent; }
+button:disabled { opacity: 0.5; }
+label { display: block; font-size: 13px; color: var(--muted); margin: 12px 0 4px; }
+input, textarea, select {
+  width: 100%; min-height: 44px; padding: 10px 12px; font-size: 16px;
+  border: 1px solid var(--line); border-radius: 10px; background: var(--bg); color: var(--fg);
+}
+textarea { min-height: 88px; }
+.row { display: flex; gap: 8px; flex-wrap: wrap; }
+.chip { display: inline-flex; align-items: center; min-height: 40px; padding: 0 14px;
+  border: 1px solid var(--line); border-radius: 999px; }
+.chip.on { background: var(--accent-fill); border-color: var(--accent); color: var(--accent); }
+
+/* landing / form pages scroll */
+.pad { padding: 16px; overflow: auto; }
+.pad h1 { font-size: 20px; margin: 8px 0 4px; }
+.hint { color: var(--muted); font-size: 13px; }
+.link-box { display: flex; gap: 8px; align-items: center; margin: 6px 0; }
+.link-box code { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  background: var(--accent-fill); padding: 8px 10px; border-radius: 8px; font-size: 12px; }
+.warn { color: #b04a2f; font-size: 13px; }
+
+/* map + capture */
+.map { position: relative; flex: 1; min-height: 0; }
+#map { position: absolute; inset: 0; }
+.crosshair { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
+  width: 34px; height: 34px; pointer-events: none; z-index: 5; }
+.crosshair::before, .crosshair::after { content: ""; position: absolute; background: var(--accent); }
+.crosshair::before { left: 16px; top: 0; width: 2px; height: 34px; }
+.crosshair::after { top: 16px; left: 0; height: 2px; width: 34px; }
+.locate { position: absolute; right: 12px; bottom: 12px; z-index: 6;
+  min-width: 44px; box-shadow: 0 2px 10px rgba(0,0,0,0.2); }
+
+/* bottom sheet */
+.sheet { background: var(--sheet); border-top: 1px solid var(--line);
+  box-shadow: var(--shadow); border-radius: 16px 16px 0 0;
+  max-height: 62dvh; display: flex; flex-direction: column; }
+.sheet .body { padding: 12px 16px; overflow: auto; }
+.sheet .foot { padding: 10px 16px calc(10px + env(safe-area-inset-bottom)); border-top: 1px solid var(--line); }
+
+.card { border: 1px solid var(--line); border-radius: 12px; padding: 12px; margin: 10px 0; }
+.toast { position: fixed; left: 50%; bottom: 80px; transform: translateX(-50%);
+  background: var(--fg); color: var(--bg); padding: 10px 16px; border-radius: 999px;
+  font-size: 14px; z-index: 20; opacity: 0; transition: opacity .2s; }
+.toast.show { opacity: 1; }

--- a/collect/src/turnstile.ts
+++ b/collect/src/turnstile.ts
@@ -1,0 +1,52 @@
+// Solve a fresh invisible Turnstile token to send with create/contribute.
+// The server verifies it when TURNSTILE_SECRET is configured (prod) and skips
+// it in local dev. Returns '' if Turnstile can't load (server then decides).
+import { TURNSTILE_SITEKEY } from './config';
+
+interface TurnstileApi {
+  render: (el: HTMLElement, opts: Record<string, unknown>) => string;
+  execute: (id: string) => void;
+  remove: (id: string) => void;
+}
+declare global {
+  interface Window { turnstile?: TurnstileApi; }
+}
+
+let loading: Promise<void> | null = null;
+function load(): Promise<void> {
+  if (window.turnstile) return Promise.resolve();
+  if (loading) return loading;
+  loading = new Promise<void>((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+    s.async = true;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error('turnstile load failed'));
+    document.head.appendChild(s);
+  });
+  return loading;
+}
+
+export async function turnstileToken(): Promise<string> {
+  try {
+    await load();
+    const ts = window.turnstile!;
+    return await new Promise<string>((resolve) => {
+      const el = document.createElement('div');
+      el.style.display = 'none';
+      document.body.appendChild(el);
+      let id = '';
+      const done = (t: string) => { try { ts.remove(id); } catch { /* noop */ } el.remove(); resolve(t); };
+      id = ts.render(el, {
+        sitekey: TURNSTILE_SITEKEY,
+        size: 'invisible',
+        callback: (t: string) => done(t),
+        'error-callback': () => done(''),
+        'timeout-callback': () => done(''),
+      });
+      ts.execute(id);
+    });
+  } catch {
+    return '';
+  }
+}

--- a/collect/src/vite-env.d.ts
+++ b/collect/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/collect/tests/attribution.test.ts
+++ b/collect/tests/attribution.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { composeAttribution } from '../src/publish/attribution';
+
+describe('composeAttribution', () => {
+  it('composes the OSM-style credit line and per-name breakdown', () => {
+    const names = ['Dinesh', 'Dinesh', 'Asha', null, '', 'Dinesh'];
+    const { line, contributors } = composeAttribution('Bengaluru Footpaths', 'CC-BY-4.0', names);
+    expect(line).toBe('Bengaluru Footpaths — 2 contributors + anonymous (CC-BY-4.0)');
+    expect(contributors).toEqual([
+      { name: 'Dinesh', records: 3 },
+      { name: 'Asha', records: 1 },
+      { name: 'anonymous', records: 2 },
+    ]);
+  });
+
+  it('handles a single named contributor (singular)', () => {
+    const { line, contributors } = composeAttribution('Survey', 'CC0-1.0', ['Asha', 'Asha']);
+    expect(line).toBe('Survey — 1 contributor (CC0-1.0)');
+    expect(contributors).toEqual([{ name: 'Asha', records: 2 }]);
+  });
+
+  it('handles all-anonymous', () => {
+    const { line, contributors } = composeAttribution('Survey', 'ODbL-1.0', [null, '', '  ']);
+    expect(line).toBe('Survey — anonymous contributors (ODbL-1.0)');
+    expect(contributors).toEqual([{ name: 'anonymous', records: 3 }]);
+  });
+
+  it('sorts named contributors by record count desc, then name', () => {
+    const { contributors } = composeAttribution('S', 'CC-BY-4.0', ['B', 'A', 'A', 'C', 'C']);
+    expect(contributors.map((c) => c.name)).toEqual(['A', 'C', 'B']);
+  });
+});

--- a/collect/tests/bounds.test.ts
+++ b/collect/tests/bounds.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { checkIndiaBounds, INDIA_BBOX } from '../src/geo/bounds';
+
+// Step 1 of the record write path (spec → "POST /collections/:id/records"):
+// every coordinate must lie in the India bbox; reject the whole record on any
+// out-of-range vertex. Mirrors web/api/v1/locate's check (lat 6-38, lng 68-98).
+describe('checkIndiaBounds', () => {
+  it('accepts a point inside India (Bengaluru)', () => {
+    expect(checkIndiaBounds({ type: 'Point', coordinates: [77.7176, 12.9899] }).ok).toBe(true);
+  });
+
+  it('rejects a point outside India (lng too high)', () => {
+    const r = checkIndiaBounds({ type: 'Point', coordinates: [100.5, 12.9] });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/68-98|India/);
+  });
+
+  it('accepts a LineString fully inside', () => {
+    expect(checkIndiaBounds({ type: 'LineString', coordinates: [[77.5, 12.9], [77.6, 13.0]] }).ok).toBe(true);
+  });
+
+  it('rejects a LineString with ANY out-of-range vertex', () => {
+    expect(checkIndiaBounds({ type: 'LineString', coordinates: [[77.5, 12.9], [200, 13.0]] }).ok).toBe(false);
+  });
+
+  it('accepts a Polygon inside (walks nested rings)', () => {
+    const poly = { type: 'Polygon', coordinates: [[[77.5, 12.9], [77.6, 12.9], [77.6, 13.0], [77.5, 12.9]]] };
+    expect(checkIndiaBounds(poly).ok).toBe(true);
+  });
+
+  it('accepts a MultiPolygon inside (deeper nesting)', () => {
+    const mp = { type: 'MultiPolygon', coordinates: [[[[77.5, 12.9], [77.6, 12.9], [77.6, 13.0], [77.5, 12.9]]]] };
+    expect(checkIndiaBounds(mp).ok).toBe(true);
+  });
+
+  it('treats the bbox edges as inclusive (68,6 and 98,38)', () => {
+    expect(checkIndiaBounds({ type: 'Point', coordinates: [68, 6] }).ok).toBe(true);
+    expect(checkIndiaBounds({ type: 'Point', coordinates: [98, 38] }).ok).toBe(true);
+  });
+
+  it('rejects malformed geometry rather than passing it', () => {
+    expect(checkIndiaBounds(null).ok).toBe(false);
+    expect(checkIndiaBounds({ type: 'Point' }).ok).toBe(false);
+    expect(checkIndiaBounds({ type: 'Point', coordinates: ['a', 'b'] }).ok).toBe(false);
+    expect(checkIndiaBounds({ type: 'Weird', coordinates: [1, 2] }).ok).toBe(false);
+  });
+
+  it('exposes the India bbox as [minLng, minLat, maxLng, maxLat]', () => {
+    expect(INDIA_BBOX).toEqual([68, 6, 98, 38]);
+  });
+});

--- a/collect/tests/validate-collection.test.ts
+++ b/collect/tests/validate-collection.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { validateNewCollection, validateSchemaDoc } from '../src/schema/validate-collection';
+
+const goodSchema = {
+  version: 1,
+  geometry: ['point'],
+  fields: [
+    { key: 'name', label: 'Name', type: 'text', required: true },
+    { key: 'condition', label: 'Condition', type: 'select', options: ['Good', 'Bad'] },
+  ],
+};
+
+const goodBody = {
+  name: '  Bengaluru Footpaths  ',
+  purpose: 'Map footpath condition',
+  license: 'CC-BY-4.0',
+  schema_doc: goodSchema,
+};
+
+describe('validateNewCollection', () => {
+  it('accepts a valid collection and normalises it', () => {
+    const r = validateNewCollection(goodBody);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.name).toBe('Bengaluru Footpaths'); // trimmed
+      expect(r.value.license).toBe('CC-BY-4.0');
+      expect(JSON.parse(r.value.schema_doc).fields).toHaveLength(2);
+      expect(r.value.data_year).toBeNull();
+    }
+  });
+
+  it('rejects a bad name length', () => {
+    expect(validateNewCollection({ ...goodBody, name: 'ab' }).ok).toBe(false);
+    expect(validateNewCollection({ ...goodBody, name: 'x'.repeat(121) }).ok).toBe(false);
+  });
+
+  it('requires a purpose', () => {
+    expect(validateNewCollection({ ...goodBody, purpose: '  ' }).ok).toBe(false);
+  });
+
+  it('rejects a non-open licence', () => {
+    expect(validateNewCollection({ ...goodBody, license: 'All-Rights-Reserved' }).ok).toBe(false);
+  });
+
+  it('accepts and validates data_year', () => {
+    const r = validateNewCollection({ ...goodBody, data_year: 2026 });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.data_year).toBe(2026);
+    expect(validateNewCollection({ ...goodBody, data_year: 3000 }).ok).toBe(false);
+  });
+});
+
+describe('validateSchemaDoc (the meta-schema check)', () => {
+  it('rejects wrong version / empty or unknown geometry', () => {
+    expect(validateSchemaDoc({ ...goodSchema, version: 2 }).ok).toBe(false);
+    expect(validateSchemaDoc({ ...goodSchema, geometry: [] }).ok).toBe(false);
+    expect(validateSchemaDoc({ ...goodSchema, geometry: ['raster'] }).ok).toBe(false);
+  });
+
+  it('rejects a bad field key, duplicate key, missing label, bad type', () => {
+    expect(validateSchemaDoc({ ...goodSchema, fields: [{ key: 'Bad Key', label: 'x', type: 'text' }] }).ok).toBe(false);
+    expect(validateSchemaDoc({ ...goodSchema, fields: [
+      { key: 'a', label: 'x', type: 'text' }, { key: 'a', label: 'y', type: 'text' }] }).ok).toBe(false);
+    expect(validateSchemaDoc({ ...goodSchema, fields: [{ key: 'a', label: '', type: 'text' }] }).ok).toBe(false);
+    expect(validateSchemaDoc({ ...goodSchema, fields: [{ key: 'a', label: 'x', type: 'wysiwyg' }] }).ok).toBe(false);
+  });
+
+  it('requires options for select/multiselect', () => {
+    expect(validateSchemaDoc({ ...goodSchema, fields: [{ key: 'a', label: 'x', type: 'select' }] }).ok).toBe(false);
+    expect(validateSchemaDoc({ ...goodSchema, fields: [{ key: 'a', label: 'x', type: 'select', options: [] }] }).ok).toBe(false);
+  });
+
+  it('caps fields at 20 and reference_layers at 3', () => {
+    const many = Array.from({ length: 21 }, (_, i) => ({ key: `f${i}`, label: 'x', type: 'text' }));
+    expect(validateSchemaDoc({ ...goodSchema, fields: many }).ok).toBe(false);
+    expect(validateSchemaDoc({ ...goodSchema, reference_layers: ['a', 'b', 'c', 'd'] }).ok).toBe(false);
+  });
+});

--- a/collect/tests/validate-record.test.ts
+++ b/collect/tests/validate-record.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { validateRecordProperties, type Field } from '../src/schema/validate-record';
+
+const fields: Field[] = [
+  { key: 'name', label: 'Name', type: 'text', required: true },
+  { key: 'condition', label: 'Condition', type: 'select', options: ['Good', 'Bad'] },
+  { key: 'width', label: 'Width', type: 'number', min: 0, integer: true },
+  { key: 'services', label: 'Services', type: 'multiselect', options: ['a', 'b', 'c'] },
+  { key: 'surveyed', label: 'Surveyed', type: 'date' },
+  { key: 'ref', label: 'Ref', type: 'url' },
+  { key: 'gone', label: 'Removed', type: 'text', deleted: true },
+];
+
+describe('validateRecordProperties', () => {
+  it('accepts a valid record and returns cleaned properties', () => {
+    const r = validateRecordProperties(fields, {
+      name: 'Kaveri footpath', condition: 'Good', width: 3, services: ['a', 'b'],
+      surveyed: '2026-08-14', ref: 'https://example.org/x',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.properties).toEqual({
+      name: 'Kaveri footpath', condition: 'Good', width: 3, services: ['a', 'b'],
+      surveyed: '2026-08-14', ref: 'https://example.org/x',
+    });
+  });
+
+  it('rejects when a required field is missing or empty', () => {
+    expect(validateRecordProperties(fields, { condition: 'Good' }).ok).toBe(false);
+    expect(validateRecordProperties(fields, { name: '   ' }).ok).toBe(false);
+  });
+
+  it('rejects a select value not in options', () => {
+    expect(validateRecordProperties(fields, { name: 'x', condition: 'Ugly' }).ok).toBe(false);
+  });
+
+  it('coerces a numeric string but rejects non-numeric, and enforces integer/min', () => {
+    const ok = validateRecordProperties(fields, { name: 'x', width: '5' });
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.properties.width).toBe(5);
+    expect(validateRecordProperties(fields, { name: 'x', width: 'wide' }).ok).toBe(false);
+    expect(validateRecordProperties(fields, { name: 'x', width: 2.5 }).ok).toBe(false); // integer
+    expect(validateRecordProperties(fields, { name: 'x', width: -1 }).ok).toBe(false);  // min 0
+  });
+
+  it('rejects a multiselect value outside options', () => {
+    expect(validateRecordProperties(fields, { name: 'x', services: ['a', 'z'] }).ok).toBe(false);
+  });
+
+  it('rejects a bad date and a non-http url', () => {
+    expect(validateRecordProperties(fields, { name: 'x', surveyed: '14-08-2026' }).ok).toBe(false);
+    expect(validateRecordProperties(fields, { name: 'x', ref: 'javascript:alert(1)' }).ok).toBe(false);
+  });
+
+  it('drops unknown keys and omits soft-deleted field values', () => {
+    const r = validateRecordProperties(fields, { name: 'x', bogus: 1, gone: 'stale' });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.properties).toEqual({ name: 'x' });
+      expect('bogus' in r.properties).toBe(false);
+      expect('gone' in r.properties).toBe(false);
+    }
+  });
+
+  it('rejects non-object input', () => {
+    expect(validateRecordProperties(fields, null).ok).toBe(false);
+    expect(validateRecordProperties(fields, 'x').ok).toBe(false);
+  });
+});

--- a/collect/tsconfig.functions.json
+++ b/collect/tsconfig.functions.json
@@ -3,13 +3,13 @@
     "target": "es2022",
     "module": "es2022",
     "moduleResolution": "bundler",
-    "lib": ["es2022", "dom", "dom.iterable"],
-    "types": [],
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src", "tests"]
+  "include": ["functions"]
 }

--- a/collect/tsconfig.json
+++ b/collect/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022", "dom"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "functions", "tests"]
+}

--- a/collect/vite.config.ts
+++ b/collect/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
+
+// Two entries: the create-a-map landing (index.html) and the /c app shell
+// (c.html, served for every /c/<id>[/admin|/view] by functions/c/[[path]].ts).
+// public/ (schema/v1.json) is copied to dist/. dist/ is the Pages output.
+export default defineConfig({
+  build: {
+    target: 'es2022',
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        app: resolve(__dirname, 'c.html'),
+      },
+    },
+  },
+  // Two-process local dev: `vite` here + `wrangler pages dev` (functions/D1/R2).
+  // Vite proxies API + the app-shell routes to wrangler.
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8789',
+      '/schema': 'http://localhost:8789',
+      '^/c/.+': 'http://localhost:8789',
+    },
+  },
+});

--- a/collect/vitest.config.ts
+++ b/collect/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Phase 1 of collect.bharatlas.com: the end-to-end loop, built bottom-up and TDD-first (see supporting-docs/spec-collect.md).

## What's here
**Pure cores (TDD, 30 vitest tests):** India bounds, record schema validation, collection + meta-schema validation, attribution compose.

**API loop** over migration 0007, via a catch-all router (`functions/api/collect/[[path]].ts`), reusing web's `insertSubmission`/`insertToken`/tokens/turnstile/ip-hash unchanged:
- `POST /collections` — create → 3 links (adm/edt/viw), Turnstile, 5/day
- `POST /collections/:id/records` — bounds + geometry-type + schema validation, 200/hr, `rec_` token
- `GET /collections/:id/records` — scoped (admin sees pending; others published)
- `GET /collections/:id` — metadata + schema + counts (computed on read)
- `POST /records/:id/moderate` · `POST /collections/:id/publish` — through the submission pipeline → catalogue submission, `contributors.json`, OSM attribution line, empty-publish + R6 dup-hash guards, linked via `collection_id`/`version`

**Mobile UI** (vanilla TS + MapLibre, bundled, no CDN lib): create landing; the `/c/<id>[/admin|/view]` app — full-bleed map + fixed crosshair, in-gesture "Use my location", schema-generated bottom-sheet form; admin review queue + publish. Turnstile wired into both forms. `public/schema/v1.json` meta-schema.

**CI:** `.github/workflows/collect.yml` — separate, path-filtered build+deploy to the `collect` Pages project (deploy isolation from `ci.yml`).

## Verification
- `npm run build` in `collect/` = 30 tests + both typechecks (dom for src, workers-types for functions) + vite bundle — all clean.
- **End-to-end against a live `wrangler pages dev` sharing one local D1 with web:** create → 2 contributes → out-of-bounds + bad-select rejects → 401 no-token → GET records → publish → republish blocked ("nothing new since v1"). The published submission lands in `submissions` exactly as web reads it (linked via `collection_id`/`collection_version`), the publication + funnel rows are written, and both R2 blobs (geojson + contributors.json) are stored. This is the spec's "riskiest assumption (the bharatlas handoff)" — proven.
- Full mobile click-through pending a real device (project rule: no bare Responsive).

## Deferred to later phases (not drift)
Schema builder + PATCH schema (P2); record edit/delete/de-identify + contributors.json linkage (P3); lines/polygons + locate enrichment (P4); import/export + publications history (P5). `category` defaults to `'other'` at publish (collections carry none — spec open-question 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)