### PR TITLE
collect: schema builder, record ownership, geometry + enrichment (Phases 2-4) + a11y/security audit

### DIFF
--- a/collect/c.html
+++ b/collect/c.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/src/styles.css" />
 </head>
 <body>
-  <div id="app"></div>
+  <main id="app"></main>
   <script type="module" src="/src/app.ts"></script>
 </body>
 </html>

--- a/collect/functions/api/collect/[[path]].ts
+++ b/collect/functions/api/collect/[[path]].ts
@@ -26,6 +26,7 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
   if (segs[0] !== 'v1') return bad(404, 'not found');
   const p = segs.slice(1);
   const { env, request } = ctx;
+  const defer = (promise: Promise<unknown>): void => ctx.waitUntil(promise);
 
   // /v1/collections
   if (p.length === 1 && p[0] === 'collections') {
@@ -40,17 +41,32 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
     }
     if (p.length === 3 && p[2] === 'records') {
       if (method === 'GET') return h.listRecords(env, request, id);
-      if (method === 'POST') return h.addRecord(env, request, id);
+      if (method === 'POST') return h.addRecord(env, request, id, defer);
       return bad(405, 'method not allowed');
     }
     if (p.length === 3 && p[2] === 'publish') {
       return method === 'POST' ? h.publish(env, request, id) : bad(405, 'method not allowed');
     }
+    if (p.length === 3 && p[2] === 'tokens') {
+      return method === 'POST' ? h.mintToken(env, request, id) : bad(405, 'method not allowed');
+    }
   }
 
-  // /v1/records/:id/moderate
-  if (p[0] === 'records' && p[1] && p[2] === 'moderate' && p.length === 3) {
-    return method === 'POST' ? h.moderateRecord(env, request, p[1]) : bad(405, 'method not allowed');
+  // /v1/records/:id  and  /v1/records/:id/{moderate|deidentify}
+  if (p[0] === 'records' && p[1]) {
+    const rid = p[1];
+    if (p.length === 2) {
+      if (method === 'GET') return h.getRecordForEdit(env, request, rid);
+      if (method === 'PATCH') return h.editRecord(env, request, rid, defer);
+      if (method === 'DELETE') return h.deleteRecordHandler(env, request, rid);
+      return bad(405, 'method not allowed');
+    }
+    if (p.length === 3 && p[2] === 'moderate') {
+      return method === 'POST' ? h.moderateRecord(env, request, rid) : bad(405, 'method not allowed');
+    }
+    if (p.length === 3 && p[2] === 'deidentify') {
+      return method === 'POST' ? h.deidentifyRecordHandler(env, request, rid) : bad(405, 'method not allowed');
+    }
   }
 
   return bad(404, 'not found');

--- a/collect/functions/lib/db.ts
+++ b/collect/functions/lib/db.ts
@@ -167,6 +167,30 @@ export async function setRecordStatus(
   await db.prepare(`UPDATE records SET status = ?, rejection_reason = ? WHERE id = ?`).bind(status, reason, id).run();
 }
 
+export async function updateRecord(
+  db: DB,
+  id: string,
+  patch: { geometry?: string; properties?: string; status?: string; admin_ctx?: string | null },
+): Promise<void> {
+  const sets: string[] = [];
+  const binds: unknown[] = [];
+  if (patch.geometry !== undefined) { sets.push('geometry = ?'); binds.push(patch.geometry); }
+  if (patch.properties !== undefined) { sets.push('properties = ?'); binds.push(patch.properties); }
+  if (patch.status !== undefined) { sets.push('status = ?'); binds.push(patch.status); }
+  if (patch.admin_ctx !== undefined) { sets.push('admin_ctx = ?'); binds.push(patch.admin_ctx); }
+  if (!sets.length) return;
+  binds.push(id);
+  await db.prepare(`UPDATE records SET ${sets.join(', ')} WHERE id = ?`).bind(...binds).run();
+}
+
+export async function deleteRecord(db: DB, id: string): Promise<void> {
+  await db.prepare(`DELETE FROM records WHERE id = ?`).bind(id).run();
+}
+
+export async function deidentifyRecord(db: DB, id: string): Promise<void> {
+  await db.prepare(`UPDATE records SET contributor = NULL WHERE id = ?`).bind(id).run();
+}
+
 // ---- publications ----------------------------------------------------------
 
 export async function nextVersion(db: DB, collectionId: string): Promise<number> {

--- a/collect/functions/lib/handlers.ts
+++ b/collect/functions/lib/handlers.ts
@@ -7,7 +7,7 @@
 
 import type { Env } from '../types';
 import { bad, json } from './http';
-import { generateToken, tokenPrefix, hashToken, generateRecordToken } from './tokens';
+import { generateToken, tokenPrefix, hashToken, generateRecordToken, verifyToken } from './tokens';
 import { bearer, permissionFor, atLeast } from './auth';
 import { checkCreateRate, checkRecordRate } from './ratelimit';
 import { logCollectAttempt } from './collect-log';
@@ -16,11 +16,42 @@ import * as db from './db';
 import { validateNewCollection } from '../../src/schema/validate-collection';
 import { validateRecordProperties, type Field } from '../../src/schema/validate-record';
 import { checkIndiaBounds } from '../../src/geo/bounds';
+import { distillAdminCtx, mergeAdminCtx, representativeCoord } from '../../src/geo/admin-ctx';
 import { composeAttribution } from '../../src/publish/attribution';
 
 const BHARATLAS_ORIGIN = 'https://bharatlas.com';
 
 const salt = (env: Env) => env.IP_SALT || 'collect-v1';
+
+// Locate enrichment (Phase 4). Best-effort: ask bharatlas /api/v1/locate for the
+// admin context at a record's representative vertex. Any error (network, timeout,
+// bad shape) resolves to null. Callers run this OFF the write path (via
+// waitUntil) so a slow locate never delays the contributor's "Add".
+async function enrich(env: Env, geometry: unknown): Promise<string | null> {
+  const c = representativeCoord(geometry);
+  if (!c) return null;
+  const origin = env.LOCATE_ORIGIN || BHARATLAS_ORIGIN;
+  try {
+    const res = await fetch(`${origin}/api/v1/locate?lat=${c[1]}&lng=${c[0]}`, {
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { results?: unknown };
+    const ctx = distillAdminCtx(data?.results);
+    return ctx ? JSON.stringify(ctx) : null;
+  } catch {
+    return null;
+  }
+}
+
+// Enrich a stored record's admin_ctx out of band. Only overwrites on a
+// successful locate — a transient failure never clears an existing context.
+async function enrichRecord(env: Env, recordId: string, geometry: unknown): Promise<void> {
+  const ctx = await enrich(env, geometry);
+  if (ctx) await db.updateRecord(env.DB, recordId, { admin_ctx: ctx });
+}
+
+type Defer = (p: Promise<unknown>) => void;
 
 // Turnstile: verify when a secret is configured (prod); skip in local dev.
 async function turnstileOk(env: Env, token: unknown): Promise<boolean> {
@@ -115,6 +146,32 @@ export async function getCollectionMeta(env: Env, req: Request, id: string): Pro
   });
 }
 
+// ---- POST /collections/:id/tokens ------------------------------------------
+// Mint a fresh edit or view link (admin only). The originals are hash-only and
+// can't be re-shown, so "share another collect link" = mint a new one.
+
+export async function mintToken(env: Env, req: Request, id: string): Promise<Response> {
+  const perm = await permissionFor(env.DB, id, bearer(req));
+  if (!atLeast(perm, 'admin')) return bad(401, 'unauthorised');
+  const c = await db.getCollection(env.DB, id);
+  if (!c) return bad(404, 'not found');
+
+  const body = await readJson(req);
+  const want = body?.permission;
+  if (want !== 'edit' && want !== 'view') return bad(400, 'permission must be edit or view');
+
+  const token = generateToken(want);
+  await db.addCollectionToken(env.DB, {
+    collectionId: id,
+    prefix: tokenPrefix(token),
+    hash: await hashToken(token),
+    permission: want,
+  });
+  const origin = new URL(req.url).origin;
+  const link = want === 'edit' ? `${origin}/c/${id}#${token}` : `${origin}/c/${id}/view#${token}`;
+  return json(200, { permission: want, token, link });
+}
+
 // ---- GET /collections/:id/records ------------------------------------------
 
 export async function listRecords(env: Env, req: Request, id: string): Promise<Response> {
@@ -141,6 +198,7 @@ export async function listRecords(env: Env, req: Request, id: string): Promise<R
       _status: r.status,
       _contributor: r.contributor,
       _created_at: r.created_at,
+      _admin_ctx: r.admin_ctx ? JSON.parse(r.admin_ctx) : null,
     },
   }));
   return json(200, { type: 'FeatureCollection', features });
@@ -148,7 +206,7 @@ export async function listRecords(env: Env, req: Request, id: string): Promise<R
 
 // ---- POST /collections/:id/records -----------------------------------------
 
-export async function addRecord(env: Env, req: Request, id: string): Promise<Response> {
+export async function addRecord(env: Env, req: Request, id: string, defer?: Defer): Promise<Response> {
   const ipHash = await ipHashFor(req, salt(env));
   const perm = await permissionFor(env.DB, id, bearer(req));
   if (!atLeast(perm, 'edit')) return bad(401, 'unauthorised — need the edit or admin link');
@@ -199,12 +257,15 @@ export async function addRecord(env: Env, req: Request, id: string): Promise<Res
     status,
     geometry: JSON.stringify(geometry),
     properties: JSON.stringify(validated.properties),
-    admin_ctx: null, // enrichment is Phase 4
+    admin_ctx: null, // filled out of band below (never blocks the write)
     contributor,
     edit_token_hash: await hashToken(recToken),
     ip_hash: ipHash,
   });
   await db.touchCollection(env.DB, id);
+
+  const task = enrichRecord(env, recId, geometry).catch(() => {});
+  if (defer) defer(task); else await task;
 
   void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'ok', collection_id: id, ip_hash: ipHash });
   return json(200, { id: recId, status, edit_token: recToken });
@@ -228,6 +289,95 @@ export async function moderateRecord(env: Env, req: Request, recordId: string): 
   return json(200, { id: recordId, status });
 }
 
