### PR TITLE
collect: data downloads (GeoJSON/CSV/KML) + basemap & bharatlas reference layer

### DIFF
--- a/collect/package-lock.json
+++ b/collect/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "collect",
       "dependencies": {
-        "maplibre-gl": "^4.7.1"
+        "maplibre-gl": "^4.7.1",
+        "pmtiles": "^3.2.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260520.1",
@@ -893,6 +894,15 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.22",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.22.tgz",
+      "integrity": "sha512-h3lhECYEKDasG7LFHu+GiHqAvsgLuQvlJvVZzJDGONo3sEL+wUOqSFLnwkZlK0qVxnxbuGFW8iBlJNYs5wgndA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/mapbox__point-geometry": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
@@ -1185,6 +1195,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1432,6 +1448,16 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pmtiles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-3.2.1.tgz",
+      "integrity": "sha512-3R4fBwwoli5mw7a6t1IGwOtfmcSAODq6Okz0zkXhS1zi9sz1ssjjIfslwPvcWw5TNhdjNBUg9fgfPLeqZlH6ng==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/leaflet": "^1.9.8",
+        "fflate": "^0.8.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.26",

--- a/collect/package.json
+++ b/collect/package.json
@@ -11,7 +11,8 @@
     "build": "vitest run && npm run typecheck && vite build"
   },
   "dependencies": {
-    "maplibre-gl": "^4.7.1"
+    "maplibre-gl": "^4.7.1",
+    "pmtiles": "^3.2.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260520.1",

--- a/collect/public/_headers
+++ b/collect/public/_headers
@@ -1,11 +1,12 @@
 # Cloudflare Pages security headers for collect. CSP allows exactly what the app
-# needs: self, Turnstile (challenges.cloudflare.com), and CARTO raster tiles.
+# needs: self, Turnstile, the basemap tile hosts (CARTO / Esri imagery / OpenTopo),
+# the bharatlas catalogue API + its R2 host for pmtiles reference overlays.
 # noindex keeps unlisted collections off search (spec). Verify in prod after
-# the first deploy — a too-strict CSP would break the map or Turnstile.
+# the first deploy — a too-strict CSP would break the map, tiles, or Turnstile.
 /*
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
   X-Robots-Tag: noindex
   Permissions-Policy: geolocation=(self), camera=()
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.basemaps.cartocdn.com; connect-src 'self' https://*.basemaps.cartocdn.com https://challenges.cloudflare.com; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com; form-action 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://services.arcgisonline.com https://*.tile.opentopomap.org; connect-src 'self' https://*.basemaps.cartocdn.com https://challenges.cloudflare.com https://bharatlas.com https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://services.arcgisonline.com https://*.tile.opentopomap.org; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com; form-action 'self'

--- a/collect/public/schema/v1.json
+++ b/collect/public/schema/v1.json
@@ -17,6 +17,15 @@
       "maxItems": 3,
       "items": { "type": "string" }
     },
+    "basemap": { "enum": ["positron", "satellite", "topo"] },
+    "reference_layer": {
+      "type": "object",
+      "required": ["id", "pmtiles_url"],
+      "properties": {
+        "id": { "type": "string" },
+        "pmtiles_url": { "type": "string", "pattern": "^https://" }
+      }
+    },
     "fields": {
       "type": "array",
       "maxItems": 20,

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -4,17 +4,19 @@
 // — for admin — a review queue + publish. Mobile-first.
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { BASEMAP, INDIA_CENTER } from './basemap';
+import { styleFor, INDIA_CENTER } from './basemap';
+import { addReferenceOverlay, setReferenceVisible } from './geo/reference';
 import { parseCtx, apiJson, type Ctx } from './api';
 import { turnstileToken } from './turnstile';
 import { validateRecordProperties, type Field } from './schema/validate-record';
 import { orderedModes, drawGeometry, type GeomMode, type Coord } from './geo/draw';
 import { representativeCoord } from './geo/admin-ctx';
 import { escapeHtml } from './util';
+import { toGeoJSON, toCSV, toKML, type ExportFeature } from './export/formats';
 interface Counts { pending: number; published: number; total: number; rejected: number; }
 interface Meta {
   id: string; name: string; purpose: string; status: string; moderation: number;
-  schema: { geometry: string[]; fields: Field[] }; counts: Counts;
+  schema: { geometry: string[]; fields: Field[]; basemap?: string; reference_layer?: { id: string; pmtiles_url: string } | null }; counts: Counts;
 }
 interface Feature { id: string; geometry: { type: string; coordinates: number[] }; properties: Record<string, unknown>; }
 
@@ -86,12 +88,13 @@ async function boot(): Promise<void> {
       <div class="crosshair" aria-hidden="true" ${isView ? 'style="display:none"' : ''}></div>
       <div class="map-loading" id="maploading"><span class="spinner"></span> Loading map…</div>
       ${isView ? '' : '<button class="locate" id="locate" aria-label="Use my location">◎</button>'}
+      ${meta.schema.reference_layer ? '<button class="locate" id="reftoggle" aria-pressed="true" style="left:12px;top:12px;right:auto;bottom:auto;width:auto;padding:0 12px">◪ Layer</button>' : ''}
       ${isAdmin ? `<button class="locate" id="manage" aria-label="Manage map${meta.counts.pending ? `, ${meta.counts.pending} pending review` : ''}" style="left:12px;right:auto;bottom:76px;width:auto;padding:0 14px">⚙${meta.counts.pending ? ` ${meta.counts.pending}` : ''}</button>` : ''}
     </div>
     <div id="panel"></div>`;
 
   map = new maplibregl.Map({
-    container: 'map', style: BASEMAP, center: INDIA_CENTER, zoom: 4,
+    container: 'map', style: styleFor(meta.schema.basemap), center: INDIA_CENTER, zoom: 4,
     attributionControl: false,
   });
   // Attribution bottom-left so it never sits under the locate button (bottom-right).
@@ -102,8 +105,17 @@ async function boot(): Promise<void> {
   map.on('load', () => {
     document.getElementById('maploading')?.remove();
     if (!isView && allowsShapes) setupDrawLayers();
+    if (meta.schema.reference_layer) void addReferenceOverlay(map, meta.schema.reference_layer.pmtiles_url).catch(() => {});
     void loadRecords();
   });
+
+  const reftoggle = document.getElementById('reftoggle') as HTMLButtonElement | null;
+  if (reftoggle) reftoggle.onclick = () => {
+    const on = reftoggle.getAttribute('aria-pressed') !== 'true';
+    reftoggle.setAttribute('aria-pressed', String(on));
+    reftoggle.style.opacity = on ? '1' : '0.55';
+    setReferenceVisible(map, on);
+  };
 
   if (!isView) {
     const locate = document.getElementById('locate') as HTMLButtonElement;
@@ -343,6 +355,13 @@ async function manageSheet(): Promise<void> {
         <button id="mint-view">+ View-only link</button>
       </div>
       <div id="minted"></div>
+      <strong style="display:block;margin-top:14px">Download the data</strong>
+      <p class="hint">Every collected point, to use anywhere.</p>
+      <div class="row">
+        <button data-dl="geojson">GeoJSON</button>
+        <button data-dl="csv">CSV</button>
+        <button data-dl="kml">KML</button>
+      </div>
     </div>
     <div class="foot row">
       <button id="back">+ Add points</button>
@@ -378,8 +397,35 @@ async function manageSheet(): Promise<void> {
   };
   (document.getElementById('mint-edit') as HTMLButtonElement).onclick = () => mint('edit');
   (document.getElementById('mint-view') as HTMLButtonElement).onclick = () => mint('view');
+  document.querySelectorAll<HTMLButtonElement>('button[data-dl]').forEach((b) => {
+    b.onclick = () => void downloadData(b.dataset.dl as 'geojson' | 'csv' | 'kml');
+  });
 
   void renderPoints();
+}
+
+const slug = (s: string): string => (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'collect-map';
+
+// Fetch every record and hand the author a file — no server round-trip.
+async function downloadData(format: 'geojson' | 'csv' | 'kml'): Promise<void> {
+  try {
+    const fc = await apiJson<{ features: ExportFeature[] }>(`/collections/${ctx.id}/records?limit=100000`, ctx.token);
+    const features = fc.features || [];
+    if (!features.length) { toast('No points to download yet'); return; }
+    const keys = meta.schema.fields.filter((f) => !f.deleted).map((f) => f.key);
+    const [content, mime, ext] =
+      format === 'geojson' ? [toGeoJSON(features, keys), 'application/geo+json', 'geojson']
+      : format === 'csv' ? [toCSV(features, keys), 'text/csv', 'csv']
+      : [toKML(features, keys, meta.name), 'application/vnd.google-earth.kml+xml', 'kml'];
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([content], { type: mime }));
+    a.download = `${slug(meta.name)}.${ext}`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+    toast(`Downloaded ${features.length} point${features.length === 1 ? '' : 's'} as ${ext.toUpperCase()}`);
+  } catch (e) {
+    toast((e as Error).message);
+  }
 }
 
 function activeFilter(): string {
@@ -511,7 +557,7 @@ async function recordEditor(): Promise<void> {
     id: string; status: string; contributor: string | null;
     geometry: { type: string; coordinates: number[] };
     properties: Record<string, unknown>;
-    schema: { geometry: string[]; fields: Field[] }; collection_name: string;
+    schema: { geometry: string[]; fields: Field[]; basemap?: string }; collection_name: string;
   }>(`/records/${ctx.recordId}`, ctx.token);
   const fields = rec.schema.fields.filter((f) => !f.deleted);
   const isPoint = rec.geometry.type === 'Point';
@@ -541,7 +587,7 @@ async function recordEditor(): Promise<void> {
       </div>
     </div></div>`;
 
-  map = new maplibregl.Map({ container: 'map', style: BASEMAP, center, zoom: isPoint ? 16 : 14, attributionControl: false });
+  map = new maplibregl.Map({ container: 'map', style: styleFor(rec.schema.basemap), center, zoom: isPoint ? 16 : 14, attributionControl: false });
   map.addControl(new maplibregl.AttributionControl({ compact: true }), 'bottom-left');
   map.on('load', () => {
     document.getElementById('maploading')?.remove();

--- a/collect/src/basemap.ts
+++ b/collect/src/basemap.ts
@@ -1,20 +1,44 @@
 import type { StyleSpecification } from 'maplibre-gl';
 
-// CARTO Positron raster (same source web's positron basemap uses) — no API key.
-export const BASEMAP: StyleSpecification = {
-  version: 8,
-  sources: {
-    carto: {
-      type: 'raster',
-      tiles: [
-        'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
-        'https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
-      ],
-      tileSize: 256,
-      attribution: '© CARTO · © OpenStreetMap contributors',
-    },
-  },
-  layers: [{ id: 'carto', type: 'raster', source: 'carto' }],
+// Basemap options an author can choose per collection. Raster styles, no API key.
+export type BasemapId = 'positron' | 'satellite' | 'topo';
+
+export const BASEMAPS: { id: BasemapId; name: string }[] = [
+  { id: 'positron', name: 'Light' },
+  { id: 'satellite', name: 'Satellite' },
+  { id: 'topo', name: 'Topographic' },
+];
+
+function raster(id: string, tiles: string[], attribution: string, maxzoom?: number): StyleSpecification {
+  const source: Record<string, unknown> = { type: 'raster', tiles, tileSize: 256, attribution };
+  if (maxzoom) source.maxzoom = maxzoom;
+  return { version: 8, sources: { [id]: source }, layers: [{ id, type: 'raster', source: id }] } as StyleSpecification;
+}
+
+const STYLES: Record<BasemapId, StyleSpecification> = {
+  positron: raster(
+    'basemap',
+    ['a', 'b', 'c', 'd'].map((s) => `https://${s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png`),
+    '© CARTO · © OpenStreetMap contributors',
+  ),
+  satellite: raster(
+    'basemap',
+    ['https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+    '© Esri, Maxar, Earthstar Geographics',
+    19,
+  ),
+  topo: raster(
+    'basemap',
+    ['a', 'b', 'c'].map((s) => `https://${s}.tile.opentopomap.org/{z}/{x}/{y}.png`),
+    '© OpenTopoMap (CC-BY-SA) · © OpenStreetMap contributors',
+    17,
+  ),
 };
 
+export function styleFor(id?: string | null): StyleSpecification {
+  return STYLES[(id as BasemapId)] ?? STYLES.positron;
+}
+
+// Back-compat default (positron).
+export const BASEMAP = STYLES.positron;
 export const INDIA_CENTER: [number, number] = [78.9, 22];

--- a/collect/src/export/formats.ts
+++ b/collect/src/export/formats.ts
@@ -1,0 +1,83 @@
+// Client-side exporters for a collection's records: GeoJSON, CSV, KML.
+// Input is the /records FeatureCollection features (properties carry the author
+// fields plus _status / _contributor / _admin_ctx). Output is a plain string the
+// UI turns into a Blob download — no server round-trip, no new dependency.
+
+import { representativeCoord } from '../geo/admin-ctx';
+
+export interface ExportFeature {
+  geometry: { type?: string; coordinates?: unknown } | null;
+  properties: Record<string, unknown>;
+}
+
+// Author fields + contributor/status + flattened admin context; drop _internal keys.
+function tidyProps(p: Record<string, unknown>, fieldKeys: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const k of fieldKeys) if (p[k] != null) out[k] = p[k];
+  if (p._contributor) out.contributor = p._contributor;
+  if (p._status) out.status = p._status;
+  const ctx = p._admin_ctx as Record<string, string> | null | undefined;
+  if (ctx) for (const [k, v] of Object.entries(ctx)) if (!(k in out)) out[k] = v;
+  return out;
+}
+
+export function toGeoJSON(features: ExportFeature[], fieldKeys: string[]): string {
+  const fc = {
+    type: 'FeatureCollection',
+    features: features.map((f) => ({ type: 'Feature', geometry: f.geometry, properties: tidyProps(f.properties, fieldKeys) })),
+  };
+  return JSON.stringify(fc, null, 2);
+}
+
+function csvCell(v: unknown): string {
+  if (v == null) return '';
+  const s = Array.isArray(v) ? v.join('|') : String(v);
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+export function toCSV(features: ExportFeature[], fieldKeys: string[]): string {
+  const cols = ['lng', 'lat', 'geometry_type', ...fieldKeys, 'contributor', 'status', 'state', 'district'];
+  const lines = [cols.map(csvCell).join(',')];
+  for (const f of features) {
+    const p = f.properties || {};
+    const c = representativeCoord(f.geometry);
+    const ctx = (p._admin_ctx as Record<string, string>) || {};
+    const row = [
+      c ? c[0] : '', c ? c[1] : '', f.geometry?.type ?? '',
+      ...fieldKeys.map((k) => p[k]),
+      p._contributor ?? '', p._status ?? '', ctx.state ?? '', ctx.district ?? '',
+    ];
+    lines.push(row.map(csvCell).join(','));
+  }
+  return lines.join('\n');
+}
+
+function xml(v: unknown): string {
+  return String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+function coordStr(c: number[]): string { return `${c[0]},${c[1]}`; }
+function ringStr(ring: number[][]): string { return ring.map(coordStr).join(' '); }
+function geomKml(g: ExportFeature['geometry']): string {
+  const geom = g as { type?: string; coordinates?: number[] & number[][] & number[][][] };
+  if (!geom?.type) return '';
+  if (geom.type === 'Point') return `<Point><coordinates>${coordStr(geom.coordinates as number[])}</coordinates></Point>`;
+  if (geom.type === 'LineString') return `<LineString><coordinates>${ringStr(geom.coordinates as number[][])}</coordinates></LineString>`;
+  if (geom.type === 'Polygon') {
+    return `<Polygon><outerBoundaryIs><LinearRing><coordinates>${ringStr((geom.coordinates as number[][][])[0])}</coordinates></LinearRing></outerBoundaryIs></Polygon>`;
+  }
+  return '';
+}
+
+export function toKML(features: ExportFeature[], fieldKeys: string[], name: string): string {
+  const marks = features.map((f) => {
+    const p = f.properties || {};
+    const title = (typeof p.name === 'string' && p.name)
+      || fieldKeys.map((k) => p[k]).find((v) => typeof v === 'string' && v) || 'point';
+    const tidy = tidyProps(p, fieldKeys);
+    const data = Object.entries(tidy)
+      .map(([k, v]) => `<Data name="${xml(k)}"><value>${xml(Array.isArray(v) ? v.join('|') : v)}</value></Data>`)
+      .join('');
+    return `<Placemark><name>${xml(title)}</name><ExtendedData>${data}</ExtendedData>${geomKml(f.geometry)}</Placemark>`;
+  }).join('');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<kml xmlns="http://www.opengis.net/kml/2.2"><Document><name>${xml(name)}</name>${marks}</Document></kml>`;
+}

--- a/collect/src/geo/catalog.ts
+++ b/collect/src/geo/catalog.ts
@@ -1,0 +1,17 @@
+// bharatlas catalogue search — a plain fetch, no map/pmtiles deps, so the create
+// form (landing entry) stays light and never pulls MapLibre.
+
+const BHARATLAS = 'https://bharatlas.com';
+
+export interface RefLayer { id: string; label: string; category: string; pmtiles_url: string; }
+
+/** Search the bharatlas catalogue (CORS-open) for layers that have pmtiles. */
+export async function searchLayers(q: string): Promise<RefLayer[]> {
+  const url = `${BHARATLAS}/api/v1/layers?limit=40${q ? `&q=${encodeURIComponent(q)}` : ''}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`catalogue ${res.status}`);
+  const body = (await res.json()) as { data?: Array<{ id: string; category?: string; downloads?: { pmtiles?: { url?: string } } }> };
+  return (body.data || [])
+    .filter((l) => l.downloads?.pmtiles?.url)
+    .map((l) => ({ id: l.id, label: l.id, category: l.category || '', pmtiles_url: l.downloads!.pmtiles!.url! }));
+}

--- a/collect/src/geo/reference.ts
+++ b/collect/src/geo/reference.ts
@@ -1,0 +1,40 @@
+// Reference layers (Phase 4/5): let an author attach ONE curated bharatlas layer
+// as a read-only overlay to orient contributors (ward boundaries on a footpath
+// survey, forest boundaries on a tree census). Rendered as pmtiles via MapLibre —
+// the same stack /view uses. A capture aid, never part of a record's geometry.
+
+import maplibregl from 'maplibre-gl';
+import { Protocol, PMTiles } from 'pmtiles';
+
+const ACCENT = '#4f46e5';
+
+let protocol: Protocol | null = null;
+function proto(): Protocol {
+  if (!protocol) {
+    protocol = new Protocol();
+    maplibregl.addProtocol('pmtiles', protocol.tile);
+  }
+  return protocol;
+}
+
+/** Add the chosen layer as a low-key overlay. source-layer = first vector layer. */
+export async function addReferenceOverlay(map: maplibregl.Map, pmtilesUrl: string): Promise<void> {
+  if (map.getSource('ref')) return;
+  const p = proto();
+  const pm = new PMTiles(pmtilesUrl);
+  p.add(pm);
+  const meta = (await pm.getMetadata()) as { vector_layers?: Array<{ id: string }> };
+  const sourceLayer = meta?.vector_layers?.[0]?.id;
+  if (!sourceLayer) return;
+  const header = await pm.getHeader();
+  map.addSource('ref', { type: 'vector', url: `pmtiles://${pmtilesUrl}`, minzoom: header.minZoom, maxzoom: header.maxZoom });
+  map.addLayer({ id: 'ref-fill', type: 'fill', source: 'ref', 'source-layer': sourceLayer, filter: ['==', ['geometry-type'], 'Polygon'], paint: { 'fill-color': ACCENT, 'fill-opacity': 0.07 } });
+  map.addLayer({ id: 'ref-line', type: 'line', source: 'ref', 'source-layer': sourceLayer, paint: { 'line-color': ACCENT, 'line-width': 1.2, 'line-opacity': 0.5 } });
+  map.addLayer({ id: 'ref-pt', type: 'circle', source: 'ref', 'source-layer': sourceLayer, filter: ['==', ['geometry-type'], 'Point'], paint: { 'circle-radius': 3, 'circle-color': ACCENT, 'circle-opacity': 0.55 } });
+}
+
+export function setReferenceVisible(map: maplibregl.Map, on: boolean): void {
+  for (const id of ['ref-fill', 'ref-line', 'ref-pt']) {
+    if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', on ? 'visible' : 'none');
+  }
+}

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -4,6 +4,8 @@ import { apiJson } from './api';
 import { turnstileToken } from './turnstile';
 import { mountSchemaBuilder } from './schema-builder';
 import { escapeHtml } from './util';
+import { BASEMAPS } from './basemap';
+import { searchLayers, type RefLayer } from './geo/catalog';
 
 const OPEN_LICENCES: [string, string][] = [
   ['CC-BY-4.0', 'CC BY 4.0 (credit required)'],
@@ -103,6 +105,12 @@ function createForm() {
         <button type="button" class="chip" data-g="line">Lines</button>
         <button type="button" class="chip" data-g="polygon">Areas</button>
       </div>
+      <label>Map background</label>
+      <select id="basemap">${BASEMAPS.map((b) => `<option value="${b.id}">${b.name}</option>`).join('')}</select>
+      <label>Reference layer <span class="hint">(optional, show a bharatlas layer for context)</span></label>
+      <input id="ref-search" placeholder="Search layers: forest, wards, hospitals…" autocomplete="off" />
+      <div id="ref-results" class="ref-results"></div>
+      <div id="ref-chosen"></div>
       <label>Licence <span class="hint">(open licences only, the map publishes openly)</span></label>
       <select id="license">${OPEN_LICENCES.map(([id, l]) => `<option value="${id}">${l}</option>`).join('')}</select>
       <label>Data year <span class="hint">(optional)</span></label>
@@ -127,6 +135,39 @@ function createForm() {
     };
   });
 
+  // Reference-layer picker: search the bharatlas catalogue, choose at most one.
+  let chosenRef: RefLayer | null = null;
+  let lastResults: RefLayer[] = [];
+  let refTimer: number | undefined;
+  const refSearch = app.querySelector<HTMLInputElement>('#ref-search')!;
+  const refResults = app.querySelector<HTMLElement>('#ref-results')!;
+  const refChosen = app.querySelector<HTMLElement>('#ref-chosen')!;
+  const renderChosen = (): void => {
+    refChosen.innerHTML = chosenRef
+      ? `<div class="link-box"><code>${escapeHtml(chosenRef.label)}${chosenRef.category ? ` · ${escapeHtml(chosenRef.category)}` : ''}</code><button type="button" id="ref-clear">Remove</button></div>`
+      : '';
+    const clr = app.querySelector<HTMLButtonElement>('#ref-clear');
+    if (clr) clr.onclick = () => { chosenRef = null; renderChosen(); };
+  };
+  refSearch.oninput = () => {
+    clearTimeout(refTimer);
+    const q = refSearch.value.trim();
+    if (!q) { refResults.innerHTML = ''; return; }
+    refTimer = window.setTimeout(async () => {
+      try {
+        lastResults = await searchLayers(q);
+        refResults.innerHTML = lastResults.length
+          ? lastResults.slice(0, 8).map((l, i) => `<button type="button" class="ref-opt" data-i="${i}">${escapeHtml(l.label)}<span class="hint">${escapeHtml(l.category)}</span></button>`).join('')
+          : '<p class="hint">No layers found.</p>';
+        refResults.querySelectorAll<HTMLButtonElement>('.ref-opt').forEach((b) => {
+          b.onclick = () => { chosenRef = lastResults[Number(b.dataset.i)]; refResults.innerHTML = ''; refSearch.value = ''; renderChosen(); };
+        });
+      } catch {
+        refResults.innerHTML = '<p class="hint">Couldn\'t reach the catalogue, try again.</p>';
+      }
+    }, 300);
+  };
+
   app.querySelector<HTMLButtonElement>('#create')!.onclick = async (ev) => {
     const btn = ev.currentTarget as HTMLButtonElement;
     const err = app.querySelector('#err')!;
@@ -149,7 +190,13 @@ function createForm() {
           purpose: app.querySelector<HTMLTextAreaElement>('#purpose')!.value,
           license: app.querySelector<HTMLSelectElement>('#license')!.value,
           data_year: dataYear,
-          schema_doc: { version: 1, geometry: [...geom], fields },
+          schema_doc: {
+            version: 1,
+            geometry: [...geom],
+            fields,
+            basemap: app.querySelector<HTMLSelectElement>('#basemap')!.value,
+            reference_layer: chosenRef ? { id: chosenRef.id, pmtiles_url: chosenRef.pmtiles_url } : undefined,
+          },
           turnstile_token,
         }),
       })).links;

