### PR TITLE
collect: UX overhaul — design system, map-first capture, admin CRUD

### DIFF
--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -196,39 +196,41 @@ const CAP_HELP: Record<GeomMode, string> = {
   polygon: 'Pan the map so the crosshair sits on a corner, then tap "Add point here", going around the area.',
 };
 
+const cap = (s: string): string => s[0].toUpperCase() + s.slice(1);
+let lastContributor = '';
+let lastAdded = '';
+
+// Capture is two steps so the MAP is the centre-piece while marking:
+//   1. renderPlaceBar — a compact bar; position the crosshair and place the shape
+//   2. detailsSheet   — the form slides up only once a shape is placed
 function captureSheet(): void {
-  const fields = meta.schema.fields.filter((f) => !f.deleted);
   const modes = orderedModes(meta.schema.geometry);
   drawMode = modes[0];
   verts = [];
   redrawDraw();
+  renderPlaceBar(modes);
+}
+
+function renderPlaceBar(modes: GeomMode[]): void {
   const panel = document.getElementById('panel')!;
   const seg = modes.length > 1
-    ? `<div class="seg" id="modesw">${modes.map((m) => `<button type="button" data-m="${m}"${m === drawMode ? ' class="on"' : ''}>${NOUN[m][0].toUpperCase()}${NOUN[m].slice(1)}</button>`).join('')}</div>`
+    ? `<div class="seg" id="modesw">${modes.map((m) => `<button type="button" data-m="${m}"${m === drawMode ? ' class="on"' : ''}>${cap(NOUN[m])}</button>`).join('')}</div>`
     : '';
-  panel.innerHTML = `<div class="sheet">
-    <form class="body" id="capform">
-      <strong>Add a <span id="cap-noun">${NOUN[drawMode]}</span></strong>
-      ${seg}
-      <p class="hint" id="cap-help">${CAP_HELP[drawMode]}</p>
-      <div class="row" id="drawctl" style="display:none;align-items:center">
-        <button type="button" id="vadd" class="accent">+ Add point here</button>
-        <button type="button" id="vundo">Undo</button>
-        <span class="hint" id="vcount"></span>
-      </div>
-      ${fields.map((f) => `<label>${escapeHtml(f.label)}${f.required ? ' *' : ''}</label>${f.hint ? `<p class="hint" style="margin:-2px 0 4px">${escapeHtml(f.hint)}</p>` : ''}${fieldInput(f)}`).join('')}
-      <label>Your name <span class="hint">(optional, published with the data)</span></label>
-      <input id="contributor" />
-    </form>
-    <div class="foot"><button class="primary" id="add">Add ${NOUN[drawMode]}</button></div>
-    <div id="lastadded" class="hint" style="padding:0 16px 10px"></div>
+  panel.innerHTML = `<div class="bar">
+    ${seg}
+    <p class="hint" id="cap-help">${CAP_HELP[drawMode]}</p>
+    <div class="row" id="drawctl" style="display:none;align-items:center">
+      <button type="button" id="vadd" class="accent">+ Add point here</button>
+      <button type="button" id="vundo">Undo</button>
+      <span class="hint" id="vcount"></span>
+    </div>
+    <button class="primary" id="place">Add ${NOUN[drawMode]}</button>
+    <div id="lastadded" class="hint">${lastAdded}</div>
   </div>`;
-  panel.querySelectorAll<HTMLElement>('[data-multi] .chip').forEach((c) => { c.onclick = () => c.classList.toggle('on'); });
 
   const syncDrawUI = (): void => {
-    document.getElementById('cap-noun')!.textContent = NOUN[drawMode];
     document.getElementById('cap-help')!.textContent = CAP_HELP[drawMode];
-    (document.getElementById('add') as HTMLButtonElement).textContent = `Add ${NOUN[drawMode]}`;
+    (document.getElementById('place') as HTMLButtonElement).textContent = `Add ${NOUN[drawMode]}`;
     document.getElementById('drawctl')!.style.display = drawMode === 'point' ? 'none' : 'flex';
     const need = drawMode === 'line' ? 2 : 3;
     const n = verts.length;
@@ -236,7 +238,6 @@ function captureSheet(): void {
       n < need ? `${n} point${n === 1 ? '' : 's'} · add ${need - n} more`
                : `${n} points · tap "Add ${NOUN[drawMode]}" when ready`;
     document.querySelectorAll('#modesw button').forEach((b) => b.classList.toggle('on', (b as HTMLElement).dataset.m === drawMode));
-    // Emphasise the crosshair while drawing so the "here" in the button reads clearly.
     document.querySelector('.crosshair')?.classList.toggle('crosshair--draw', drawMode !== 'point');
   };
   syncDrawUI();
@@ -250,54 +251,73 @@ function captureSheet(): void {
   (document.getElementById('vundo') as HTMLButtonElement).onclick = () => {
     verts.pop(); redrawDraw(); syncDrawUI();
   };
-
-  (document.getElementById('add') as HTMLButtonElement).onclick = async (ev) => {
-    const btn = ev.currentTarget as HTMLButtonElement;
-    const form = document.getElementById('capform') as HTMLFormElement;
-    if (!form.reportValidity()) return; // native: required, URL format, number min/max
+  (document.getElementById('place') as HTMLButtonElement).onclick = () => {
     const c = map.getCenter();
     const geometry = drawGeometry(drawMode, verts, [c.lng, c.lat]);
     if (!geometry) { toast(`A ${NOUN[drawMode]} needs ${drawMode === 'line' ? '2' : '3'} points or more`); return; }
+    detailsSheet(geometry, modes);
+  };
+}
+
+function detailsSheet(geometry: GeoJSON.Geometry, modes: GeomMode[]): void {
+  const fields = meta.schema.fields.filter((f) => !f.deleted);
+  const noun = NOUN[drawMode];
+  const panel = document.getElementById('panel')!;
+  panel.innerHTML = `<div class="sheet">
+    <form class="body" id="capform">
+      <strong>${cap(noun)} details</strong>
+      <p class="hint">Placed on the map. Add the details, then save.</p>
+      ${fields.map((f) => `<label>${escapeHtml(f.label)}${f.required ? ' *' : ''}</label>${f.hint ? `<p class="hint" style="margin:-2px 0 4px">${escapeHtml(f.hint)}</p>` : ''}${fieldInput(f)}`).join('')}
+      <label>Your name <span class="hint">(optional, published with the data)</span></label>
+      <input id="contributor" />
+    </form>
+    <div class="foot row">
+      <button type="button" id="cancel">← Back</button>
+      <button class="primary" id="save" style="flex:1">Save ${noun}</button>
+    </div>
+  </div>`;
+  (document.getElementById('contributor') as HTMLInputElement).value = lastContributor;
+  panel.querySelectorAll<HTMLElement>('[data-multi] .chip').forEach((c) => { c.onclick = () => c.classList.toggle('on'); });
+  // Back keeps a line/area's vertices so drawing work isn't lost.
+  (document.getElementById('cancel') as HTMLButtonElement).onclick = () => renderPlaceBar(modes);
+
+  (document.getElementById('save') as HTMLButtonElement).onclick = async (ev) => {
+    const btn = ev.currentTarget as HTMLButtonElement;
+    const form = document.getElementById('capform') as HTMLFormElement;
+    if (!form.reportValidity()) return;
+    const raw: Record<string, unknown> = {};
+    for (const f of fields) {
+      const el = panel.querySelector(`[data-k="${f.key}"]`);
+      if (!el) continue;
+      if (f.type === 'multiselect') {
+        const on = [...el.querySelectorAll('.chip.on')].map((c2) => (c2 as HTMLElement).dataset.v);
+        if (on.length) raw[f.key] = on;
+      } else {
+        const val = (el as HTMLInputElement).value;
+        if (val) raw[f.key] = val;
+      }
+    }
+    const valid = validateRecordProperties(fields, raw);
+    if (!valid.ok) { toast(valid.error); return; }
     btn.disabled = true;
     try {
-      const raw: Record<string, unknown> = {};
-      for (const f of fields) {
-        const el = panel.querySelector(`[data-k="${f.key}"]`);
-        if (!el) continue;
-        if (f.type === 'multiselect') {
-          const on = [...el.querySelectorAll('.chip.on')].map((c2) => (c2 as HTMLElement).dataset.v);
-          if (on.length) raw[f.key] = on;
-        } else {
-          const val = (el as HTMLInputElement).value;
-          if (val) raw[f.key] = val;
-        }
-      }
-      // Same validator the server uses — immediate feedback, no wasted round-trip.
-      const valid = validateRecordProperties(fields, raw);
-      if (!valid.ok) { toast(valid.error); btn.disabled = false; return; }
-      const contributor = (document.getElementById('contributor') as HTMLInputElement).value;
+      lastContributor = (document.getElementById('contributor') as HTMLInputElement).value;
       const turnstile_token = await turnstileToken();
       const res = await apiJson<{ id: string; edit_token: string }>(`/collections/${ctx.id}/records`, ctx.token, {
         method: 'POST',
-        body: JSON.stringify({ geometry, properties: valid.properties, contributor, turnstile_token }),
+        body: JSON.stringify({ geometry, properties: valid.properties, contributor: lastContributor, turnstile_token }),
       });
-      if (geometry.type === 'Point') marker(geometry.coordinates);
+      if (geometry.type === 'Point') marker((geometry as GeoJSON.Point).coordinates as number[]);
       else addRecordShape(geometry);
-      verts = []; redrawDraw(); syncDrawUI();
-      toast(meta.moderation ? `Added, pending review ✓` : 'Added ✓');
+      verts = []; redrawDraw();
+      toast(meta.moderation ? 'Added, pending review ✓' : 'Added ✓');
       const editUrl = `${location.origin}/c/${ctx.id}/r/${res.id}#${res.edit_token}`;
-      const la = document.getElementById('lastadded');
-      if (la) la.innerHTML = `✓ Added. <a href="${editUrl}">edit this ${NOUN[drawMode]}</a>`;
-      // Keep #contributor — one surveyor adds many points and shouldn't re-type their name.
-      panel.querySelectorAll('input:not(#contributor),textarea,select').forEach((el) => { (el as HTMLInputElement).value = ''; });
-      panel.querySelectorAll('.chip.on').forEach((c2) => c2.classList.remove('on'));
-      btn.textContent = `Add ${NOUN[drawMode]}`;
+      lastAdded = `✓ Added. <a href="${editUrl}">edit this ${noun}</a>`;
+      renderPlaceBar(modes); // back to the map, ready for the next one
     } catch (e) {
-      // Field resilience (spec): keep the entry on failure, offer a retry.
-      toast(`Couldn't save: ${(e as Error).message}. Your entry is kept, tap Retry.`);
-      btn.textContent = 'Retry';
+      toast(`Couldn't save: ${(e as Error).message}. Your details are kept, tap Save to retry.`);
+      btn.disabled = false;
     }