+// ---- record-owner ops (rec_ token or admin): get / edit / delete / de-identify
+
+async function recordAuth(
+  env: Env,
+  req: Request,
+  recordId: string,
+): Promise<{ record: db.RecordRow; isAdmin: boolean } | null> {
+  const record = await db.getRecord(env.DB, recordId);
+  if (!record) return null;
+  const token = bearer(req);
+  if (!token) return null;
+  const perm = await permissionFor(env.DB, record.collection_id, token);
+  if (atLeast(perm, 'admin')) return { record, isAdmin: true };
+  if (record.edit_token_hash && (await verifyToken(token, record.edit_token_hash))) {
+    return { record, isAdmin: false };
+  }
+  return null;
+}
+
+export async function getRecordForEdit(env: Env, req: Request, recordId: string): Promise<Response> {
+  const auth = await recordAuth(env, req, recordId);
+  if (!auth) return bad(401, 'unauthorised');
+  const c = await db.getCollection(env.DB, auth.record.collection_id);
+  if (!c) return bad(404, 'not found');
+  const r = auth.record;
+  return json(200, {
+    id: r.id,
+    status: r.status,
+    contributor: r.contributor,
+    geometry: JSON.parse(r.geometry),
+    properties: JSON.parse(r.properties),
+    schema: JSON.parse(c.schema_doc),
+    collection_name: c.name,
+  });
+}
+
+export async function editRecord(env: Env, req: Request, recordId: string, defer?: Defer): Promise<Response> {
+  const auth = await recordAuth(env, req, recordId);
+  if (!auth) return bad(401, 'unauthorised');
+  const c = await db.getCollection(env.DB, auth.record.collection_id);
+  if (!c) return bad(404, 'not found');
+  const body = await readJson(req);
+  if (!body) return bad(400, 'invalid JSON body');
+
+  const schema = JSON.parse(c.schema_doc) as { geometry: string[]; fields: Field[] };
+  const patch: { geometry?: string; properties?: string; status?: string } = {};
+  let movedGeometry: unknown;
+
+  if (body.geometry !== undefined) {
+    const bounds = checkIndiaBounds(body.geometry);
+    if (!bounds.ok) return bad(400, bounds.error);
+    const bucket = geomBucket((body.geometry as { type: string }).type);
+    if (!bucket || !schema.geometry.includes(bucket)) {
+      return bad(400, `this collection accepts ${schema.geometry.join(', ')} geometry`);
+    }
+    patch.geometry = JSON.stringify(body.geometry);
+    movedGeometry = body.geometry;
+  }
+  if (body.properties !== undefined) {
+    const v = validateRecordProperties(schema.fields, body.properties);
+    if (!v.ok) return bad(400, v.error);
+    patch.properties = JSON.stringify(v.properties);
+  }
+  // R3: a contributor edit goes back to pending for re-review (when moderated).
+  if (!auth.isAdmin && c.moderation) patch.status = 'pending';
+  await db.updateRecord(env.DB, recordId, patch);
+
+  // Re-enrich a moved shape out of band — only overwrites admin_ctx on success.
+  if (movedGeometry !== undefined) {
+    const task = enrichRecord(env, recordId, movedGeometry).catch(() => {});
+    if (defer) defer(task); else await task;
+  }
+  return json(200, { id: recordId, status: patch.status ?? auth.record.status });
+}
+
+export async function deleteRecordHandler(env: Env, req: Request, recordId: string): Promise<Response> {
+  const auth = await recordAuth(env, req, recordId);
+  if (!auth) return bad(401, 'unauthorised');
+  await db.deleteRecord(env.DB, recordId);
+  return json(200, { id: recordId, deleted: true });
+}
+
+export async function deidentifyRecordHandler(env: Env, req: Request, recordId: string): Promise<Response> {
+  const auth = await recordAuth(env, req, recordId);
+  if (!auth) return bad(401, 'unauthorised');
+  await db.deidentifyRecord(env.DB, recordId);
+  return json(200, { id: recordId, contributor: null });
+}
+
 // ---- POST /collections/:id/publish -----------------------------------------
 
 export async function publish(env: Env, req: Request, id: string): Promise<Response> {
@@ -243,10 +393,13 @@ export async function publish(env: Env, req: Request, id: string): Promise<Respo
     return bad(409, 'nothing approved to publish yet');
   }
 
+  // Flatten locate enrichment into the published properties (state, district…),
+  // so the catalogue layer is filterable by admin area. Author fields win on any
+  // key collision; enrichment only fills keys the author did not define.
   const features = rows.map((r) => ({
     type: 'Feature' as const,
     geometry: JSON.parse(r.geometry),
-    properties: JSON.parse(r.properties),
+    properties: mergeAdminCtx(JSON.parse(r.properties), r.admin_ctx),
   }));
   const fc = { type: 'FeatureCollection', features };
   const bytes = new TextEncoder().encode(JSON.stringify(fc));
@@ -263,7 +416,7 @@ export async function publish(env: Env, req: Request, id: string): Promise<Respo
   }
 
   const attribution = composeAttribution(c.name, c.license, rows.map((r) => r.contributor));
-  const geomTypes = [...new Set(rows.map((r) => (JSON.parse(r.geometry) as { type: string }).type))].join(',');
+  const geomTypes = [...new Set(features.map((f) => (f.geometry as { type: string }).type))].join(',');
 
   const submissionId = nanoid(10);
   const r2Key = `community/${submissionId}/${submissionId}.geojson`;

--- a/collect/functions/types.ts
+++ b/collect/functions/types.ts
@@ -7,4 +7,7 @@ export interface Env {
   TURNSTILE_SECRET?: string;
   PUBLIC_TURNSTILE_SITEKEY?: string;
   IP_SALT?: string;
+  // Origin for locate enrichment (defaults to https://bharatlas.com); override
+  // in tests to point at a stub. Phase 4.
+  LOCATE_ORIGIN?: string;
 }

--- a/collect/index.html
+++ b/collect/index.html
@@ -4,11 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="robots" content="noindex" />
+  <meta name="description" content="Design a small map form, share a link, and collect points together, then publish to the bharatlas open atlas. No accounts." />
   <title>collect · bharatlas</title>
   <link rel="stylesheet" href="/src/styles.css" />
 </head>
 <body>
-  <div id="app"></div>
+  <main id="app"></main>
   <script type="module" src="/src/landing.ts"></script>
 </body>
 </html>

--- a/collect/public/_headers
+++ b/collect/public/_headers
@@ -1,0 +1,11 @@
+# Cloudflare Pages security headers for collect. CSP allows exactly what the app
+# needs: self, Turnstile (challenges.cloudflare.com), and CARTO raster tiles.
+# noindex keeps unlisted collections off search (spec). Verify in prod after
+# the first deploy — a too-strict CSP would break the map or Turnstile.
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Frame-Options: DENY
+  X-Robots-Tag: noindex
+  Permissions-Policy: geolocation=(self), camera=()
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.basemaps.cartocdn.com; connect-src 'self' https://*.basemaps.cartocdn.com https://challenges.cloudflare.com; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com; form-action 'self'

--- a/collect/public/robots.txt
+++ b/collect/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/collect/public/schema/v1.json
+++ b/collect/public/schema/v1.json
@@ -28,6 +28,7 @@
           "label": { "type": "string", "minLength": 1 },
           "type": { "enum": ["text", "paragraph", "number", "select", "multiselect", "date", "url"] },
           "required": { "type": "boolean" },
+          "hint": { "type": "string" },
           "options": { "type": "array", "items": { "type": "string" } },
           "min": { "type": "number" },
           "max": { "type": "number" },

--- a/collect/src/api.ts
+++ b/collect/src/api.ts
@@ -1,18 +1,21 @@
 // Client-side helpers: parse the collection id + mode + token from the URL
 // (token rides the fragment, never sent in a request line), and call the API.
 