--- a/collect/src/schema/validate-collection.ts
+++ b/collect/src/schema/validate-collection.ts
@@ -9,6 +9,7 @@ export const FIELD_TYPES = [
   'text', 'paragraph', 'number', 'select', 'multiselect', 'date', 'url',
 ] as const;
 export const GEOMETRY_TYPES = ['point', 'line', 'polygon'] as const;
+export const BASEMAP_IDS = ['positron', 'satellite', 'topo'] as const;
 
 const KEY_RE = /^[a-z][a-z0-9_]*$/;
 const MAX_FIELDS = 20;
@@ -63,6 +64,19 @@ export function validateSchemaDoc(input: unknown): Result<Record<string, unknown
   if (refs !== undefined) {
     if (!Array.isArray(refs) || !refs.every(isStr)) return fail('reference_layers must be a string array');
     if (refs.length > MAX_REF_LAYERS) return fail(`too many reference layers (max ${MAX_REF_LAYERS})`);
+  }
+
+  // Map options (Phase 4/5): an author-chosen basemap + one bharatlas overlay.
+  if (doc.basemap !== undefined && !BASEMAP_IDS.includes(doc.basemap as (typeof BASEMAP_IDS)[number])) {
+    return fail(`unknown basemap: ${String(doc.basemap)}`);
+  }
+  const ref = doc.reference_layer;
+  if (ref !== undefined && ref !== null) {
+    if (typeof ref !== 'object' || Array.isArray(ref)) return fail('reference_layer must be an object');
+    const r = ref as Record<string, unknown>;
+    if (!isStr(r.id) || !isStr(r.pmtiles_url) || !r.pmtiles_url.startsWith('https://')) {
+      return fail('reference_layer needs id and an https pmtiles_url');
+    }
   }
   return { ok: true, value: doc };
 }

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -150,6 +150,11 @@ textarea { min-height: 92px; line-height: 1.5; }
 }
 .link-box .btn, .link-box button { min-height: 40px; padding: 0 12px; }
 