-    btn.disabled = false;
   };
 }
 
@@ -412,24 +432,26 @@ async function renderPoints(): Promise<void> {
     const qs = status ? `?status=${status}&limit=300` : '?limit=300';
     const fc = await apiJson<{ features: Feature[] }>(`/collections/${ctx.id}/records${qs}`, ctx.token);
     const feats = fc.features || [];
-    if (!feats.length) { q.innerHTML = '<p class="hint">No points here yet.</p>'; return; }
+    if (!feats.length) { q.innerHTML = '<p class="empty">No points here yet. Share the collect link and they will show up as people add them.</p>'; return; }
     q.innerHTML = feats.map((f) => {
       const p = f.properties as { _status?: string; _contributor?: string; _admin_ctx?: AdminCtx };
       const st = p._status || 'published';
       const geom = f.geometry?.type && f.geometry.type !== 'Point' ? `<span class="hint">${nounFor(f.geometry.type)}</span> ` : '';
-      const acts = [
+      // Two action rows (max two buttons each) so labels never wrap: moderation
+      // on top, then edit/delete. Better hierarchy, and it fits at 360px.
+      const mod = [
         st !== 'published' ? `<button data-act="published" data-id="${f.id}">✓ Approve</button>` : '',
-        st === 'pending' ? `<button data-act="rejected" data-id="${f.id}">✗ Reject</button>` : '',
-        `<button data-edit="${f.id}">✎ Edit</button>`,
-        `<button data-del="${f.id}">🗑 Delete</button>`,
+        st === 'pending' ? `<button class="danger" data-act="rejected" data-id="${f.id}">✗ Reject</button>` : '',
       ].filter(Boolean).join('');
+      const crud = `<button data-edit="${f.id}">✎ Edit</button><button class="danger" data-del="${f.id}">🗑 Delete</button>`;
       return `<div class="card" data-id="${f.id}">
         <div class="row" style="justify-content:space-between;align-items:center;gap:6px">
           <strong style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${geom}${escapeHtml(cardTitle(f.properties))}</strong>
           <span class="badge badge--${st}">${st}</span>
         </div>
         <div class="hint">${escapeHtml(p._contributor || 'anonymous')}${fmtAdminCtx(p._admin_ctx ?? null)}</div>
-        <div class="row" style="margin-top:8px">${acts}</div>
+        ${mod ? `<div class="row" style="margin-top:8px">${mod}</div>` : ''}
+        <div class="row" style="margin-top:8px">${crud}</div>
       </div>`;
     }).join('');
 

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -115,10 +115,13 @@ async function boot(): Promise<void> {
         { enableHighAccuracy: true, timeout: 8000 },
       );
     };
-    captureSheet();
-  }
-  if (isAdmin) {
-    (document.getElementById('manage') as HTMLButtonElement).onclick = manageSheet;
+    if (isAdmin) {
+      // Admin lands on Manage (review + CRUD + publish); the ⚙ button returns here.
+      (document.getElementById('manage') as HTMLButtonElement).onclick = manageSheet;
+      void manageSheet();
+    } else {
+      captureSheet();
+    }
   }
   if (isView) viewPanel();
 }