-export type Mode = 'capture' | 'admin' | 'view';
+export type Mode = 'capture' | 'admin' | 'view' | 'record';
 
 export interface Ctx {
   id: string;
   mode: Mode;
   token: string;
+  recordId?: string;
 }
 
 export function parseCtx(): Ctx | null {
+  const token = location.hash.replace(/^#/, '');
+  const rec = location.pathname.match(/^\/c\/([A-Za-z0-9_-]{6,})\/r\/([A-Za-z0-9_-]{6,})\/?$/);
+  if (rec) return { id: rec[1], mode: 'record', token, recordId: rec[2] };
   const m = location.pathname.match(/^\/c\/([A-Za-z0-9_-]{6,})(?:\/(admin|view))?\/?$/);
   if (!m) return null;
-  const token = location.hash.replace(/^#/, '');
   let mode: Mode = 'capture';
   if (m[2] === 'admin' || token.startsWith('adm_')) mode = 'admin';
   else if (m[2] === 'view' || token.startsWith('viw_')) mode = 'view';

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -7,10 +7,10 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { BASEMAP, INDIA_CENTER } from './basemap';
 import { parseCtx, apiJson, type Ctx } from './api';
 import { turnstileToken } from './turnstile';
-
-interface Field {
-  key: string; label: string; type: string; required?: boolean; options?: string[]; deleted?: boolean;
-}
+import { validateRecordProperties, type Field } from './schema/validate-record';
+import { orderedModes, drawGeometry, type GeomMode, type Coord } from './geo/draw';
+import { representativeCoord } from './geo/admin-ctx';
+import { escapeHtml } from './util';
 interface Counts { pending: number; published: number; total: number; rejected: number; }
 interface Meta {
   id: string; name: string; purpose: string; status: string; moderation: number;
@@ -23,16 +23,50 @@ let map: maplibregl.Map;
 let meta: Meta;
 let ctx: Ctx;
 
+// Draw state (Phase 4). Points use the map centre; lines/polygons collect
+// vertices by panning the crosshair and tapping "+ vertex".
+const ACCENT = '#4f46e5';
+let drawMode: GeomMode = 'point';
+let verts: Coord[] = [];
+let drawReady = false;
+let allowsShapes = false; // collection declares line/polygon → draw layers are worth adding
+
+const emptyFC = (): GeoJSON.FeatureCollection => ({ type: 'FeatureCollection', features: [] });
+
+// Add the in-progress draw source + layers once the style is up (only needed
+// for line/polygon collections — points-only stays light).
+function setupDrawLayers(): void {
+  if (drawReady || !allowsShapes || !map.isStyleLoaded()) return;
+  map.addSource('draw', { type: 'geojson', data: emptyFC() });
+  map.addLayer({ id: 'draw-fill', type: 'fill', source: 'draw', filter: ['==', '$type', 'Polygon'], paint: { 'fill-color': ACCENT, 'fill-opacity': 0.15 } });
+  map.addLayer({ id: 'draw-line', type: 'line', source: 'draw', filter: ['!=', '$type', 'Point'], paint: { 'line-color': ACCENT, 'line-width': 2.5 } });
+  map.addLayer({ id: 'draw-vert', type: 'circle', source: 'draw', filter: ['==', '$type', 'Point'], paint: { 'circle-radius': 5, 'circle-color': '#fff', 'circle-stroke-color': ACCENT, 'circle-stroke-width': 2 } });
+  drawReady = true;
+}
+
+function redrawDraw(): void {
+  if (!drawReady) { setupDrawLayers(); if (!drawReady) return; }
+  const features: GeoJSON.Feature[] = verts.map((v) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: v }, properties: {} }));
+  if (drawMode === 'polygon' && verts.length >= 3) {
+    features.push({ type: 'Feature', geometry: { type: 'Polygon', coordinates: [[...verts, verts[0]]] }, properties: {} });
+  } else if (verts.length >= 2) {
+    features.push({ type: 'Feature', geometry: { type: 'LineString', coordinates: verts }, properties: {} });
+  }
+  (map.getSource('draw') as maplibregl.GeoJSONSource | undefined)?.setData({ type: 'FeatureCollection', features });
+}
+
 function toast(msg: string): void {
   const t = document.createElement('div');
   t.className = 'toast';
+  t.setAttribute('role', 'status');
+  t.setAttribute('aria-live', 'polite');
   t.textContent = msg;
   document.body.appendChild(t);
   requestAnimationFrame(() => t.classList.add('show'));
   setTimeout(() => { t.classList.remove('show'); setTimeout(() => t.remove(), 300); }, 2400);
 }
 
-function marker(coords: number[], color = '#1a7f5a'): void {
+function marker(coords: number[], color = ACCENT): void {
   if (coords.length >= 2) new maplibregl.Marker({ color }).setLngLat([coords[0], coords[1]]).addTo(map);
 }
 
@@ -44,23 +78,32 @@ async function boot(): Promise<void> {
 
   app.innerHTML = `
     <div class="topbar">
-      <a href="/">←</a><span>${meta.name}</span>
+      <a href="/" aria-label="Back to start">←</a><span>${escapeHtml(meta.name)}</span>
       <span class="muted" style="margin-left:auto">${isAdmin ? 'admin' : isView ? 'view' : ''}</span>
     </div>
     <div class="map">
       <div id="map"></div>
-      <div class="crosshair" ${isView ? 'style="display:none"' : ''}></div>
-      ${isView ? '' : '<button class="locate" id="locate" title="Use my location">◎</button>'}
-      ${isAdmin ? '<button class="locate" id="manage" style="left:12px;right:auto;bottom:76px">⚙</button>' : ''}
+      <div class="crosshair" aria-hidden="true" ${isView ? 'style="display:none"' : ''}></div>
+      <div class="map-loading" id="maploading"><span class="spinner"></span> Loading map…</div>
+      ${isView ? '' : '<button class="locate" id="locate" aria-label="Use my location">◎</button>'}
+      ${isAdmin ? `<button class="locate" id="manage" aria-label="Manage map${meta.counts.pending ? `, ${meta.counts.pending} pending review` : ''}" style="left:12px;right:auto;bottom:76px;width:auto;padding:0 14px">⚙${meta.counts.pending ? ` ${meta.counts.pending}` : ''}</button>` : ''}
     </div>
     <div id="panel"></div>`;
 
   map = new maplibregl.Map({
     container: 'map', style: BASEMAP, center: INDIA_CENTER, zoom: 4,
-    attributionControl: { compact: true },
+    attributionControl: false,
   });
+  // Attribution bottom-left so it never sits under the locate button (bottom-right).
+  map.addControl(new maplibregl.AttributionControl({ compact: true }), 'bottom-left');
   map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
-  map.on('load', loadRecords);
+  drawReady = false; verts = [];
+  allowsShapes = orderedModes(meta.schema.geometry).some((m) => m !== 'point');
+  map.on('load', () => {
+    document.getElementById('maploading')?.remove();
+    if (!isView && allowsShapes) setupDrawLayers();
+    void loadRecords();
+  });
 
   if (!isView) {
     const locate = document.getElementById('locate') as HTMLButtonElement;
@@ -77,74 +120,173 @@ async function boot(): Promise<void> {
   if (isAdmin) {
     (document.getElementById('manage') as HTMLButtonElement).onclick = manageSheet;
   }
+  if (isView) viewPanel();
+}
+
+function viewPanel(): void {
+  const panel = document.getElementById('panel')!;
+  const n = meta.counts.published;
+  panel.innerHTML = `<div class="sheet"><div class="body">
+    <strong>${escapeHtml(meta.name)}</strong>
+    ${meta.purpose ? `<p class="hint">${escapeHtml(meta.purpose)}</p>` : ''}
+    <p class="hint">${n ? `${n} point${n === 1 ? '' : 's'} on the map.` : 'No points published yet.'}</p>
+  </div></div>`;
+}
+
+let recordShapes: GeoJSON.Feature[] = [];
+
+// The non-point records overlay: one accumulating source for existing +
+// just-added lines/polygons. Points are plain markers.
+function syncRecordShapes(): void {
+  if (!map.isStyleLoaded()) return;
+  const data = { type: 'FeatureCollection', features: recordShapes } as GeoJSON.FeatureCollection;
+  const src = map.getSource('records') as maplibregl.GeoJSONSource | undefined;
+  if (src) { src.setData(data); return; }
+  map.addSource('records', { type: 'geojson', data });
+  map.addLayer({ id: 'records-fill', type: 'fill', source: 'records', filter: ['==', '$type', 'Polygon'], paint: { 'fill-color': ACCENT, 'fill-opacity': 0.1 } });
+  map.addLayer({ id: 'records-line', type: 'line', source: 'records', filter: ['!=', '$type', 'Point'], paint: { 'line-color': ACCENT, 'line-width': 2, 'line-opacity': 0.7 } });
+}
+
+function addRecordShape(geometry: GeoJSON.Geometry): void {
+  recordShapes.push({ type: 'Feature', geometry, properties: {} });
+  syncRecordShapes();
 }
 
 async function loadRecords(): Promise<void> {
   try {
-    const fc = await apiJson<{ features: Feature[] }>(`/collections/${ctx.id}/records`, ctx.token);
-    for (const f of fc.features || []) if (f.geometry?.type === 'Point') marker(f.geometry.coordinates);
+    // Published-only on the capture map (admin's un-moderated pins live in the queue).
+    const fc = await apiJson<{ features: Feature[] }>(`/collections/${ctx.id}/records?status=published`, ctx.token);
+    recordShapes = [];
+    for (const f of fc.features || []) {
+      if (f.geometry?.type === 'Point') marker(f.geometry.coordinates);
+      else if (f.geometry) recordShapes.push({ type: 'Feature', geometry: f.geometry as GeoJSON.Geometry, properties: {} });
+    }
+    if (recordShapes.length) syncRecordShapes();
   } catch { /* map still usable */ }
 }
 
 function fieldInput(f: Field): string {
+  const req = f.required ? ' required' : '';
+  const ml = f.maxLength ? ` maxlength="${f.maxLength}"` : '';
   switch (f.type) {
-    case 'paragraph': return `<textarea data-k="${f.key}"></textarea>`;
-    case 'number': return `<input data-k="${f.key}" inputmode="decimal" />`;
-    case 'date': return `<input data-k="${f.key}" type="date" />`;
-    case 'url': return `<input data-k="${f.key}" inputmode="url" placeholder="https://" />`;
+    case 'paragraph': return `<textarea data-k="${f.key}"${req}${ml}></textarea>`;
+    case 'number': return `<input data-k="${f.key}" inputmode="${f.integer ? 'numeric' : 'decimal'}"${f.min != null ? ` min="${f.min}"` : ''}${f.max != null ? ` max="${f.max}"` : ''} step="${f.integer ? '1' : 'any'}"${req} />`;
+    case 'date': return `<input data-k="${f.key}" type="date"${req} />`;
+    case 'url': return `<input data-k="${f.key}" type="url"${req} placeholder="https://" />`;
     case 'select':
-      return `<select data-k="${f.key}"><option value=""></option>${(f.options || []).map((o) => `<option>${o}</option>`).join('')}</select>`;
+      return `<select data-k="${f.key}"${req}><option value=""></option>${(f.options || []).map((o) => `<option>${escapeHtml(o)}</option>`).join('')}</select>`;
     case 'multiselect':
-      return `<div class="row" data-k="${f.key}" data-multi>${(f.options || []).map((o) => `<button type="button" class="chip" data-v="${o}">${o}</button>`).join('')}</div>`;
-    default: return `<input data-k="${f.key}" />`;
+      return `<div class="row" data-k="${f.key}" data-multi>${(f.options || []).map((o) => `<button type="button" class="chip" data-v="${escapeHtml(o)}">${escapeHtml(o)}</button>`).join('')}</div>`;
+    default: return `<input data-k="${f.key}"${req}${ml} />`;
   }
 }
 
+const NOUN: Record<GeomMode, string> = { point: 'point', line: 'line', polygon: 'area' };
+function nounFor(geometryType: string): string {
+  if (geometryType === 'Polygon' || geometryType === 'MultiPolygon') return NOUN.polygon;
+  if (geometryType === 'LineString' || geometryType === 'MultiLineString') return NOUN.line;
+  return NOUN.point;
+}
+const CAP_HELP: Record<GeomMode, string> = {
+  point: 'Move the map so the crosshair sits on the spot.',
+  line: 'Pan so the crosshair is on each point, then tap + vertex. Need 2 or more.',
+  polygon: 'Pan the crosshair to each corner, then tap + vertex. Need 3 or more.',
+};
+
 function captureSheet(): void {
   const fields = meta.schema.fields.filter((f) => !f.deleted);
+  const modes = orderedModes(meta.schema.geometry);
+  drawMode = modes[0];
+  verts = [];
+  redrawDraw();
   const panel = document.getElementById('panel')!;
+  const seg = modes.length > 1
+    ? `<div class="seg" id="modesw">${modes.map((m) => `<button type="button" data-m="${m}"${m === drawMode ? ' class="on"' : ''}>${NOUN[m][0].toUpperCase()}${NOUN[m].slice(1)}</button>`).join('')}</div>`
+    : '';
   panel.innerHTML = `<div class="sheet">
-    <div class="body">
-      <strong>Add a point</strong>
-      <p class="hint">Move the map so the crosshair sits on the spot.</p>
-      ${fields.map((f) => `<label>${f.label}${f.required ? ' *' : ''}</label>${fieldInput(f)}`).join('')}
-      <label>Your name <span class="hint">(optional — published with the data)</span></label>
+    <form class="body" id="capform">
+      <strong>Add a <span id="cap-noun">${NOUN[drawMode]}</span></strong>
+      ${seg}
+      <p class="hint" id="cap-help">${CAP_HELP[drawMode]}</p>
+      <div class="row" id="drawctl" style="display:none;align-items:center">
+        <button type="button" id="vadd">+ vertex</button>
+        <button type="button" id="vundo">Undo</button>
+        <span class="hint" id="vcount"></span>
+      </div>
+      ${fields.map((f) => `<label>${escapeHtml(f.label)}${f.required ? ' *' : ''}</label>${f.hint ? `<p class="hint" style="margin:-2px 0 4px">${escapeHtml(f.hint)}</p>` : ''}${fieldInput(f)}`).join('')}
+      <label>Your name <span class="hint">(optional, published with the data)</span></label>
       <input id="contributor" />
-    </div>
-    <div class="foot"><button class="primary" id="add">Add point</button></div>
+    </form>
+    <div class="foot"><button class="primary" id="add">Add ${NOUN[drawMode]}</button></div>
+    <div id="lastadded" class="hint" style="padding:0 16px 10px"></div>
   </div>`;
   panel.querySelectorAll<HTMLElement>('[data-multi] .chip').forEach((c) => { c.onclick = () => c.classList.toggle('on'); });
 
+  const syncDrawUI = (): void => {
+    document.getElementById('cap-noun')!.textContent = NOUN[drawMode];
+    document.getElementById('cap-help')!.textContent = CAP_HELP[drawMode];
+    (document.getElementById('add') as HTMLButtonElement).textContent = `Add ${NOUN[drawMode]}`;
+    document.getElementById('drawctl')!.style.display = drawMode === 'point' ? 'none' : 'flex';
+    document.getElementById('vcount')!.textContent = `${verts.length} point${verts.length === 1 ? '' : 's'}`;
+    document.querySelectorAll('#modesw button').forEach((b) => b.classList.toggle('on', (b as HTMLElement).dataset.m === drawMode));
+  };
+  syncDrawUI();
+
+  document.querySelectorAll<HTMLButtonElement>('#modesw button').forEach((b) => {
+    b.onclick = () => { drawMode = b.dataset.m as GeomMode; verts = []; redrawDraw(); syncDrawUI(); };
+  });
+  (document.getElementById('vadd') as HTMLButtonElement).onclick = () => {
+    const c = map.getCenter(); verts.push([c.lng, c.lat]); redrawDraw(); syncDrawUI();
+  };
+  (document.getElementById('vundo') as HTMLButtonElement).onclick = () => {
+    verts.pop(); redrawDraw(); syncDrawUI();
+  };
+
   (document.getElementById('add') as HTMLButtonElement).onclick = async (ev) => {
     const btn = ev.currentTarget as HTMLButtonElement;
+    const form = document.getElementById('capform') as HTMLFormElement;
+    if (!form.reportValidity()) return; // native: required, URL format, number min/max
+    const c = map.getCenter();
+    const geometry = drawGeometry(drawMode, verts, [c.lng, c.lat]);
+    if (!geometry) { toast(`A ${NOUN[drawMode]} needs ${drawMode === 'line' ? '2' : '3'} points or more`); return; }
     btn.disabled = true;
     try {
-      const props: Record<string, unknown> = {};
+      const raw: Record<string, unknown> = {};
       for (const f of fields) {
         const el = panel.querySelector(`[data-k="${f.key}"]`);
         if (!el) continue;
         if (f.type === 'multiselect') {
-          const on = [...el.querySelectorAll('.chip.on')].map((c) => (c as HTMLElement).dataset.v);
-          if (on.length) props[f.key] = on;
-        } else if (f.type === 'number') {
-          const v = (el as HTMLInputElement).value; if (v) props[f.key] = Number(v);
+          const on = [...el.querySelectorAll('.chip.on')].map((c2) => (c2 as HTMLElement).dataset.v);
+          if (on.length) raw[f.key] = on;
         } else {
-          const v = (el as HTMLInputElement).value; if (v) props[f.key] = v;
+          const val = (el as HTMLInputElement).value;
+          if (val) raw[f.key] = val;
         }
       }
-      const c = map.getCenter();
+      // Same validator the server uses — immediate feedback, no wasted round-trip.
+      const valid = validateRecordProperties(fields, raw);
+      if (!valid.ok) { toast(valid.error); btn.disabled = false; return; }
       const contributor = (document.getElementById('contributor') as HTMLInputElement).value;
       const turnstile_token = await turnstileToken();
-      await apiJson(`/collections/${ctx.id}/records`, ctx.token, {
+      const res = await apiJson<{ id: string; edit_token: string }>(`/collections/${ctx.id}/records`, ctx.token, {
         method: 'POST',
-        body: JSON.stringify({ geometry: { type: 'Point', coordinates: [c.lng, c.lat] }, properties: props, contributor, turnstile_token }),
+        body: JSON.stringify({ geometry, properties: valid.properties, contributor, turnstile_token }),
       });
-      marker([c.lng, c.lat]);
-      toast(meta.moderation ? 'Added — pending review ✓' : 'Added ✓');
-      panel.querySelectorAll('input,textarea,select').forEach((el) => { (el as HTMLInputElement).value = ''; });
-      panel.querySelectorAll('.chip.on').forEach((c) => c.classList.remove('on'));
+      if (geometry.type === 'Point') marker(geometry.coordinates);
+      else addRecordShape(geometry);
+      verts = []; redrawDraw(); syncDrawUI();
+      toast(meta.moderation ? `Added, pending review ✓` : 'Added ✓');
+      const editUrl = `${location.origin}/c/${ctx.id}/r/${res.id}#${res.edit_token}`;
+      const la = document.getElementById('lastadded');
+      if (la) la.innerHTML = `✓ Added. <a href="${editUrl}">edit this ${NOUN[drawMode]}</a>`;
+      // Keep #contributor — one surveyor adds many points and shouldn't re-type their name.
+      panel.querySelectorAll('input:not(#contributor),textarea,select').forEach((el) => { (el as HTMLInputElement).value = ''; });
+      panel.querySelectorAll('.chip.on').forEach((c2) => c2.classList.remove('on'));
+      btn.textContent = `Add ${NOUN[drawMode]}`;
     } catch (e) {
-      toast((e as Error).message);
+      // Field resilience (spec): keep the entry on failure, offer a retry.
+      toast(`Couldn't save: ${(e as Error).message}. Your entry is kept, tap Retry.`);
+      btn.textContent = 'Retry';
     }
     btn.disabled = false;
   };
@@ -159,15 +301,60 @@ async function manageSheet(): Promise<void> {
       <strong>Manage map</strong>
       <p class="hint">${counts.published} approved · ${counts.pending} pending · ${counts.total} total</p>
       <div id="queue"><p class="hint">Loading pending…</p></div>
+      <strong style="display:block;margin-top:14px">Share links</strong>
+      <p class="hint">Mint a fresh link to share. The original links can't be shown again.</p>
+      <div class="row">
+        <button id="mint-edit">+ Collect link</button>
+        <button id="mint-view">+ View-only link</button>
+      </div>
+      <div id="minted"></div>
     </div>
     <div class="foot row">
       <button id="back">← Capture</button>
-      <button class="primary" id="publish" style="flex:1">Publish v${'?'} → atlas</button>
+      <button class="primary" id="publish" style="flex:1">Publish → atlas</button>
     </div>
   </div>`;
   (document.getElementById('back') as HTMLButtonElement).onclick = captureSheet;
   (document.getElementById('publish') as HTMLButtonElement).onclick = doPublish;
+
+  const mint = async (permission: 'edit' | 'view') => {
+    try {
+      const res = await apiJson<{ link: string }>(`/collections/${ctx.id}/tokens`, ctx.token, {
+        method: 'POST', body: JSON.stringify({ permission }),
+      });
+      const box = document.getElementById('minted')!;
+      const row = document.createElement('div');
+      row.className = 'link-box';
+      row.innerHTML = `<code>${res.link}</code><button>Copy</button>`;
+      const btn = row.querySelector('button')!;
+      btn.onclick = () => { navigator.clipboard?.writeText(res.link); btn.textContent = '✓'; };
+      box.prepend(row);
+    } catch (e) {
+      toast((e as Error).message);
+    }
+  };
+  (document.getElementById('mint-edit') as HTMLButtonElement).onclick = () => mint('edit');
+  (document.getElementById('mint-view') as HTMLButtonElement).onclick = () => mint('view');
+
   renderQueue();
+}
+
+type AdminCtx = { state?: string; district?: string; subdistrict?: string } | null;
+function fmtAdminCtx(ctx: AdminCtx): string {
+  if (!ctx) return '';
+  const parts = [ctx.district, ctx.state].filter(Boolean);
+  return parts.length ? ` · 📍 ${parts.join(', ')}` : '';
+}
+
+// Queue card label: the record's `name`, else the first author field value
+// (the author may have renamed/removed the seeded `name` field).
+function cardTitle(props: Record<string, unknown>): string {
+  const named = props.name;
+  if (typeof named === 'string' && named.trim()) return named;
+  for (const [k, v] of Object.entries(props)) {
+    if (!k.startsWith('_') && typeof v === 'string' && v.trim()) return v;
+  }
+  return '(no name)';
 }
 
 async function renderQueue(): Promise<void> {
@@ -178,8 +365,8 @@ async function renderQueue(): Promise<void> {
     const feats = fc.features || [];
     if (!feats.length) { q.innerHTML = '<p class="hint">Nothing pending.</p>'; return; }
     q.innerHTML = feats.map((f) => `<div class="card" data-id="${f.id}">
-        <div>${String((f.properties as { name?: string }).name ?? '(no name)')}</div>
-        <div class="hint">${(f.properties as { _contributor?: string })._contributor || 'anonymous'}</div>
+        <div>${escapeHtml(cardTitle(f.properties))}</div>
+        <div class="hint">${escapeHtml((f.properties as { _contributor?: string })._contributor || 'anonymous')}${fmtAdminCtx((f.properties as { _admin_ctx?: AdminCtx })._admin_ctx ?? null)}</div>
         <div class="row" style="margin-top:8px">
           <button data-act="rejected" style="flex:1">✗ Reject</button>
           <button class="primary" data-act="published" style="flex:1">✓ Approve</button>
@@ -221,10 +408,134 @@ async function doPublish(ev: Event): Promise<void> {
   }
 }
 
-if (!parseCtx()?.token) {
+// The contributor's own record: edit / delete / de-identify via the rec_ token
+// (reached at /c/<id>/r/<record-id>#<rec_>).
+async function recordEditor(): Promise<void> {
+  const rec = await apiJson<{
+    id: string; status: string; contributor: string | null;
+    geometry: { type: string; coordinates: number[] };
+    properties: Record<string, unknown>;
+    schema: { geometry: string[]; fields: Field[] }; collection_name: string;
+  }>(`/records/${ctx.recordId}`, ctx.token);
+  const fields = rec.schema.fields.filter((f) => !f.deleted);
+  const isPoint = rec.geometry.type === 'Point';
+  const noun = nounFor(rec.geometry.type);
+  const center = representativeCoord(rec.geometry) ?? INDIA_CENTER;
+
+  app.innerHTML = `
+    <div class="topbar"><a href="/c/${ctx.id}#${ctx.token}" aria-label="Back">←</a><span>Your ${noun}</span>
+      <span class="muted" style="margin-left:auto">${escapeHtml(rec.collection_name)}</span></div>
+    <div class="map">
+      <div id="map"></div>${isPoint ? '<div class="crosshair" aria-hidden="true"></div>' : ''}
+      <div class="map-loading" id="maploading"><span class="spinner"></span> Loading map…</div>
+      ${isPoint ? '<button class="locate" id="locate" aria-label="Use my location">◎</button>' : ''}
+    </div>
+    <div id="panel"><div class="sheet">
+      <form class="body" id="recform">
+        <strong>Edit your ${noun}</strong>
+        <p class="hint">${isPoint ? 'Move the map to reposition; update the details.' : 'Update the details below.'} Status: ${rec.status}.</p>
+        ${fields.map((f) => `<label>${escapeHtml(f.label)}${f.required ? ' *' : ''}</label>${f.hint ? `<p class="hint" style="margin:-2px 0 4px">${escapeHtml(f.hint)}</p>` : ''}${fieldInput(f)}`).join('')}
+      </form>
+      <div class="foot">
+        <button class="primary" id="save">Save changes</button>
+        <div class="row" style="margin-top:8px">
+          <button type="button" id="deid" style="flex:1"${rec.contributor ? '' : ' disabled'}>Remove my name</button>
+          <button type="button" id="del" style="flex:1">Delete ${noun}</button>
+        </div>
+      </div>
+    </div></div>`;
+
+  map = new maplibregl.Map({ container: 'map', style: BASEMAP, center, zoom: isPoint ? 16 : 14, attributionControl: false });
+  map.addControl(new maplibregl.AttributionControl({ compact: true }), 'bottom-left');
+  map.on('load', () => {
+    document.getElementById('maploading')?.remove();
+    if (isPoint) { marker(center); return; }
+    map.addSource('rec', { type: 'geojson', data: { type: 'Feature', geometry: rec.geometry as GeoJSON.Geometry, properties: {} } });
+    map.addLayer({ id: 'rec-fill', type: 'fill', source: 'rec', filter: ['==', '$type', 'Polygon'], paint: { 'fill-color': ACCENT, 'fill-opacity': 0.15 } });
+    map.addLayer({ id: 'rec-line', type: 'line', source: 'rec', filter: ['!=', '$type', 'Point'], paint: { 'line-color': ACCENT, 'line-width': 2.5 } });
+  });
+
+  const panel = document.getElementById('panel')!;
+  for (const f of fields) {
+    const el = panel.querySelector(`[data-k="${f.key}"]`);
+    if (!el) continue;
+    const val = rec.properties[f.key];
+    if (f.type === 'multiselect') {
+      const arr = Array.isArray(val) ? val : [];
+      el.querySelectorAll<HTMLElement>('.chip').forEach((c) => {
+        c.onclick = () => c.classList.toggle('on');
+        if (arr.includes(c.dataset.v)) c.classList.add('on');
+      });
+    } else if (val != null) {
+      (el as HTMLInputElement).value = String(val);
+    }
+  }
+
+  const locateBtn = document.getElementById('locate') as HTMLButtonElement | null;
+  if (locateBtn) locateBtn.onclick = () => {
+    if (!navigator.geolocation) return toast('Location not available');
+    navigator.geolocation.getCurrentPosition(
+      (pos) => map.flyTo({ center: [pos.coords.longitude, pos.coords.latitude], zoom: 16 }),
+      () => toast("Couldn't get your location"), { enableHighAccuracy: true, timeout: 8000 },
+    );
+  };
+
+  (document.getElementById('save') as HTMLButtonElement).onclick = async (ev) => {
+    const btn = ev.currentTarget as HTMLButtonElement;
+    const form = document.getElementById('recform') as HTMLFormElement;
+    if (!form.reportValidity()) return;
+    btn.disabled = true;
+    try {
+      const raw: Record<string, unknown> = {};
+      for (const f of fields) {
+        const el = panel.querySelector(`[data-k="${f.key}"]`);
+        if (!el) continue;
+        if (f.type === 'multiselect') {
+          const on = [...el.querySelectorAll('.chip.on')].map((c) => (c as HTMLElement).dataset.v);
+          if (on.length) raw[f.key] = on;
+        } else {
+          const v = (el as HTMLInputElement).value; if (v) raw[f.key] = v;
+        }
+      }
+      const valid = validateRecordProperties(fields, raw);
+      if (!valid.ok) { toast(valid.error); btn.disabled = false; return; }
+      // Points can be repositioned by panning; shapes edit properties only.
+      const body: Record<string, unknown> = { properties: valid.properties };
+      if (isPoint) { const c = map.getCenter(); body.geometry = { type: 'Point', coordinates: [c.lng, c.lat] }; }
+      await apiJson(`/records/${ctx.recordId}`, ctx.token, { method: 'PATCH', body: JSON.stringify(body) });
+      toast('Saved ✓');
+    } catch (e) { toast((e as Error).message); }
+    btn.disabled = false;
+  };
+
+  (document.getElementById('deid') as HTMLButtonElement).onclick = async (ev) => {
+    const btn = ev.currentTarget as HTMLButtonElement;
+    btn.disabled = true;
+    try {
+      await apiJson(`/records/${ctx.recordId}/deidentify`, ctx.token, { method: 'POST' });
+      toast('Your name was removed ✓');
+    } catch (e) { toast((e as Error).message); btn.disabled = false; }
+  };
+
+  let delArmed = false;
+  (document.getElementById('del') as HTMLButtonElement).onclick = async (ev) => {
+    const btn = ev.currentTarget as HTMLButtonElement;
+    if (!delArmed) { delArmed = true; btn.textContent = 'Tap again to delete'; return; }
+    btn.disabled = true;
+    try {
+      await apiJson(`/records/${ctx.recordId}`, ctx.token, { method: 'DELETE' });
+      app.innerHTML = `<div class="pad"><h1>${noun[0].toUpperCase()}${noun.slice(1)} deleted</h1><p class="hint">Your contribution was removed.</p><a class="btn" href="/c/${ctx.id}#${ctx.token}">← Back to the map</a></div>`;
+    } catch (e) { toast((e as Error).message); btn.disabled = false; }
+  };
+}
+
+const initCtx = parseCtx();
+if (!initCtx?.token) {
   app.innerHTML = `<div class="pad"><h1>Invalid link</h1><p class="hint">Open a collect link (with its token in the URL) to continue.</p></div>`;
 } else {
-  boot().catch((e) => {
+  ctx = initCtx;
+  app.innerHTML = `<div class="pad center"><span class="spinner"></span><p class="hint">Loading…</p></div>`;
+  (initCtx.mode === 'record' ? recordEditor() : boot()).catch((e) => {
     app.innerHTML = `<div class="pad"><h1>Couldn't load</h1><p class="warn">${(e as Error).message}</p></div>`;
   });
 }

--- a/collect/src/geo/admin-ctx.ts
+++ b/collect/src/geo/admin-ctx.ts
@@ -1,0 +1,86 @@
+// Locate enrichment (Phase 4). Two pure helpers used by the record handlers:
+//   representativeCoord — pick one [lng,lat] from any geometry to query locate
+//   distillAdminCtx     — flatten /api/v1/locate `results` to a small named map
+// stored in records.admin_ctx and surfaced in the review queue + published output.
+
+export type AdminCtx = Record<string, string>;
+
+// Per admin level, the property key(s) that hold its display name, in order of
+// preference. Only these known levels are kept — admin_ctx stays small + stable.
+const NAME_KEYS: Record<string, string[]> = {
+  state: ['STNAME', 'stname', 'state'],
+  district: ['dtname', 'Dist', 'district'],
+  subdistrict: ['sdtname'],
+  block: ['block_name'],
+  parliament_constituency: ['pc_name'],
+  assembly_constituency: ['ac_name'],
+  high_court: ['name', 'short_name'],
+  seismic_zone: ['seismic_zo'],
+};
+
+interface LocateEntry {
+  level?: unknown;
+  feature?: { properties?: Record<string, unknown> };
+}
+
+function nameFor(level: string, props: Record<string, unknown>): string | null {
+  for (const key of NAME_KEYS[level] ?? []) {
+    const v = props[key];
+    if (typeof v === 'string' && v.trim() !== '') return v.trim();
+  }
+  return null;
+}
+
+/** Flatten a locate `results` object to `{level: name}`; null if nothing known resolves. */
+export function distillAdminCtx(results: unknown): AdminCtx | null {
+  if (!results || typeof results !== 'object') return null;
+  const ctx: AdminCtx = {};
+  for (const group of Object.values(results as Record<string, unknown>)) {
+    if (!Array.isArray(group)) continue;
+    for (const entry of group as LocateEntry[]) {
+      const level = entry?.level;
+      if (typeof level !== 'string' || !(level in NAME_KEYS)) continue;
+      const name = nameFor(level, entry?.feature?.properties ?? {});
+      if (name) ctx[level] = name;
+    }
+  }
+  return Object.keys(ctx).length ? ctx : null;
+}
+
+/**
+ * Merge enrichment into a record's properties for the published output: each
+ * admin level (state, district…) becomes a top-level property, but an author
+ * field of the same key always wins. Returns a new object; input untouched.
+ */
+export function mergeAdminCtx(
+  properties: Record<string, unknown>,
+  adminCtxJson: string | null,
+): Record<string, unknown> {
+  if (!adminCtxJson) return properties;
+  let ctx: AdminCtx;
+  try {
+    ctx = JSON.parse(adminCtxJson) as AdminCtx;
+  } catch {
+    return properties;
+  }
+  const out = { ...properties };
+  for (const [k, v] of Object.entries(ctx)) if (!(k in out)) out[k] = v;
+  return out;
+}
+
+/** First [lng,lat] vertex of any GeoJSON geometry; null if none/malformed. */
+export function representativeCoord(geometry: unknown): [number, number] | null {
+  const g = geometry as { coordinates?: unknown } | null;
+  if (!g || typeof g !== 'object') return null;
+  let found: [number, number] | null = null;
+  const walk = (node: unknown): void => {
+    if (found || !Array.isArray(node)) return;
+    if (typeof node[0] === 'number' && typeof node[1] === 'number') {
+      found = [node[0], node[1]];
+      return;
+    }
+    for (const child of node) walk(child);
+  };
+  walk(g.coordinates);
+  return found;
+}

--- a/collect/src/geo/draw.ts
+++ b/collect/src/geo/draw.ts
@@ -1,0 +1,29 @@
+// Pure geometry assembly for the capture screen (Phase 4). The UI collects
+// vertices by panning the crosshair and tapping "+ vertex" (no map-tap handler,
+// so it never fights the pan gesture); these helpers turn mode + vertices into
+// GeoJSON. Points use the live map centre; lines/polygons use the dropped verts.
+
+export type GeomMode = 'point' | 'line' | 'polygon';
+export type Coord = [number, number];
+export type DrawGeometry =
+  | { type: 'Point'; coordinates: Coord }
+  | { type: 'LineString'; coordinates: Coord[] }
+  | { type: 'Polygon'; coordinates: Coord[][] };
+
+const VALID: GeomMode[] = ['point', 'line', 'polygon'];
+
+/** Declared geometry set → the modes to offer, point-first; always non-empty. */
+export function orderedModes(declared: readonly string[]): GeomMode[] {
+  const modes = VALID.filter((m) => declared.includes(m));
+  return modes.length ? modes : ['point'];
+}
+
+/** Build a geometry from the active mode; null when a shape needs more vertices. */
+export function drawGeometry(mode: GeomMode, vertices: Coord[], center: Coord): DrawGeometry | null {
+  if (mode === 'point') return { type: 'Point', coordinates: center };
+  if (mode === 'line') return vertices.length >= 2 ? { type: 'LineString', coordinates: vertices } : null;
+  if (mode === 'polygon') {
+    return vertices.length >= 3 ? { type: 'Polygon', coordinates: [[...vertices, vertices[0]]] } : null;
+  }
+  return null;
+}

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -2,6 +2,8 @@
 // is Phase 2); the author picks name / purpose / geometry / licence.
 import { apiJson } from './api';
 import { turnstileToken } from './turnstile';
+import { mountSchemaBuilder } from './schema-builder';
+import { escapeHtml } from './util';
 
 const OPEN_LICENCES: [string, string][] = [
   ['CC-BY-4.0', 'CC BY 4.0 (credit required)'],
@@ -13,32 +15,95 @@ const OPEN_LICENCES: [string, string][] = [
   ['CDLA-Permissive-2.0', 'CDLA Permissive 2.0'],
 ];
 
-const defaultSchema = (geometry: string[]) => ({
-  version: 1,
-  geometry,
-  fields: [
-    { key: 'name', label: 'Name of the place', type: 'text', required: true },
-    { key: 'notes', label: 'Notes', type: 'paragraph' },
-  ],
-});
-
 const app = document.getElementById('app')!;
 
-function render() {
+interface SavedMap { name: string; links: Record<string, string>; at: string; }
+
+function myMaps(): SavedMap[] {
+  try { return JSON.parse(localStorage.getItem('collect:maps') || '[]'); } catch { return []; }
+}
+function saveMap(name: string, links: Record<string, string>): void {
+  try {
+    const store = myMaps();
+    store.unshift({ name: name || 'Untitled map', links, at: new Date().toISOString() });
+    localStorage.setItem('collect:maps', JSON.stringify(store.slice(0, 50)));
+  } catch { /* per-device convenience only */ }
+}
+
+function mapsSection(): string {
+  const maps = myMaps();
+  return `<label>Your maps <span class="hint">(saved on this device)</span></label>
+    ${maps.length
+      ? maps.map((m) => `<div class="link-box">
+          <span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(m.name || 'Untitled map')}</span>
+          <a class="btn" href="${m.links.edit}">Open</a>
+          <a class="btn" href="${m.links.admin}">Admin</a>
+        </div>`).join('')
+      : '<p class="hint">Your created maps will appear here.</p>'}`;
+}
+
+// The landing: a list of your maps + a "start collecting" CTA into the create form.
+function home() {
   app.innerHTML = `
-    <div class="topbar"><span>New map</span><span class="muted" style="margin-left:auto">collect · bharatlas</span></div>
+    <div class="topbar"><span>collect</span><span class="muted" style="margin-left:auto">bharatlas</span></div>
+    <div class="pad">
+      <h1>Make a map, collect together</h1>
+      <p class="hint">Here you <strong>design</strong> a small form. Share the collect link and anyone <strong>adds points</strong> on the map, no accounts. Publish to the bharatlas atlas when it's ready.</p>
+      <button class="primary" id="start">＋ Make a new map</button>
+      <div style="height:18px"></div>
+      ${mapsSection()}
+      <div style="height:14px"></div>
+      <button id="export" class="wide">⬇ Back up my maps to a file</button>
+      <label class="btn wide" style="cursor:pointer">⬆ Restore maps from a backup<input id="import" type="file" accept="application/json" hidden></label>
+      <p class="hint">There are no accounts, so a backup file is the only way to keep your admin links if you change device or browser.</p>
+      <p id="imp-err" class="warn"></p>
+    </div>`;
+  app.querySelector<HTMLButtonElement>('#start')!.onclick = createForm;
+
+  app.querySelector<HTMLButtonElement>('#export')!.onclick = () => {
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([JSON.stringify(myMaps(), null, 2)], { type: 'application/json' }));
+    a.download = 'collect-maps.json';
+    a.click();
+  };
+  app.querySelector<HTMLInputElement>('#import')!.onchange = async (e) => {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    try {
+      const incoming = JSON.parse(await file.text()) as SavedMap[];
+      if (!Array.isArray(incoming)) throw new Error('not a maps file');
+      const seen = new Set<string>();
+      const merged = [...incoming, ...myMaps()].filter((m) => {
+        const key = m?.links?.admin || m?.links?.edit || '';
+        if (!key || seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+      localStorage.setItem('collect:maps', JSON.stringify(merged.slice(0, 100)));
+      home();
+    } catch (ex) {
+      app.querySelector('#imp-err')!.textContent = `Couldn't import: ${(ex as Error).message}`;
+    }
+  };
+}
+
+function createForm() {
+  app.innerHTML = `
+    <div class="topbar"><a href="#" id="tohome" aria-label="Back to your maps">←</a><span>New map</span><span class="muted" style="margin-left:auto">collect</span></div>
     <div class="pad">
       <label>Name your map</label>
       <input id="name" maxlength="120" placeholder="Bengaluru footpath survey" />
       <label>What's it for? <span class="hint">(shown to contributors)</span></label>
       <textarea id="purpose" maxlength="2000" placeholder="Mapping footpath condition across the ward"></textarea>
-      <label>Contributors add</label>
+      <label>What contributors fill in <span class="hint">(the form for each point)</span></label>
+      <div id="fields-builder"></div>
+      <label>Contributors add <span class="hint">(pick one or more)</span></label>
       <div class="row" id="geom">
         <button type="button" class="chip on" data-g="point">Points</button>
         <button type="button" class="chip" data-g="line">Lines</button>
         <button type="button" class="chip" data-g="polygon">Areas</button>
       </div>
-      <label>Licence <span class="hint">(open licences only — the map publishes openly)</span></label>
+      <label>Licence <span class="hint">(open licences only, the map publishes openly)</span></label>
       <select id="license">${OPEN_LICENCES.map(([id, l]) => `<option value="${id}">${l}</option>`).join('')}</select>
       <label>Data year <span class="hint">(optional)</span></label>
       <input id="year" inputmode="numeric" placeholder="2026" />
@@ -46,6 +111,12 @@ function render() {
       <button class="primary" id="create">Create map</button>
       <p id="err" class="warn"></p>
     </div>`;
+
+  app.querySelector<HTMLAnchorElement>('#tohome')!.onclick = (e) => { e.preventDefault(); home(); };
+
+  const builder = mountSchemaBuilder(app.querySelector<HTMLElement>('#fields-builder')!, [
+    { key: 'name', label: 'Name of the place', type: 'text', required: true },
+  ]);
 
   const geom = new Set(['point']);
   app.querySelectorAll<HTMLButtonElement>('#geom .chip').forEach((c) => {
@@ -63,18 +134,26 @@ function render() {
     btn.disabled = true;
     const year = (app.querySelector<HTMLInputElement>('#year')!.value || '').trim();
     try {
+      const name = app.querySelector<HTMLInputElement>('#name')!.value;
+      const fields = builder.getFields();
+      if (!fields.length) { err.textContent = 'Add at least one field for contributors to fill in.'; btn.disabled = false; return; }
+      const dataYear = year ? Number(year) : undefined;
+      if (dataYear !== undefined && !Number.isInteger(dataYear)) {
+        err.textContent = 'Data year must be a whole number like 2026.'; btn.disabled = false; return;
+      }
       const turnstile_token = await turnstileToken();
       const links = (await apiJson<{ id: string; links: Record<string, string> }>('/collections', '', {
         method: 'POST',
         body: JSON.stringify({
-          name: app.querySelector<HTMLInputElement>('#name')!.value,
+          name,
           purpose: app.querySelector<HTMLTextAreaElement>('#purpose')!.value,
           license: app.querySelector<HTMLSelectElement>('#license')!.value,
-          data_year: year ? Number(year) : undefined,
-          schema_doc: defaultSchema([...geom]),
+          data_year: dataYear,
+          schema_doc: { version: 1, geometry: [...geom], fields },
           turnstile_token,
         }),
       })).links;
+      saveMap(name, links);
       done(links);
     } catch (e) {
       err.textContent = (e as Error).message;
@@ -88,24 +167,21 @@ function linkRow(label: string, url: string): string {
 }
 
 function done(links: Record<string, string>) {
-  try {
-    const store = JSON.parse(localStorage.getItem('collect:maps') || '[]');
-    store.unshift({ links, at: new Date().toISOString() });
-    localStorage.setItem('collect:maps', JSON.stringify(store.slice(0, 50)));
-  } catch { /* per-device convenience only */ }
-
   app.innerHTML = `
     <div class="topbar"><span>Your map is live</span></div>
     <div class="pad">
-      ${linkRow('🔗 Collect link — share this', links.edit)}
+      ${linkRow('🔗 Collect link, share this', links.edit)}
       <p class="hint">Anyone with this can add points. No login.</p>
       ${linkRow('👁 View-only', links.view)}
-      ${linkRow('🔑 Admin — keep secret', links.admin)}
-      <p class="warn">⚠ Shown once. Lose the admin link, lose the map.</p>
+      ${linkRow('🔑 Admin, keep secret', links.admin)}
+      <p class="warn">⚠ The <strong>admin</strong> link is shown once and can't be recovered, so save it. Fresh collect / view links can always be minted from the admin screen.</p>
       <button id="dl">⬇ Download my links</button>
       <div style="height:10px"></div>
       <a class="btn primary" href="${links.edit}">Open the map →</a>
+      <div style="height:8px"></div>
+      <a class="btn" href="#" id="tohome-done">← Your maps</a>
     </div>`;
+  app.querySelector<HTMLAnchorElement>('#tohome-done')!.onclick = (e) => { e.preventDefault(); home(); };
 
   app.querySelectorAll<HTMLButtonElement>('[data-copy]').forEach((b) => {
     b.onclick = () => { navigator.clipboard?.writeText(decodeURIComponent(b.dataset.copy!)); b.textContent = '✓'; };
@@ -119,4 +195,4 @@ function done(links: Record<string, string>) {
   };
 }
 
-render();
+home();

--- a/collect/src/schema-builder.ts
+++ b/collect/src/schema-builder.ts
@@ -1,0 +1,153 @@
+// The Phase-2 schema builder: add fields from the 7 types, set required +
+// type-specific config (options/chips for choices, whole-numbers for number),
+// reorder, remove. Generates schema_doc.fields. Keys derive from labels.
+import { deriveKey } from './schema/derive-key';
+import { escapeHtml } from './util';
+
+export interface BuilderField {
+  key: string;
+  label: string;
+  type: string;
+  required?: boolean;
+  hint?: string;
+  options?: string[];
+  integer?: boolean;
+  min?: number;
+  max?: number;
+  maxLength?: number;
+  render?: 'chips';
+}
+
+const TYPES: [string, string][] = [
+  ['text', 'Text'],
+  ['paragraph', 'Long text'],
+  ['number', 'Number'],
+  ['select', 'Choice (pick one)'],
+  ['multiselect', 'Choice (pick many)'],
+  ['date', 'Date'],
+  ['url', 'Link (URL)'],
+];
+const MAX_FIELDS = 20;
+const needsOptions = (t: string) => t === 'select' || t === 'multiselect';
+const typeLabel = (t: string) => TYPES.find(([v]) => v === t)?.[1] ?? t;
+
+export function mountSchemaBuilder(
+  container: HTMLElement,
+  initial: BuilderField[] = [],
+): { getFields: () => BuilderField[] } {
+  const fields: BuilderField[] = initial.slice();
+
+  container.innerHTML = `
+    <div id="sb-list"></div>
+    <div class="card">
+      <input id="sb-label" placeholder="Field label, e.g. Condition" />
+      <div class="row" style="margin-top:6px">
+        <select id="sb-type" style="flex:1">${TYPES.map(([v, l]) => `<option value="${v}">${l}</option>`).join('')}</select>
+        <label class="chip" style="gap:6px"><input type="checkbox" id="sb-req" style="width:auto;min-height:auto" /> Required</label>
+      </div>
+      <input id="sb-hint" placeholder="Help text (optional), shown under the field" style="margin-top:6px" />
+      <div id="sb-extra"></div>
+      <p id="sb-err" class="warn"></p>
+      <button id="sb-add">+ Add field</button>
+    </div>`;
+
+  const q = <T extends HTMLElement>(sel: string) => container.querySelector<T>(sel)!;
+  const listEl = q<HTMLElement>('#sb-list');
+  const labelEl = q<HTMLInputElement>('#sb-label');
+  const typeEl = q<HTMLSelectElement>('#sb-type');
+  const reqEl = q<HTMLInputElement>('#sb-req');
+  const extraEl = q<HTMLElement>('#sb-extra');
+  const errEl = q<HTMLElement>('#sb-err');
+
+  function renderList(): void {
+    if (!fields.length) {
+      listEl.innerHTML = '<p class="hint">No fields yet. Add at least one.</p>';
+      return;
+    }
+    listEl.innerHTML = fields.map((f, i) => `
+      <div class="link-box">
+        <span style="flex:1;overflow:hidden;text-overflow:ellipsis">${escapeHtml(f.label)}${f.required ? ' *' : ''}
+          <span class="hint">${typeLabel(f.type)}${f.options ? ` · ${f.options.length} options` : ''}</span></span>
+        <button data-mv="up" data-i="${i}" aria-label="Move up" ${i === 0 ? 'disabled' : ''}>↑</button>
+        <button data-mv="dn" data-i="${i}" aria-label="Move down" ${i === fields.length - 1 ? 'disabled' : ''}>↓</button>
+        <button data-rm="${i}" aria-label="Remove field">✕</button>
+      </div>`).join('');
+
+    listEl.querySelectorAll<HTMLButtonElement>('[data-rm]').forEach((b) => {
+      b.onclick = () => { fields.splice(Number(b.dataset.rm), 1); renderList(); };
+    });
+    listEl.querySelectorAll<HTMLButtonElement>('[data-mv]').forEach((b) => {
+      b.onclick = () => {
+        const i = Number(b.dataset.i);
+        const j = b.dataset.mv === 'up' ? i - 1 : i + 1;
+        if (j < 0 || j >= fields.length) return;
+        [fields[i], fields[j]] = [fields[j], fields[i]];
+        renderList();
+      };
+    });
+  }
+
+  function renderExtra(): void {
+    const t = typeEl.value;
+    if (needsOptions(t)) {
+      extraEl.innerHTML = `<label>Options <span class="hint">(one per line)</span></label>
+        <textarea id="sb-opts" placeholder="Good&#10;Needs repair&#10;Unusable"></textarea>
+        <label class="chip" style="gap:6px;margin-top:6px"><input type="checkbox" id="sb-chips" style="width:auto;min-height:auto" /> Show as chips</label>`;
+    } else if (t === 'number') {
+      extraEl.innerHTML = `<div class="row" style="margin-top:6px">
+          <input id="sb-min" inputmode="decimal" placeholder="Min" style="flex:1" />
+          <input id="sb-max" inputmode="decimal" placeholder="Max" style="flex:1" />
+        </div>
+        <label class="chip" style="gap:6px;margin-top:6px"><input type="checkbox" id="sb-int" style="width:auto;min-height:auto" /> Whole numbers only</label>`;
+    } else if (t === 'text' || t === 'paragraph') {
+      extraEl.innerHTML = `<label>Max length <span class="hint">(optional)</span></label>
+        <input id="sb-maxlen" inputmode="numeric" placeholder="e.g. 200" />`;
+    } else {
+      extraEl.innerHTML = '';
+    }
+  }
+  typeEl.onchange = renderExtra;
+
+  q<HTMLButtonElement>('#sb-add').onclick = () => {
+    errEl.textContent = '';
+    const label = labelEl.value.trim();
+    if (!label) { errEl.textContent = 'Give the field a label.'; return; }
+    if (fields.length >= MAX_FIELDS) { errEl.textContent = `Max ${MAX_FIELDS} fields.`; return; }
+
+    const type = typeEl.value;
+    const f: BuilderField = { key: deriveKey(label, fields.map((x) => x.key)), label, type };
+    if (reqEl.checked) f.required = true;
+    const hint = q<HTMLInputElement>('#sb-hint').value.trim();
+    if (hint) f.hint = hint;
+
+    if (needsOptions(type)) {
+      const opts = (container.querySelector<HTMLTextAreaElement>('#sb-opts')?.value || '')
+        .split('\n').map((s) => s.trim()).filter(Boolean);
+      if (!opts.length) { errEl.textContent = 'Add at least one option.'; return; }
+      f.options = opts;
+      if (container.querySelector<HTMLInputElement>('#sb-chips')?.checked) f.render = 'chips';
+    }
+    if (type === 'number') {
+      const min = container.querySelector<HTMLInputElement>('#sb-min')?.value.trim();
+      const max = container.querySelector<HTMLInputElement>('#sb-max')?.value.trim();
+      if (min && Number.isFinite(Number(min))) f.min = Number(min);
+      if (max && Number.isFinite(Number(max))) f.max = Number(max);
+      if (container.querySelector<HTMLInputElement>('#sb-int')?.checked) f.integer = true;
+    }
+    if (type === 'text' || type === 'paragraph') {
+      const ml = container.querySelector<HTMLInputElement>('#sb-maxlen')?.value.trim();
+      if (ml && Number.isInteger(Number(ml)) && Number(ml) > 0) f.maxLength = Number(ml);
+    }
+
+    fields.push(f);
+    labelEl.value = '';
+    q<HTMLInputElement>('#sb-hint').value = '';
+    reqEl.checked = false;
+    renderExtra();
+    renderList();
+  };
+
+  renderExtra();
+  renderList();
+  return { getFields: () => fields.slice() };
+}

--- a/collect/src/schema/derive-key.ts
+++ b/collect/src/schema/derive-key.ts
@@ -1,0 +1,20 @@
+// Derive a stable field key from a human label (keys are immutable once a
+// record exists; the builder generates them from the label at add time).
+// Matches the meta-schema's KEY_RE: /^[a-z][a-z0-9_]*$/, and is made unique
+// against keys already in the form.
+
+export function deriveKey(label: string, existing: Iterable<string> = []): string {
+  const taken = new Set(existing);
+  let base = (label || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_') // non-alphanumeric → underscore
+    .replace(/_+/g, '_')         // collapse repeats
+    .replace(/^_+|_+$/g, '');    // trim leading/trailing
+  if (!base) base = 'field';
+  if (!/^[a-z]/.test(base)) base = `f_${base}`;
+
+  let key = base;
+  let n = 2;
+  while (taken.has(key)) key = `${base}_${n++}`;
+  return key;
+}

--- a/collect/src/schema/validate-record.ts
+++ b/collect/src/schema/validate-record.ts
@@ -11,6 +11,7 @@ export interface Field {
   label: string;
   type: FieldType;
   required?: boolean;
+  hint?: string;        // help text shown under the field (all types)
   options?: string[];   // select / multiselect
   min?: number;         // number
   max?: number;         // number

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -2,24 +2,26 @@
    dark via prefers-color-scheme. 44px touch targets; safe-area insets. */
 :root {
   --bg: #ffffff;
-  --fg: #16181d;
-  --line: #e3e6ea;
+  --fg: #0a0a0a;
+  --line: #e5e7eb;
   --muted: #6b7280;
-  --accent: #1a7f5a;
-  --accent-fill: #eaf6f0;
+  --accent: #4f46e5;        /* bharatlas indigo — text, borders, links */
+  --accent-strong: #4f46e5; /* solid fill under WHITE text (AA ≥ 4.5:1 both themes) */
+  --accent-fill: #eef2ff;   /* indigo-50 tint */
   --sheet: #ffffff;
   --shadow: 0 -6px 24px rgba(0, 0, 0, 0.12);
 }
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #0e1013;
-    --fg: #e8eaed;
-    --line: #2a2e35;
-    --muted: #9aa1ab;
-    --accent: #3ecf8e;
-    --accent-fill: #10261d;
-    --sheet: #14171c;
-    --shadow: 0 -6px 24px rgba(0, 0, 0, 0.5);
+    --bg: #0a0a0a;
+    --fg: #ededed;
+    --line: #262626;
+    --muted: #9ca3af;
+    --accent: #818cf8;        /* bharatlas indigo (dark) — text, borders, links */
+    --accent-strong: #4f46e5; /* keep the darker fill so WHITE button text stays AA */
+    --accent-fill: #1e1b4b;   /* deep indigo tint */
+    --sheet: #171717;
+    --shadow: 0 -6px 24px rgba(0, 0, 0, 0.6);
   }
 }
 
@@ -49,10 +51,13 @@ button, .btn {
   font-size: 16px; font-weight: 600; cursor: pointer;
 }
 button.primary, .btn.primary {
-  background: var(--accent); border-color: var(--accent); color: #fff; width: 100%;
+  background: var(--accent-strong); border-color: var(--accent-strong); color: #fff; width: 100%;
 }
 button.ghost { background: transparent; }
 button:disabled { opacity: 0.5; }
+/* equal full-width stacked actions (e.g. Back up / Restore) */
+.wide { width: 100%; display: flex; align-items: center; justify-content: center; gap: 6px; }
+.wide + .wide { margin-top: 8px; }
 label { display: block; font-size: 13px; color: var(--muted); margin: 12px 0 4px; }
 input, textarea, select {
   width: 100%; min-height: 44px; padding: 10px 12px; font-size: 16px;
@@ -63,6 +68,12 @@ textarea { min-height: 88px; }
 .chip { display: inline-flex; align-items: center; min-height: 40px; padding: 0 14px;
   border: 1px solid var(--line); border-radius: 999px; }
 .chip.on { background: var(--accent-fill); border-color: var(--accent); color: var(--accent); }
+
+/* segmented geometry-mode switcher (capture, Phase 4) */
+.seg { display: inline-flex; gap: 0; margin: 4px 0 2px; border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+.seg button { min-height: 38px; border: 0; border-radius: 0; border-left: 1px solid var(--line); background: var(--bg); font-size: 14px; padding: 0 14px; }
+.seg button:first-child { border-left: 0; }
+.seg button.on { background: var(--accent-strong); color: #fff; }
 
 /* landing / form pages scroll */
 .pad { padding: 16px; overflow: auto; }
@@ -96,3 +107,12 @@ textarea { min-height: 88px; }
   background: var(--fg); color: var(--bg); padding: 10px 16px; border-radius: 999px;
   font-size: 14px; z-index: 20; opacity: 0; transition: opacity .2s; }
 .toast.show { opacity: 1; }
+
+/* loading states */
+.center { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; text-align: center; }
+.spinner { width: 20px; height: 20px; border: 3px solid var(--line); border-top-color: var(--accent);
+  border-radius: 50%; display: inline-block; vertical-align: middle; animation: spin .8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.map-loading { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); z-index: 4;
+  background: var(--sheet); border: 1px solid var(--line); border-radius: 999px; padding: 8px 16px;
+  font-size: 14px; color: var(--muted); display: flex; align-items: center; gap: 8px; }

--- a/collect/src/turnstile.ts
+++ b/collect/src/turnstile.ts
@@ -1,15 +1,20 @@
-// Solve a fresh invisible Turnstile token to send with create/contribute.
-// The server verifies it when TURNSTILE_SECRET is configured (prod) and skips
-// it in local dev. Returns '' if Turnstile can't load (server then decides).
+// Solve a Turnstile token to send with create/contribute. Turnstile requires
+// https, so on http/localhost (dev) we skip it — the server also skips
+// verification when no secret is configured, so local testing stays clean and
+// error-free. In prod (https) the invisible widget solves in the background.
 import { TURNSTILE_SITEKEY } from './config';
 
 interface TurnstileApi {
   render: (el: HTMLElement, opts: Record<string, unknown>) => string;
-  execute: (id: string) => void;
+  execute: (el: HTMLElement | string) => void;
   remove: (id: string) => void;
 }
 declare global {
   interface Window { turnstile?: TurnstileApi; }
+}
+
+export function turnstileActive(): boolean {
+  return typeof location !== 'undefined' && location.protocol === 'https:';
 }
 
 let loading: Promise<void> | null = null;
@@ -28,23 +33,35 @@ function load(): Promise<void> {
 }
 
 export async function turnstileToken(): Promise<string> {
+  if (!turnstileActive()) return ''; // dev / http — server skips verification too
   try {
     await load();
     const ts = window.turnstile!;
     return await new Promise<string>((resolve) => {
+      // Off-screen (not display:none — Turnstile rejects that). Invisible-mode
+      // widget solves in the background via execute().
       const el = document.createElement('div');
-      el.style.display = 'none';
+      el.style.position = 'fixed';
+      el.style.left = '-9999px';
+      el.style.bottom = '0';
       document.body.appendChild(el);
+      let settled = false;
       let id = '';
-      const done = (t: string) => { try { ts.remove(id); } catch { /* noop */ } el.remove(); resolve(t); };
+      const done = (t: string) => {
+        if (settled) return;
+        settled = true;
+        try { ts.remove(id); } catch { /* noop */ }
+        el.remove();
+        resolve(t);
+      };
       id = ts.render(el, {
         sitekey: TURNSTILE_SITEKEY,
-        size: 'invisible',
         callback: (t: string) => done(t),
         'error-callback': () => done(''),
         'timeout-callback': () => done(''),
       });
-      ts.execute(id);
+      ts.execute(el);
+      setTimeout(() => done(''), 9000); // never hang a submit
     });
   } catch {
     return '';

--- a/collect/src/util.ts
+++ b/collect/src/util.ts
@@ -1,0 +1,12 @@
+// Shared helpers. escapeHtml mirrors web/src/util — every untrusted string
+// (contributor names, author labels, saved-map names) is routed through it
+// before landing in innerHTML. The CSP blocks inline script, but escaping also
+// stops markup/phishing-link injection on the admin's high-value screen.
+export function escapeHtml(s: unknown): string {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/collect/tests/admin-ctx.test.ts
+++ b/collect/tests/admin-ctx.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { distillAdminCtx, mergeAdminCtx, representativeCoord } from '../src/geo/admin-ctx';
+
+// A trimmed copy of the real /api/v1/locate `results` shape (Bengaluru point).
+const RESULTS = {
+  boundaries: [
+    { level: 'state', feature: { properties: { STNAME: 'KARNATAKA' } } },
+    { level: 'district', feature: { properties: { dtname: 'Bengaluru Urban' } } },
+    { level: 'subdistrict', feature: { properties: { sdtname: 'Bengaluru East' } } },
+    { level: 'block', feature: { properties: { block_name: 'BENGALURU EAST' } } },
+  ],
+  people: [
+    { level: 'parliament_constituency', feature: { properties: { pc_name: 'BANGALORE NORTH' } } },
+    { level: 'assembly_constituency', feature: { properties: { ac_name: 'K.R.Pura' } } },
+    { level: 'high_court', feature: { properties: { name: 'Karnataka High Court' } } },
+  ],
+  environment: [
+    { level: 'seismic_zone', feature: { properties: { seismic_zo: 'Seismic Zone-II' } } },
+  ],
+};
+
+describe('distillAdminCtx', () => {
+  it('flattens locate results to a small named admin context', () => {
+    expect(distillAdminCtx(RESULTS)).toEqual({
+      state: 'KARNATAKA',
+      district: 'Bengaluru Urban',
+      subdistrict: 'Bengaluru East',
+      block: 'BENGALURU EAST',
+      parliament_constituency: 'BANGALORE NORTH',
+      assembly_constituency: 'K.R.Pura',
+      high_court: 'Karnataka High Court',
+      seismic_zone: 'Seismic Zone-II',
+    });
+  });
+
+  it('keeps only the levels actually present', () => {
+    expect(distillAdminCtx({ boundaries: [RESULTS.boundaries[0]] })).toEqual({ state: 'KARNATAKA' });
+  });
+
+  it('returns null when nothing resolves', () => {
+    expect(distillAdminCtx({})).toBeNull();
+    expect(distillAdminCtx({ boundaries: [] })).toBeNull();
+    expect(distillAdminCtx(null)).toBeNull();
+    expect(distillAdminCtx({ boundaries: [{ level: 'state', feature: { properties: {} } }] })).toBeNull();
+  });
+
+  it('ignores unknown levels', () => {
+    expect(distillAdminCtx({ misc: [{ level: 'zzz', feature: { properties: { name: 'x' } } }] })).toBeNull();
+  });
+});
+
+describe('mergeAdminCtx', () => {
+  it('flattens admin levels into properties', () => {
+    expect(mergeAdminCtx({ name: 'x' }, JSON.stringify({ state: 'KA', district: 'BU' }))).toEqual({
+      name: 'x', state: 'KA', district: 'BU',
+    });
+  });
+  it('author fields win on key collision', () => {
+    expect(mergeAdminCtx({ state: 'my state' }, JSON.stringify({ state: 'KA' }))).toEqual({ state: 'my state' });
+  });
+  it('passes properties through when there is no enrichment or bad JSON', () => {
+    expect(mergeAdminCtx({ name: 'x' }, null)).toEqual({ name: 'x' });
+    expect(mergeAdminCtx({ name: 'x' }, 'not json')).toEqual({ name: 'x' });
+  });
+});
+
+describe('representativeCoord', () => {
+  it('returns a point coordinate', () => {
+    expect(representativeCoord({ type: 'Point', coordinates: [77.71, 12.98] })).toEqual([77.71, 12.98]);
+  });
+  it('returns the first vertex of a line', () => {
+    expect(representativeCoord({ type: 'LineString', coordinates: [[77.7, 12.9], [77.8, 13.0]] })).toEqual([77.7, 12.9]);
+  });
+  it('returns the first vertex of a polygon', () => {
+    expect(representativeCoord({ type: 'Polygon', coordinates: [[[77.7, 12.9], [77.8, 12.9], [77.8, 13.0], [77.7, 12.9]]] })).toEqual([77.7, 12.9]);
+  });
+  it('digs into MultiPolygon', () => {
+    expect(representativeCoord({ type: 'MultiPolygon', coordinates: [[[[78.1, 20.2], [78.2, 20.2]]]] })).toEqual([78.1, 20.2]);
+  });
+  it('returns null for malformed geometry', () => {
+    expect(representativeCoord(null)).toBeNull();
+    expect(representativeCoord({ type: 'Point', coordinates: [] })).toBeNull();
+    expect(representativeCoord({})).toBeNull();
+  });
+});

--- a/collect/tests/derive-key.test.ts
+++ b/collect/tests/derive-key.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { deriveKey } from '../src/schema/derive-key';
+
+describe('deriveKey', () => {
+  it('slugifies a label to a valid key', () => {
+    expect(deriveKey('Name of the place')).toBe('name_of_the_place');
+    expect(deriveKey('Condition!')).toBe('condition');
+    expect(deriveKey('A  B   C')).toBe('a_b_c');
+  });
+
+  it('prefixes when it would not start with a letter', () => {
+    expect(deriveKey('123 count')).toBe('f_123_count');
+  });
+
+  it('falls back to "field" for empty / non-latin labels', () => {
+    expect(deriveKey('   ')).toBe('field');
+    expect(deriveKey('  !!  ')).toBe('field');
+  });
+
+  it('makes the key unique against existing keys', () => {
+    expect(deriveKey('Name', ['name'])).toBe('name_2');
+    expect(deriveKey('Name', ['name', 'name_2'])).toBe('name_3');
+  });
+
+  it('always matches the meta-schema key pattern', () => {
+    const re = /^[a-z][a-z0-9_]*$/;
+    for (const label of ['Name', '99 bottles', '   ', 'Full Name (legal)', 'X']) {
+      expect(re.test(deriveKey(label))).toBe(true);
+    }
+  });
+});

--- a/collect/tests/draw.test.ts
+++ b/collect/tests/draw.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { drawGeometry, orderedModes, type GeomMode } from '../src/geo/draw';
+
+const C: [number, number] = [77.6, 12.9];
+const V: [number, number][] = [[77.6, 12.9], [77.7, 12.9], [77.7, 13.0]];
+
+describe('drawGeometry', () => {
+  it('point uses the map centre, ignoring vertices', () => {
+    expect(drawGeometry('point', [], C)).toEqual({ type: 'Point', coordinates: C });
+  });
+
+  it('line needs at least two vertices', () => {
+    expect(drawGeometry('line', [V[0]], C)).toBeNull();
+    expect(drawGeometry('line', [V[0], V[1]], C)).toEqual({ type: 'LineString', coordinates: [V[0], V[1]] });
+  });
+
+  it('polygon needs at least three vertices and closes the ring', () => {
+    expect(drawGeometry('polygon', [V[0], V[1]], C)).toBeNull();
+    expect(drawGeometry('polygon', V, C)).toEqual({
+      type: 'Polygon',
+      coordinates: [[V[0], V[1], V[2], V[0]]],
+    });
+  });
+});
+
+describe('orderedModes', () => {
+  it('keeps only valid declared modes, point first', () => {
+    expect(orderedModes(['polygon', 'point', 'line'])).toEqual(['point', 'line', 'polygon']);
+    expect(orderedModes(['point'])).toEqual(['point']);
+    expect(orderedModes(['line', 'polygon'])).toEqual(['line', 'polygon']);
+  });
+  it('falls back to point when nothing valid is declared', () => {
+    expect(orderedModes([])).toEqual(['point']);
+    expect(orderedModes(['blob' as GeomMode])).toEqual(['point']);
+  });
+});

--- a/collect/tests/util.test.ts
+++ b/collect/tests/util.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { escapeHtml } from '../src/util';
+
+describe('escapeHtml', () => {
+  it('neutralises markup-injection characters', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(escapeHtml('a & b "q" \'x\'')).toBe('a &amp; b &quot;q&quot; &#39;x&#39;');
+  });
+  it('coerces nullish + non-strings to a safe string', () => {
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
+    expect(escapeHtml(42)).toBe('42');
+  });
+  it('leaves plain text untouched', () => {
+    expect(escapeHtml('Kaveri footpath')).toBe('Kaveri footpath');
+  });
+});


### PR DESCRIPTION
Builds **collect.bharatlas.com** Phases 2–4 on top of the Phase 0/1 substrate (#150, #151), plus a full accessibility / security / UX audit pass. All work is under `collect/`.

## Phases
- **Phase 2 — schema builder.** The 7 field types with per-type settings (choice options + chips, number range + whole-numbers, text/paragraph max-length, per-field hint), `label→key` derivation, reorder/remove.
- **Phase 3 — record ownership.** Contributors edit / delete / de-identify their own record via a `rec_` token at `/c/<id>/r/<record-id>#<rec_>` (OSM-style; a contributor edit resets to `pending` when the collection is moderated).
- **Phase 4 — geometry + enrichment.** Lines and polygons via a self-contained crosshair drawer (Point/Line/Area switch, `+vertex`/undo; no map-tap handler, so it never fights the pan gesture). Best-effort locate enrichment fills `records.admin_ctx` **off the write path** (`waitUntil`), shown in the review queue and flattened into the published GeoJSON (`state`/`district`/…).

## Audit (accessibility · security · UX)
- **Security:** escape all untrusted `innerHTML` (`src/util.ts`) — contributor names reach the admin's review screen.
- **Accessibility 86 → 100** (Lighthouse mobile): AA contrast via an `--accent-strong` fill token for white-on-accent buttons; `<main>` landmark.
- **Perf:** enrichment deferred so **Add** returns in ~45 ms instead of blocking up to 4 s on locate; a transient locate failure never clobbers a good `admin_ctx`. Landing entry 11 KB (no MapLibre); capture app 224 KB gz (MapLibre floor; Phase 4 added 0 KB).
- Admin capture map shows published-only; contributor name kept across adds; queue title falls back to the first field; data-year validation.
- CSP headers + `robots.txt` + meta description; equal, self-explanatory **Back up / Restore** buttons; home "Your maps" landing (localStorage + backup/restore); indigo palette match; Turnstile invisible-mode gated to https.

## Notes
- collect stays `noindex` by design (token-gated; data SEO lives on the apex atlas).
- **Deferred to a real-device pass:** in-progress line/polygon pixel render and drag-to-move vertices. Terra Draw remains a clean future swap.

## Verification
55 vitest tests green · typecheck + `vite build` clean · e2e-verified against a shared local D1 (create → contribute point/line/polygon → enrich → moderate → publish; published R2 GeoJSON carries flat admin columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)