+/* reference-layer search results (create form) */
+.ref-results { display: flex; flex-direction: column; gap: 6px; margin-top: 6px; max-height: 230px; overflow: auto; }
+.ref-opt { width: 100%; justify-content: space-between; gap: 10px; }
+.ref-opt .hint { font-weight: 400; text-transform: capitalize; }
+
 /* empty state — an invitation, not a dead end */
 .empty {
   text-align: center; color: var(--muted); font-size: 14px; line-height: 1.5;

--- a/collect/tests/formats.test.ts
+++ b/collect/tests/formats.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { toGeoJSON, toCSV, toKML } from '../src/export/formats';
+
+const FIELDS = ['name', 'cond', 'tags'];
+const FEATURES = [
+  {
+    geometry: { type: 'Point', coordinates: [77.61, 12.98] },
+    properties: { name: 'MG Road', cond: 'Good', tags: ['a', 'b'], _status: 'published', _contributor: 'Ravi', _admin_ctx: { state: 'KARNATAKA', district: 'Bengaluru Urban' } },
+  },
+  {
+    geometry: { type: 'LineString', coordinates: [[77.60, 12.97], [77.62, 12.99]] },
+    properties: { name: 'Church St, "the edge"', cond: 'Blocked', _status: 'pending', _contributor: null, _admin_ctx: null },
+  },
+];
+
+describe('toGeoJSON', () => {
+  it('emits a FeatureCollection with tidy properties (no _internal keys)', () => {
+    const fc = JSON.parse(toGeoJSON(FEATURES, FIELDS));
+    expect(fc.type).toBe('FeatureCollection');
+    expect(fc.features).toHaveLength(2);
+    expect(fc.features[0].geometry).toEqual({ type: 'Point', coordinates: [77.61, 12.98] });
+    expect(fc.features[0].properties).toMatchObject({
+      name: 'MG Road', cond: 'Good', tags: ['a', 'b'], contributor: 'Ravi', status: 'published', state: 'KARNATAKA', district: 'Bengaluru Urban',
+    });
+    expect(fc.features[0].properties._status).toBeUndefined();
+    expect(fc.features[0].properties._admin_ctx).toBeUndefined();
+  });
+});
+
+describe('toCSV', () => {
+  it('has a header + one row per feature, with representative lng/lat', () => {
+    const rows = toCSV(FEATURES, FIELDS).split('\n');
+    expect(rows[0]).toBe('lng,lat,geometry_type,name,cond,tags,contributor,status,state,district');
+    expect(rows[1]).toBe('77.61,12.98,Point,MG Road,Good,a|b,Ravi,published,KARNATAKA,Bengaluru Urban');
+    expect(rows).toHaveLength(3);
+  });
+  it('quotes cells with commas/quotes and uses the line first vertex', () => {
+    const row = toCSV([FEATURES[1]], FIELDS).split('\n')[1];
+    expect(row.startsWith('77.6,12.97,LineString,')).toBe(true);
+    expect(row).toContain('"Church St, ""the edge"""');
+  });
+});
+
+describe('toKML', () => {
+  it('wraps features as placemarks with matching geometry + escaped names', () => {
+    const kml = toKML(FEATURES, FIELDS, 'Footpath survey');
+    expect(kml).toContain('<name>Footpath survey</name>');
+    expect(kml).toContain('<Point><coordinates>77.61,12.98</coordinates></Point>');
+    expect(kml).toContain('<LineString><coordinates>77.6,12.97 77.62,12.99</coordinates></LineString>');
+    expect(kml).toContain('Church St, &quot;the edge&quot;');
+    expect(kml).toContain('<Data name="cond"><value>Good</value></Data>');
+  });
+});

--- a/collect/tests/validate-collection.test.ts
+++ b/collect/tests/validate-collection.test.ts
@@ -75,4 +75,12 @@ describe('validateSchemaDoc (the meta-schema check)', () => {
     expect(validateSchemaDoc({ ...goodSchema, fields: many }).ok).toBe(false);
     expect(validateSchemaDoc({ ...goodSchema, reference_layers: ['a', 'b', 'c', 'd'] }).ok).toBe(false);
   });
+
+  it('accepts a valid basemap + reference_layer, rejects bad ones', () => {
+    expect(validateSchemaDoc({ ...goodSchema, basemap: 'satellite' }).ok).toBe(true);
+    expect(validateSchemaDoc({ ...goodSchema, basemap: 'streets' }).ok).toBe(false);
+    expect(validateSchemaDoc({ ...goodSchema, reference_layer: { id: 'soi_forests', pmtiles_url: 'https://r2.dev/x.pmtiles' } }).ok).toBe(true);
+    expect(validateSchemaDoc({ ...goodSchema, reference_layer: { id: 'x', pmtiles_url: 'http://insecure' } }).ok).toBe(false);
+    expect(validateSchemaDoc({ ...goodSchema, reference_layer: { id: 'x' } }).ok).toBe(false);
+  });
 });