@@ -189,8 +192,8 @@ function nounFor(geometryType: string): string {
 }
 const CAP_HELP: Record<GeomMode, string> = {
   point: 'Move the map so the crosshair sits on the spot.',
-  line: 'Pan so the crosshair is on each point, then tap + vertex. Need 2 or more.',
-  polygon: 'Pan the crosshair to each corner, then tap + vertex. Need 3 or more.',
+  line: 'Pan the map so the crosshair sits on a point, then tap "Add point here". Repeat along the line.',
+  polygon: 'Pan the map so the crosshair sits on a corner, then tap "Add point here", going around the area.',
 };
 
 function captureSheet(): void {
@@ -209,7 +212,7 @@ function captureSheet(): void {
       ${seg}
       <p class="hint" id="cap-help">${CAP_HELP[drawMode]}</p>
       <div class="row" id="drawctl" style="display:none;align-items:center">
-        <button type="button" id="vadd">+ vertex</button>
+        <button type="button" id="vadd" class="accent">+ Add point here</button>
         <button type="button" id="vundo">Undo</button>
         <span class="hint" id="vcount"></span>
       </div>
@@ -227,8 +230,14 @@ function captureSheet(): void {
     document.getElementById('cap-help')!.textContent = CAP_HELP[drawMode];
     (document.getElementById('add') as HTMLButtonElement).textContent = `Add ${NOUN[drawMode]}`;
     document.getElementById('drawctl')!.style.display = drawMode === 'point' ? 'none' : 'flex';
-    document.getElementById('vcount')!.textContent = `${verts.length} point${verts.length === 1 ? '' : 's'}`;
+    const need = drawMode === 'line' ? 2 : 3;
+    const n = verts.length;
+    document.getElementById('vcount')!.textContent =
+      n < need ? `${n} point${n === 1 ? '' : 's'} · add ${need - n} more`
+               : `${n} points · tap "Add ${NOUN[drawMode]}" when ready`;
     document.querySelectorAll('#modesw button').forEach((b) => b.classList.toggle('on', (b as HTMLElement).dataset.m === drawMode));
+    // Emphasise the crosshair while drawing so the "here" in the button reads clearly.
+    document.querySelector('.crosshair')?.classList.toggle('crosshair--draw', drawMode !== 'point');
   };
   syncDrawUI();
 
@@ -293,14 +302,20 @@ function captureSheet(): void {
 }
 
 async function manageSheet(): Promise<void> {
-  const fresh = await apiJson<Meta>(`/collections/${ctx.id}`, ctx.token).catch(() => meta);
-  const counts = fresh.counts;
+  meta = await apiJson<Meta>(`/collections/${ctx.id}`, ctx.token).catch(() => meta);
+  const c = meta.counts;
   const panel = document.getElementById('panel')!;
   panel.innerHTML = `<div class="sheet">
     <div class="body">
       <strong>Manage map</strong>
-      <p class="hint">${counts.published} approved · ${counts.pending} pending · ${counts.total} total</p>
-      <div id="queue"><p class="hint">Loading pending…</p></div>
+      <p class="hint" id="mcounts">${c.published} approved · ${c.pending} pending · ${c.rejected} rejected</p>
+      <div class="row" id="pfilter" style="margin:8px 0 4px">
+        <button type="button" class="chip on" data-s="">All ${c.total}</button>
+        <button type="button" class="chip" data-s="pending">Pending ${c.pending}</button>
+        <button type="button" class="chip" data-s="published">Approved ${c.published}</button>
+        ${c.rejected ? `<button type="button" class="chip" data-s="rejected">Rejected ${c.rejected}</button>` : ''}
+      </div>
+      <div id="points"><p class="hint">Loading points…</p></div>
       <strong style="display:block;margin-top:14px">Share links</strong>
       <p class="hint">Mint a fresh link to share. The original links can't be shown again.</p>
       <div class="row">
@@ -310,12 +325,19 @@ async function manageSheet(): Promise<void> {
       <div id="minted"></div>
     </div>
     <div class="foot row">
-      <button id="back">← Capture</button>
+      <button id="back">+ Add points</button>
       <button class="primary" id="publish" style="flex:1">Publish → atlas</button>
     </div>
   </div>`;
   (document.getElementById('back') as HTMLButtonElement).onclick = captureSheet;
   (document.getElementById('publish') as HTMLButtonElement).onclick = doPublish;
+  document.querySelectorAll<HTMLButtonElement>('#pfilter .chip').forEach((b) => {
+    b.onclick = () => {
+      document.querySelectorAll('#pfilter .chip').forEach((x) => x.classList.remove('on'));
+      b.classList.add('on');
+      void renderPoints();
+    };
+  });
 
   const mint = async (permission: 'edit' | 'view') => {
     try {
@@ -325,7 +347,8 @@ async function manageSheet(): Promise<void> {
       const box = document.getElementById('minted')!;
       const row = document.createElement('div');
       row.className = 'link-box';
-      row.innerHTML = `<code>${res.link}</code><button>Copy</button>`;
+      row.innerHTML = `<code></code><button>Copy</button>`;
+      row.querySelector('code')!.textContent = res.link; // textContent — never innerHTML a URL
       const btn = row.querySelector('button')!;
       btn.onclick = () => { navigator.clipboard?.writeText(res.link); btn.textContent = '✓'; };
       box.prepend(row);
@@ -336,7 +359,26 @@ async function manageSheet(): Promise<void> {
   (document.getElementById('mint-edit') as HTMLButtonElement).onclick = () => mint('edit');
   (document.getElementById('mint-view') as HTMLButtonElement).onclick = () => mint('view');
 
-  renderQueue();
+  void renderPoints();
+}
+
+function activeFilter(): string {
+  return (document.querySelector('#pfilter .chip.on') as HTMLElement | null)?.dataset.s || '';
+}
+
+// Refresh the counts line + filter-chip totals after a moderation/delete.
+async function refreshCounts(): Promise<void> {
+  try {
+    meta = await apiJson<Meta>(`/collections/${ctx.id}`, ctx.token);
+    const c = meta.counts;
+    const line = document.getElementById('mcounts');
+    if (line) line.textContent = `${c.published} approved · ${c.pending} pending · ${c.rejected} rejected`;
+    const label: Record<string, string> = { '': `All ${c.total}`, pending: `Pending ${c.pending}`, published: `Approved ${c.published}`, rejected: `Rejected ${c.rejected}` };
+    document.querySelectorAll<HTMLElement>('#pfilter .chip').forEach((b) => {
+      const t = label[b.dataset.s || ''];
+      if (t) b.textContent = t;
+    });
+  } catch { /* leave stale counts */ }
 }
 
 type AdminCtx = { state?: string; district?: string; subdistrict?: string } | null;
@@ -357,33 +399,65 @@ function cardTitle(props: Record<string, unknown>): string {
   return '(no name)';
 }
 
-async function renderQueue(): Promise<void> {
-  const q = document.getElementById('queue');
+// The admin point manager: every marked point (filtered) with per-point CRUD —
+// approve/reject (moderation), edit (opens the record editor with the admin
+// token), delete. Read = list; Update = edit link; Delete = delete; Create =
+// the "+ Add points" button (capture) or a contributor's own add.
+async function renderPoints(): Promise<void> {
+  const q = document.getElementById('points');
   if (!q) return;
+  const status = activeFilter();
+  q.innerHTML = '<p class="hint">Loading…</p>';
   try {
-    const fc = await apiJson<{ features: Feature[] }>(`/collections/${ctx.id}/records?status=pending&limit=25`, ctx.token);
+    const qs = status ? `?status=${status}&limit=300` : '?limit=300';
+    const fc = await apiJson<{ features: Feature[] }>(`/collections/${ctx.id}/records${qs}`, ctx.token);
     const feats = fc.features || [];
-    if (!feats.length) { q.innerHTML = '<p class="hint">Nothing pending.</p>'; return; }
-    q.innerHTML = feats.map((f) => `<div class="card" data-id="${f.id}">
-        <div>${escapeHtml(cardTitle(f.properties))}</div>
-        <div class="hint">${escapeHtml((f.properties as { _contributor?: string })._contributor || 'anonymous')}${fmtAdminCtx((f.properties as { _admin_ctx?: AdminCtx })._admin_ctx ?? null)}</div>
-        <div class="row" style="margin-top:8px">
-          <button data-act="rejected" style="flex:1">✗ Reject</button>
-          <button class="primary" data-act="published" style="flex:1">✓ Approve</button>
-        </div></div>`).join('');
+    if (!feats.length) { q.innerHTML = '<p class="hint">No points here yet.</p>'; return; }
+    q.innerHTML = feats.map((f) => {
+      const p = f.properties as { _status?: string; _contributor?: string; _admin_ctx?: AdminCtx };
+      const st = p._status || 'published';
+      const geom = f.geometry?.type && f.geometry.type !== 'Point' ? `<span class="hint">${nounFor(f.geometry.type)}</span> ` : '';
+      const acts = [
+        st !== 'published' ? `<button data-act="published" data-id="${f.id}">✓ Approve</button>` : '',
+        st === 'pending' ? `<button data-act="rejected" data-id="${f.id}">✗ Reject</button>` : '',
+        `<button data-edit="${f.id}">✎ Edit</button>`,
+        `<button data-del="${f.id}">🗑 Delete</button>`,
+      ].filter(Boolean).join('');
+      return `<div class="card" data-id="${f.id}">
+        <div class="row" style="justify-content:space-between;align-items:center;gap:6px">
+          <strong style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${geom}${escapeHtml(cardTitle(f.properties))}</strong>
+          <span class="badge badge--${st}">${st}</span>
+        </div>
+        <div class="hint">${escapeHtml(p._contributor || 'anonymous')}${fmtAdminCtx(p._admin_ctx ?? null)}</div>
+        <div class="row" style="margin-top:8px">${acts}</div>
+      </div>`;
+    }).join('');
+
     q.querySelectorAll<HTMLButtonElement>('button[data-act]').forEach((b) => {
       b.onclick = async () => {
-        const card = b.closest('.card') as HTMLElement;
         try {
-          await apiJson(`/records/${card.dataset.id}/moderate`, ctx.token, {
-            method: 'POST', body: JSON.stringify({ status: b.dataset.act }),
-          });
-          card.remove();
+          await apiJson(`/records/${b.dataset.id}/moderate`, ctx.token, { method: 'POST', body: JSON.stringify({ status: b.dataset.act }) });
+          await refreshCounts();
+          void renderPoints();
+        } catch (e) { toast((e as Error).message); }
+      };
+    });
+    q.querySelectorAll<HTMLButtonElement>('button[data-edit]').forEach((b) => {
+      b.onclick = () => { location.href = `/c/${ctx.id}/r/${b.dataset.edit}#${ctx.token}`; };
+    });
+    q.querySelectorAll<HTMLButtonElement>('button[data-del]').forEach((b) => {
+      let armed = false;
+      b.onclick = async () => {
+        if (!armed) { armed = true; b.textContent = 'Tap to confirm'; return; }
+        try {
+          await apiJson(`/records/${b.dataset.del}`, ctx.token, { method: 'DELETE' });
+          await refreshCounts();
+          void renderPoints();
         } catch (e) { toast((e as Error).message); }
       };
     });
   } catch (e) {
-    q.innerHTML = `<p class="warn">${(e as Error).message}</p>`;
+    q.innerHTML = `<p class="warn">${escapeHtml((e as Error).message)}</p>`;
   }
 }
 

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -53,9 +53,9 @@ function home() {
       <div style="height:18px"></div>
       ${mapsSection()}
       <div style="height:14px"></div>
-      <button id="export" class="wide">⬇ Back up my maps to a file</button>
-      <label class="btn wide" style="cursor:pointer">⬆ Restore maps from a backup<input id="import" type="file" accept="application/json" hidden></label>
-      <p class="hint">There are no accounts, so a backup file is the only way to keep your admin links if you change device or browser.</p>
+      <button id="export" class="wide">⬇ Save my map links</button>
+      <label class="btn wide" style="cursor:pointer">⬆ Restore map links<input id="import" type="file" accept="application/json" hidden></label>
+      <p class="hint">This file holds the <strong>links</strong> to your maps (your admin access), not the points people collect. With no accounts, it's how you reach your maps again from another device or browser.</p>
       <p id="imp-err" class="warn"></p>
     </div>`;
   app.querySelector<HTMLButtonElement>('#start')!.onclick = createForm;
@@ -63,7 +63,7 @@ function home() {
   app.querySelector<HTMLButtonElement>('#export')!.onclick = () => {
     const a = document.createElement('a');
     a.href = URL.createObjectURL(new Blob([JSON.stringify(myMaps(), null, 2)], { type: 'application/json' }));
-    a.download = 'collect-maps.json';
+    a.download = 'collect-map-links.json';
     a.click();
   };
   app.querySelector<HTMLInputElement>('#import')!.onchange = async (e) => {

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -39,7 +39,7 @@ function mapsSection(): string {
           <a class="btn" href="${m.links.edit}">Open</a>
           <a class="btn" href="${m.links.admin}">Admin</a>
         </div>`).join('')
-      : '<p class="hint">Your created maps will appear here.</p>'}`;
+      : '<p class="empty">No maps yet. Make one above, and it will appear here to reopen anytime.</p>'}`;
 }
 
 // The landing: a list of your maps + a "start collecting" CTA into the create form.

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -57,6 +57,7 @@ button.primary, .btn.primary {
   background: var(--accent-strong); border-color: var(--accent-strong); color: #fff; width: 100%;
 }
 button.ghost { background: transparent; }
+button.accent { border-color: var(--accent); color: var(--accent); flex: 1; }
 button:disabled { opacity: 0.5; }
 /* equal full-width stacked actions (e.g. Back up / Restore) */
 .wide { width: 100%; display: flex; align-items: center; justify-content: center; gap: 6px; }
@@ -95,6 +96,9 @@ textarea { min-height: 88px; }
 .crosshair::before, .crosshair::after { content: ""; position: absolute; background: var(--accent); }
 .crosshair::before { left: 16px; top: 0; width: 2px; height: 34px; }
 .crosshair::after { top: 16px; left: 0; height: 2px; width: 34px; }
+/* while drawing a line/area, ring the crosshair so "Add point here" reads clearly */
+.crosshair--draw::after, .crosshair--draw::before { background: var(--accent-strong); }
+.crosshair--draw { outline: 2px solid var(--accent-strong); outline-offset: 6px; border-radius: 50%; }
 .locate { position: absolute; right: 12px; bottom: 12px; z-index: 6;
   min-width: 44px; box-shadow: 0 2px 10px rgba(0,0,0,0.2); }
 
@@ -106,6 +110,11 @@ textarea { min-height: 88px; }
 .sheet .foot { padding: 10px 16px calc(10px + env(safe-area-inset-bottom)); border-top: 1px solid var(--line); }
 
 .card { border: 1px solid var(--line); border-radius: 12px; padding: 12px; margin: 10px 0; }
+.card .row button { flex: 1; min-height: 40px; font-size: 14px; padding: 0 10px; }
+.badge { font-size: 11px; font-weight: 700; padding: 1px 8px; border-radius: 999px; border: 1px solid currentColor; white-space: nowrap; text-transform: capitalize; }
+.badge--pending { color: #d97706; }
+.badge--published { color: var(--accent); }
+.badge--rejected { color: #dc2626; }
 .toast { position: fixed; left: 50%; bottom: 80px; transform: translateX(-50%);
   background: var(--fg); color: var(--bg); padding: 10px 16px; border-radius: 999px;
   font-size: 14px; z-index: 20; opacity: 0; transition: opacity .2s; }

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -1,27 +1,55 @@
-/* collect — mobile-first, reuses the bharatlas token system. Light default;
-   dark via prefers-color-scheme. 44px touch targets; safe-area insets. */
+/* collect — bharatlas's contribution tool.
+   Design system "a precise instrument": ONE control family, layered surfaces
+   for depth, indigo accent, the surveyor crosshair as the recurring motif.
+   Mobile-first · light default + dark via prefers-color-scheme · WCAG AA.
+
+   Control types (each internally consistent — no ad-hoc shapes):
+     · action button  — rounded-rect, --radius, height --ctl-h  (.btn / <button>)
+     · toggle / filter — pill, --radius-pill                     (.chip)
+     · segmented       — one rounded track, equal cells          (.seg) */
+
 :root {
+  color-scheme: light dark;
   --bg: #ffffff;
-  --fg: #0a0a0a;
-  --line: #e5e7eb;
-  --muted: #6b7280;
-  --accent: #4f46e5;        /* bharatlas indigo — text, borders, links */
-  --accent-strong: #4f46e5; /* solid fill under WHITE text (AA ≥ 4.5:1 both themes) */
-  --accent-fill: #eef2ff;   /* indigo-50 tint */
+  --surface: #f4f6f8;        /* raised sections, code chips */
+  --card: #ffffff;
+  --fg: #0f1115;
+  --muted: #59606e;          /* AA on --bg */
+  --line: #e5e8ed;
+  --line-strong: #d2d7df;
+  --accent: #4f46e5;         /* indigo — text, borders, links */
+  --accent-strong: #4f46e5;  /* fill under WHITE text (AA both themes) */
+  --accent-fill: #eef2ff;
+  --danger: #dc2626;
+  --amber: #b45309;
   --sheet: #ffffff;
-  --shadow: 0 -6px 24px rgba(0, 0, 0, 0.12);
+  --radius: 12px;
+  --radius-pill: 999px;
+  --ctl-h: 46px;
+  --shadow-sheet: 0 -10px 34px rgba(15, 17, 21, .12);
+  --shadow-card: 0 1px 2px rgba(15, 17, 21, .05);
+  --shadow-pop: 0 6px 22px rgba(15, 17, 21, .16);
+  --ring: 0 0 0 3px rgba(79, 70, 229, .40);
 }
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #0a0a0a;
-    --fg: #ededed;
-    --line: #262626;
-    --muted: #9ca3af;
-    --accent: #818cf8;        /* bharatlas indigo (dark) — text, borders, links */
-    --accent-strong: #4f46e5; /* keep the darker fill so WHITE button text stays AA */
-    --accent-fill: #1e1b4b;   /* deep indigo tint */
-    --sheet: #171717;
-    --shadow: 0 -6px 24px rgba(0, 0, 0, 0.6);
+    --bg: #0b0d10;
+    --surface: #171b21;
+    --card: #14171d;
+    --fg: #eceef2;
+    --muted: #99a1af;        /* AA on --bg */
+    --line: #262c35;
+    --line-strong: #39414d;
+    --accent: #818cf8;
+    --accent-strong: #4f46e5;
+    --accent-fill: #1e1b4b;
+    --danger: #f87171;
+    --amber: #fbbf24;
+    --sheet: #14171d;
+    --shadow-sheet: 0 -10px 34px rgba(0, 0, 0, .6);
+    --shadow-card: 0 1px 2px rgba(0, 0, 0, .35);
+    --shadow-pop: 0 6px 22px rgba(0, 0, 0, .5);
+    --ring: 0 0 0 3px rgba(129, 140, 248, .45);
   }
 }
 
@@ -30,101 +58,194 @@ html, body { margin: 0; height: 100%; }
 body {
   background: var(--bg);
   color: var(--fg);
-  font: 16px/1.45 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font: 400 16px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
   -webkit-text-size-adjust: 100%;
 }
 #app { height: 100dvh; display: flex; flex-direction: column; }
+strong { font-weight: 650; letter-spacing: -.01em; }
 
+/* top bar */
 .topbar {
   display: flex; align-items: center; gap: 10px;
-  padding: max(8px, env(safe-area-inset-top)) 14px 8px;
-  border-bottom: 1px solid var(--line);
-  font-weight: 600;
+  padding: max(10px, env(safe-area-inset-top)) 16px 10px;
+  border-bottom: 1px solid var(--line); background: var(--bg);
+  font-weight: 650; letter-spacing: -.01em;
 }
-.topbar a { color: var(--fg); text-decoration: none; font-size: 22px; }
-.topbar .muted { color: var(--muted); font-weight: 400; font-size: 13px; }
+.topbar a { color: var(--fg); text-decoration: none; font-size: 20px; line-height: 1; }
+.topbar > span:first-of-type { font-size: 17px; }
+.topbar .muted { color: var(--muted); font-weight: 400; font-size: 13px; letter-spacing: 0; }
 
-/* buttons + inputs */
+/* ── action buttons: one shape, one height ─────────────────────────────── */
 button, .btn {
-  min-height: 44px; padding: 0 16px; border-radius: 12px;
-  border: 1px solid var(--line); background: var(--bg); color: var(--fg);
-  font-size: 16px; font-weight: 600; cursor: pointer;
+  min-height: var(--ctl-h); padding: 0 16px; border-radius: var(--radius);
+  border: 1px solid var(--line-strong); background: var(--card); color: var(--fg);
+  font-size: 15px; font-weight: 600; line-height: 1; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  text-decoration: none; box-sizing: border-box; white-space: nowrap;
+  transition: transform .06s ease, background .15s ease, border-color .15s ease, box-shadow .15s ease, opacity .15s ease;
 }
-/* .btn on <a>/<label>: center text in the 44px box + drop the anchor underline
-   so link-buttons (Open/Admin) sit level with adjacent text. */
-.btn { display: inline-flex; align-items: center; justify-content: center; text-decoration: none; box-sizing: border-box; }
+button:active, .btn:active { transform: translateY(1px); }
+button:focus-visible, .btn:focus-visible,
+input:focus-visible, select:focus-visible, textarea:focus-visible { outline: none; box-shadow: var(--ring); }
+button:disabled, .btn:disabled { opacity: .5; cursor: default; transform: none; }
+
 button.primary, .btn.primary {
-  background: var(--accent-strong); border-color: var(--accent-strong); color: #fff; width: 100%;
+  background: var(--accent-strong); border-color: var(--accent-strong); color: #fff;
+  width: 100%; box-shadow: 0 1px 2px rgba(79, 70, 229, .35);
 }
-button.ghost { background: transparent; }
-button.accent { border-color: var(--accent); color: var(--accent); flex: 1; }
-button:disabled { opacity: 0.5; }
-/* equal full-width stacked actions (e.g. Back up / Restore) */
-.wide { width: 100%; display: flex; align-items: center; justify-content: center; gap: 6px; }
+button.ghost { background: transparent; border-color: var(--line); }
+button.accent { border-color: var(--accent); color: var(--accent); background: var(--accent-fill); }
+button.danger { border-color: var(--line-strong); color: var(--danger); background: var(--card); }
+
+/* equal full-width stacked actions (Save / Restore) */
+.wide { width: 100%; }
 .wide + .wide { margin-top: 8px; }
-label { display: block; font-size: 13px; color: var(--muted); margin: 12px 0 4px; }
+
+/* inputs share the button metrics */
+label { display: block; font-size: 13px; font-weight: 500; color: var(--muted); margin: 14px 0 5px; }
 input, textarea, select {
-  width: 100%; min-height: 44px; padding: 10px 12px; font-size: 16px;
-  border: 1px solid var(--line); border-radius: 10px; background: var(--bg); color: var(--fg);
+  width: 100%; min-height: var(--ctl-h); padding: 11px 13px; font-size: 16px; color: var(--fg);
+  border: 1px solid var(--line-strong); border-radius: var(--radius); background: var(--bg);
+  transition: border-color .15s ease, box-shadow .15s ease;
 }
-textarea { min-height: 88px; }
+input::placeholder, textarea::placeholder { color: var(--muted); opacity: .8; }
+textarea { min-height: 92px; line-height: 1.5; }
+
 .row { display: flex; gap: 8px; flex-wrap: wrap; }
-.chip { display: inline-flex; align-items: center; min-height: 40px; padding: 0 14px;
-  border: 1px solid var(--line); border-radius: 999px; }
+
+/* ── toggles / filters: pill ───────────────────────────────────────────── */
+.chip {
+  display: inline-flex; align-items: center; gap: 6px; min-height: 40px; padding: 0 14px;
+  border: 1px solid var(--line-strong); border-radius: var(--radius-pill);
+  background: var(--card); font-size: 14px; font-weight: 600; color: var(--fg); cursor: pointer;
+  transition: background .15s ease, border-color .15s ease, color .15s ease;
+}
 .chip.on { background: var(--accent-fill); border-color: var(--accent); color: var(--accent); }
 
-/* segmented geometry-mode switcher (capture, Phase 4) */
-.seg { display: inline-flex; gap: 0; margin: 4px 0 2px; border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
-.seg button { min-height: 38px; border: 0; border-radius: 0; border-left: 1px solid var(--line); background: var(--bg); font-size: 14px; padding: 0 14px; }
-.seg button:first-child { border-left: 0; }
-.seg button.on { background: var(--accent-strong); color: #fff; }
+/* ── segmented switcher (Point / Line / Area) ──────────────────────────── */
+.seg {
+  display: inline-flex; margin: 6px 0 2px; padding: 3px; gap: 3px;
+  border: 1px solid var(--line-strong); border-radius: var(--radius); background: var(--surface);
+}
+.seg button {
+  min-height: 34px; border: 0; border-radius: 9px; background: transparent;
+  font-size: 14px; font-weight: 600; padding: 0 16px; color: var(--muted);
+}
+.seg button.on { background: var(--accent-strong); color: #fff; box-shadow: var(--shadow-card); }
 
 /* landing / form pages scroll */
-.pad { padding: 16px; overflow: auto; }
-.pad h1 { font-size: 20px; margin: 8px 0 4px; }
-.hint { color: var(--muted); font-size: 13px; }
-.link-box { display: flex; gap: 8px; align-items: center; margin: 6px 0; }
-.link-box code { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  background: var(--accent-fill); padding: 8px 10px; border-radius: 8px; font-size: 12px; }
-.warn { color: #b04a2f; font-size: 13px; }
+.pad { padding: 20px 16px calc(20px + env(safe-area-inset-bottom)); overflow: auto; }
+.pad h1 { font-size: 23px; font-weight: 700; letter-spacing: -.025em; line-height: 1.15; margin: 6px 0 8px; }
+.hint { color: var(--muted); font-size: 13px; line-height: 1.5; font-variant-numeric: tabular-nums; }
+.warn { color: var(--danger); font-size: 13px; line-height: 1.5; }
 
-/* map + capture */
+.link-box {
+  display: flex; gap: 8px; align-items: center; margin: 8px 0;
+  padding: 6px; border: 1px solid var(--line); border-radius: var(--radius); background: var(--card);
+}
+.link-box code {
+  flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  background: var(--surface); padding: 9px 11px; border-radius: 9px; font-size: 12px; color: var(--muted);
+}
+.link-box .btn, .link-box button { min-height: 40px; padding: 0 12px; }
+
+/* empty state — an invitation, not a dead end */
+.empty {
+  text-align: center; color: var(--muted); font-size: 14px; line-height: 1.5;
+  padding: 22px 16px; border: 1px dashed var(--line-strong); border-radius: var(--radius); background: var(--surface);
+}
+
+/* ── map + capture ─────────────────────────────────────────────────────── */
 .map { position: relative; flex: 1; min-height: 0; }
 #map { position: absolute; inset: 0; }
-.crosshair { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
-  width: 34px; height: 34px; pointer-events: none; z-index: 5; }
-.crosshair::before, .crosshair::after { content: ""; position: absolute; background: var(--accent); }
+.crosshair {
+  position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
+  width: 34px; height: 34px; pointer-events: none; z-index: 5;
+}
+.crosshair::before, .crosshair::after { content: ""; position: absolute; background: var(--accent); border-radius: 2px; }
 .crosshair::before { left: 16px; top: 0; width: 2px; height: 34px; }
 .crosshair::after { top: 16px; left: 0; height: 2px; width: 34px; }
 /* while drawing a line/area, ring the crosshair so "Add point here" reads clearly */
-.crosshair--draw::after, .crosshair--draw::before { background: var(--accent-strong); }
-.crosshair--draw { outline: 2px solid var(--accent-strong); outline-offset: 6px; border-radius: 50%; }
-.locate { position: absolute; right: 12px; bottom: 12px; z-index: 6;
-  min-width: 44px; box-shadow: 0 2px 10px rgba(0,0,0,0.2); }
+.crosshair--draw::before, .crosshair--draw::after { background: var(--accent-strong); }
+.crosshair--draw {
+  outline: 2px solid var(--accent-strong); outline-offset: 6px; border-radius: 50%;
+  animation: pulse 1.8s ease-in-out infinite;
+}
+@keyframes pulse { 0%, 100% { outline-color: var(--accent-strong); } 50% { outline-color: color-mix(in srgb, var(--accent-strong) 45%, transparent); } }
+.locate {
+  position: absolute; right: 14px; bottom: 14px; z-index: 6;
+  min-width: var(--ctl-h); padding: 0; font-size: 18px;
+  background: var(--card); box-shadow: var(--shadow-pop);
+}
 
-/* bottom sheet */
-.sheet { background: var(--sheet); border-top: 1px solid var(--line);
-  box-shadow: var(--shadow); border-radius: 16px 16px 0 0;
-  max-height: 62dvh; display: flex; flex-direction: column; }
-.sheet .body { padding: 12px 16px; overflow: auto; }
-.sheet .foot { padding: 10px 16px calc(10px + env(safe-area-inset-bottom)); border-top: 1px solid var(--line); }
+/* ── bottom sheet ──────────────────────────────────────────────────────── */
+.sheet {
+  position: relative; background: var(--sheet); border-top: 1px solid var(--line);
+  box-shadow: var(--shadow-sheet); border-radius: 18px 18px 0 0;
+  max-height: 64dvh; display: flex; flex-direction: column;
+  animation: sheet-in .22s cubic-bezier(.2, .7, .3, 1);
+}
+.sheet::before, .bar::before {
+  content: ""; position: absolute; top: 7px; left: 50%; transform: translateX(-50%);
+  width: 36px; height: 4px; border-radius: 999px; background: var(--line-strong); opacity: .8;
+}
 
-.card { border: 1px solid var(--line); border-radius: 12px; padding: 12px; margin: 10px 0; }
-.card .row button { flex: 1; min-height: 40px; font-size: 14px; padding: 0 10px; }
-.badge { font-size: 11px; font-weight: 700; padding: 1px 8px; border-radius: 999px; border: 1px solid currentColor; white-space: nowrap; text-transform: capitalize; }
-.badge--pending { color: #d97706; }
+/* compact placing controls — keeps the map the centre-piece while marking */
+.bar {
+  position: relative; background: var(--sheet); border-top: 1px solid var(--line);
+  box-shadow: var(--shadow-sheet); border-radius: 18px 18px 0 0;
+  padding: 18px 16px calc(14px + env(safe-area-inset-bottom));
+  display: flex; flex-direction: column; gap: 10px;
+  animation: sheet-in .22s cubic-bezier(.2, .7, .3, 1);
+}
+.bar #cap-help { margin: 0; }
+.bar .seg { align-self: center; }
+.sheet .body { padding: 20px 16px 14px; overflow: auto; }
+.sheet .body > strong { font-size: 17px; }
+.sheet .foot {
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+  border-top: 1px solid var(--line); background: var(--sheet);
+}
+@keyframes sheet-in { from { transform: translateY(14px); } to { transform: translateY(0); } }
+
+/* ── cards + badges ────────────────────────────────────────────────────── */
+.card {
+  border: 1px solid var(--line); border-radius: var(--radius); padding: 13px 14px; margin: 10px 0;
+  background: var(--card); box-shadow: var(--shadow-card);
+}
+.card .row button { flex: 1; min-height: 42px; font-size: 14px; padding: 0 8px; }
+.badge {
+  font-size: 11px; font-weight: 700; letter-spacing: .01em; padding: 2px 9px;
+  border-radius: var(--radius-pill); border: 1px solid currentColor; white-space: nowrap; text-transform: capitalize;
+}
+.badge--pending { color: var(--amber); }
 .badge--published { color: var(--accent); }
-.badge--rejected { color: #dc2626; }
-.toast { position: fixed; left: 50%; bottom: 80px; transform: translateX(-50%);
-  background: var(--fg); color: var(--bg); padding: 10px 16px; border-radius: 999px;
-  font-size: 14px; z-index: 20; opacity: 0; transition: opacity .2s; }
-.toast.show { opacity: 1; }
+.badge--rejected { color: var(--danger); }
 
-/* loading states */
+/* toast — direction, not decoration */
+.toast {
+  position: fixed; left: 50%; bottom: calc(84px + env(safe-area-inset-bottom));
+  transform: translate(-50%, 8px); background: var(--fg); color: var(--bg);
+  padding: 11px 18px; border-radius: var(--radius-pill); box-shadow: var(--shadow-pop);
+  font-size: 14px; font-weight: 500; max-width: min(90vw, 420px); text-align: center;
+  z-index: 20; opacity: 0; transition: opacity .2s ease, transform .2s ease;
+}
+.toast.show { opacity: 1; transform: translate(-50%, 0); }
+
+/* ── loading ───────────────────────────────────────────────────────────── */
 .center { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; text-align: center; }
-.spinner { width: 20px; height: 20px; border: 3px solid var(--line); border-top-color: var(--accent);
-  border-radius: 50%; display: inline-block; vertical-align: middle; animation: spin .8s linear infinite; }
+.spinner {
+  width: 20px; height: 20px; border: 3px solid var(--line); border-top-color: var(--accent);
+  border-radius: 50%; display: inline-block; vertical-align: middle; animation: spin .8s linear infinite;
+}
 @keyframes spin { to { transform: rotate(360deg); } }
-.map-loading { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); z-index: 4;
-  background: var(--sheet); border: 1px solid var(--line); border-radius: 999px; padding: 8px 16px;
-  font-size: 14px; color: var(--muted); display: flex; align-items: center; gap: 8px; }
+.map-loading {
+  position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); z-index: 4;
+  background: var(--sheet); border: 1px solid var(--line); border-radius: 999px; padding: 9px 16px;
+  box-shadow: var(--shadow-pop); font-size: 14px; color: var(--muted); display: flex; align-items: center; gap: 8px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: .001ms !important; animation-iteration-count: 1 !important; transition-duration: .001ms !important; }
+}

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -50,6 +50,9 @@ button, .btn {
   border: 1px solid var(--line); background: var(--bg); color: var(--fg);
   font-size: 16px; font-weight: 600; cursor: pointer;
 }
+/* .btn on <a>/<label>: center text in the 44px box + drop the anchor underline
+   so link-buttons (Open/Admin) sit level with adjacent text. */
+.btn { display: inline-flex; align-items: center; justify-content: center; text-decoration: none; box-sizing: border-box; }
 button.primary, .btn.primary {
   background: var(--accent-strong); border-color: var(--accent-strong); color: #fff; width: 100%;
 }


### PR DESCRIPTION
Follow-up to #152, a round of collect UX work driven by testing feedback. All under `collect/` (frontend + CSS only; no API/schema change).

## Design system ("a precise instrument")
Ends the button shape/size drift with **one control system** on the bharatlas theme: a single action-button family (one height/radius, press + focus-ring states), pill toggles, one segmented switcher; layered surface/elevation tokens for depth; refined bottom-sheet (grab handle), cards, chips, status badges; tasteful micro-interactions; friendly empty states. Light + dark, **Lighthouse a11y 100**, `prefers-reduced-motion` respected.

## Map-first, two-step capture
The **map is now the centre-piece while marking**: a compact place-bar (position the crosshair, place the point/line/area) and a details form that slides up **only once a shape is placed**. Crosshair drawing stays but reads clearly ("+ Add point here", ringed crosshair, "N points · add M more").

## Admin point manager + CRUD
Admin now **lands on a Manage screen** (was the contributor capture screen): every marked point with per-point **Approve / Reject / Edit / Delete**, status badges, filter chips (All / Pending / Approved / Rejected), the locate context (district, state), mint-links, publish, and "+ Add points". Edit opens the record editor with the admin token. Card actions are split into two rows so labels never wrap at 360px.

## Smaller fixes
- Link-buttons (Open/Admin) align with row text, no anchor underline.
- Home backup buttons are honest: **"Save / Restore my map links"** (the file holds admin links, not the collected points).

## Verification
55 vitest green · typecheck + build clean · verified in Chrome at 390px (home, capture place-bar + details sheet, admin Manage, both light + dark) · no console errors · Lighthouse mobile a11y 100 / best-practices 100.

## Not in this PR (still to scope)
Multi-format data download (GeoJSON/CSV/KML/Parquet) and bharatlas reference layers / basemap — both are real features awaiting design decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)