### PR DESCRIPTION
Two author/admin features, both under `collect/`.

## Download the data (GeoJSON / CSV / KML)
The admin **Manage** screen gains a **Download the data** section — every collected record as **GeoJSON**, **CSV**, or **KML**, generated client-side (no server round-trip, no new dependency). Pure converters in `src/export/formats.ts`, TDD'd: tidy properties (author fields + contributor/status + flattened admin context), representative lng/lat, CSV quoting, KML placemarks.

## Map layers — basemap + one bharatlas reference overlay
An author picks a **basemap** (Light / Satellite / Topographic) and, optionally, **one bharatlas layer** as a read-only **reference overlay** — so a forest survey can use satellite imagery + forest boundaries, not just wards. The create form searches the bharatlas catalogue (`/api/v1/layers`, CORS-open); the choice is stored in `schema_doc` (`basemap` + `reference_layer{id,pmtiles_url}`) and rendered on the capture / view / record maps via **pmtiles**, with a **◪ Layer** show/hide toggle.

- `basemap.ts` → a registry + `styleFor()` (adds Esri imagery + OpenTopo raster).
- `geo/catalog.ts` (`searchLayers`, no map deps — keeps the landing entry light) split from `geo/reference.ts` (pmtiles overlay; imports maplibre + `pmtiles`).
- `validate-collection.ts` validates the new optional `schema_doc` keys; `schema/v1.json` meta-schema updated to match.
- **CSP** (`_headers`) adds the catalogue API, the R2 pmtiles host, and the Esri/OpenTopo tile hosts.

## Verification
Verified in Chrome at 390px: **satellite basemap + forest pmtiles overlay render cross-origin** with the toggle working; catalogue search returns real layers (`soi_forests`, `wards_bengaluru_gba`, …); download buttons render. **No console/CSP errors.** Landing entry stays **5 KB gz** (no MapLibre); the map app carries pmtiles (+~4 KB gz). **60 vitest** green · typecheck + build clean.

## Notes
- `reference_layer.pmtiles_url` is denormalized at pick-time to avoid a catalogue fetch on every map load; R2 URLs are stable.
- Attribution for Esri/OpenTopo basemaps is shown via MapLibre's attribution control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)