### PR TITLE
collect: publish category, content-safety, bulk import + overlay polish

### DIFF
--- a/collect/functions/api/collect/[[path]].ts
+++ b/collect/functions/api/collect/[[path]].ts
@@ -47,6 +47,9 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
     if (p.length === 3 && p[2] === 'publish') {
       return method === 'POST' ? h.publish(env, request, id) : bad(405, 'method not allowed');
     }
+    if (p.length === 3 && p[2] === 'import') {
+      return method === 'POST' ? h.importRecords(env, request, id) : bad(405, 'method not allowed');
+    }
     if (p.length === 3 && p[2] === 'tokens') {
       return method === 'POST' ? h.mintToken(env, request, id) : bad(405, 'method not allowed');
     }

--- a/collect/functions/lib/collect-log.ts
+++ b/collect/functions/lib/collect-log.ts
@@ -2,7 +2,7 @@
 // attempt (spec → Deployment checklist item 8). Coarse facts only — no field
 // values, no names. Best-effort; never blocks the request.
 
-export type CollectEvent = 'create' | 'contribute' | 'publish';
+export type CollectEvent = 'create' | 'contribute' | 'publish' | 'import';
 
 export interface CollectAttempt {
   event: CollectEvent;

--- a/collect/functions/lib/db.ts
+++ b/collect/functions/lib/db.ts
@@ -96,16 +96,17 @@ export interface NewRecordRow {
   contributor: string | null;
   edit_token_hash: string;
   ip_hash: string;
+  source?: string | null; // NULL = field-collected; set = imported from
 }
 
 export async function insertRecord(db: DB, r: NewRecordRow): Promise<void> {
   await db
     .prepare(
       `INSERT INTO records
-       (id, collection_id, created_at, status, geometry, properties, admin_ctx, contributor, edit_token_hash, ip_hash)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       (id, collection_id, created_at, status, geometry, properties, admin_ctx, contributor, edit_token_hash, ip_hash, source)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
-    .bind(r.id, r.collectionId, now(), r.status, r.geometry, r.properties, r.admin_ctx, r.contributor, r.edit_token_hash, r.ip_hash)
+    .bind(r.id, r.collectionId, now(), r.status, r.geometry, r.properties, r.admin_ctx, r.contributor, r.edit_token_hash, r.ip_hash, r.source ?? null)
     .run();
 }
 
@@ -119,6 +120,7 @@ export interface RecordRow {
   admin_ctx: string | null;
   contributor: string | null;
   edit_token_hash: string | null;
+  source: string | null;
 }
 
 export async function listRecords(

--- a/collect/functions/lib/handlers.ts
+++ b/collect/functions/lib/handlers.ts
@@ -199,6 +199,7 @@ export async function listRecords(env: Env, req: Request, id: string): Promise<R
       _contributor: r.contributor,
       _created_at: r.created_at,
       _admin_ctx: r.admin_ctx ? JSON.parse(r.admin_ctx) : null,
+      _source: r.source,
     },
   }));
   return json(200, { type: 'FeatureCollection', features });
@@ -397,6 +398,13 @@ export async function importRecords(env: Env, req: Request, id: string): Promise
   if (!Array.isArray(recs)) return bad(400, 'records must be an array');
   if (recs.length > 5000) return bad(413, 'import at most 5000 records per request');
 
+  // Rights gate (Phase 5): the importer must attest the right to publish this
+  // data under the map's open licence, and name the source (per-record provenance).
+  if (body.rights_confirmed !== true) return bad(400, 'confirm you have the right to publish this data under the map licence');
+  const source = typeof body.source === 'string' ? body.source.trim() : '';
+  if (!source) return bad(400, 'name the data source (where this data comes from)');
+  if (source.length > 200) return bad(400, 'source must be under 200 characters');
+
   const schema = JSON.parse(c.schema_doc) as { geometry: string[]; fields: Field[] };
   const contributor = typeof body.contributor === 'string' && body.contributor.trim() !== '' ? body.contributor.trim() : null;
   const status: 'pending' | 'published' = c.moderation ? 'pending' : 'published';
@@ -417,7 +425,7 @@ export async function importRecords(env: Env, req: Request, id: string): Promise
       geometry: JSON.stringify(r.geometry), properties: JSON.stringify(v.properties),
       admin_ctx: null, contributor,
       edit_token_hash: await hashToken(generateRecordToken()), // discarded — no owner
-      ip_hash: ipHash,
+      ip_hash: ipHash, source, // per-record provenance
     });
     imported++;
   }
@@ -463,7 +471,13 @@ export async function publish(env: Env, req: Request, id: string): Promise<Respo
     if (prev?.content_hash === contentHash) return bad(409, `nothing new since v${version - 1}`);
   }
 
-  const attribution = composeAttribution(c.name, c.license, rows.map((r) => r.contributor));
+  // Imported records are credited via their source, not the contributor tally;
+  // field records (no source) feed the contributor credit.
+  const attribution = composeAttribution(
+    c.name, c.license,
+    rows.filter((r) => !r.source).map((r) => r.contributor),
+    rows.map((r) => r.source),
+  );
   const geomTypes = [...new Set(features.map((f) => (f.geometry as { type: string }).type))].join(',');
 
   const submissionId = nanoid(10);
@@ -479,6 +493,7 @@ export async function publish(env: Env, req: Request, id: string): Promise<Respo
     JSON.stringify({
       attribution: attribution.line,
       contributors: attribution.contributors,
+      sources: attribution.sources,
       collection_url: `${new URL(req.url).origin}/c/${id}`,
       version,
     }),

--- a/collect/functions/lib/handlers.ts
+++ b/collect/functions/lib/handlers.ts
@@ -378,6 +378,54 @@ export async function deidentifyRecordHandler(env: Env, req: Request, recordId: 
   return json(200, { id: recordId, contributor: null });
 }
 
+// ---- POST /collections/:id/import ------------------------------------------
+// Bulk import (admin only) — Phase 5. Server re-validates every record (never
+// trusts the client); admin-authed so it skips the per-contributor rate limit.
+// A throwaway edit-token hash means imported records have no contributor owner
+// (admin manages them). Enrichment is skipped in bulk (admin_ctx stays null).
+
+export async function importRecords(env: Env, req: Request, id: string): Promise<Response> {
+  const perm = await permissionFor(env.DB, id, bearer(req));
+  if (!atLeast(perm, 'admin')) return bad(401, 'unauthorised');
+  const c = await db.getCollection(env.DB, id);
+  if (!c) return bad(404, 'not found');
+  if (c.status === 'closed') return bad(403, 'this collection is closed');
+
+  const body = await readJson(req);
+  if (!body) return bad(400, 'invalid JSON body');
+  const recs = body.records;
+  if (!Array.isArray(recs)) return bad(400, 'records must be an array');
+  if (recs.length > 5000) return bad(413, 'import at most 5000 records per request');
+
+  const schema = JSON.parse(c.schema_doc) as { geometry: string[]; fields: Field[] };
+  const contributor = typeof body.contributor === 'string' && body.contributor.trim() !== '' ? body.contributor.trim() : null;
+  const status: 'pending' | 'published' = c.moderation ? 'pending' : 'published';
+  const ipHash = await ipHashFor(req, salt(env));
+
+  let imported = 0;
+  const errors: Array<{ index: number; error: string }> = [];
+  for (let i = 0; i < recs.length; i++) {
+    const r = recs[i] as { geometry?: unknown; properties?: unknown };
+    const bounds = checkIndiaBounds(r?.geometry);
+    if (!bounds.ok) { errors.push({ index: i, error: bounds.error }); continue; }
+    const bucket = geomBucket((r.geometry as { type: string }).type);
+    if (!bucket || !schema.geometry.includes(bucket)) { errors.push({ index: i, error: `geometry not allowed here` }); continue; }
+    const v = validateRecordProperties(schema.fields, r?.properties);
+    if (!v.ok) { errors.push({ index: i, error: v.error }); continue; }
+    await db.insertRecord(env.DB, {
+      id: nanoid(10), collectionId: id, status,
+      geometry: JSON.stringify(r.geometry), properties: JSON.stringify(v.properties),
+      admin_ctx: null, contributor,
+      edit_token_hash: await hashToken(generateRecordToken()), // discarded — no owner
+      ip_hash: ipHash,
+    });
+    imported++;
+  }
+  await db.touchCollection(env.DB, id);
+  void logCollectAttempt(env.DB, { event: 'import', outcome: imported ? 'ok' : 'rejected', collection_id: id, ip_hash: ipHash });
+  return json(200, { imported, errors });
+}
+
 // ---- POST /collections/:id/publish -----------------------------------------
 
 export async function publish(env: Env, req: Request, id: string): Promise<Response> {
@@ -442,7 +490,7 @@ export async function publish(env: Env, req: Request, id: string): Promise<Respo
     status: 'accepted',
     name: c.name,
     description: c.description,
-    category: 'other', // collections carry no category in v1
+    category: (JSON.parse(c.schema_doc) as { category?: string }).category || 'other',
     license: c.license,
     attribution: attribution.line,
     source_url: `https://collect.bharatlas.com/c/${id}`,

--- a/collect/public/schema/v1.json
+++ b/collect/public/schema/v1.json
@@ -17,6 +17,7 @@
       "maxItems": 3,
       "items": { "type": "string" }
     },
+    "category": { "enum": ["boundaries", "city-wards", "people", "environment", "water", "agriculture", "transport", "infrastructure", "culture", "health-edu", "other"] },
     "basemap": { "enum": ["positron", "satellite", "topo"] },
     "reference_layer": {
       "type": "object",

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -467,27 +467,56 @@ async function importFlow(file: File): Promise<void> {
   const needsLngLat = format === 'csv';
   const guess = autoMapping(fields, parsed.columns);
   const opts = (sel?: string): string =>
-    `<option value="">— none —</option>` + parsed.columns.map((c) => `<option${c === sel ? ' selected' : ''}>${escapeHtml(c)}</option>`).join('');
+    `<option value="">— choose a column —</option>` + parsed.columns.map((c) => `<option${c === sel ? ' selected' : ''}>${escapeHtml(c)}</option>`).join('');
+  const n = parsed.features.length;
+  // A column map (applies to ALL rows), not a single-record form.
   panel.innerHTML = `
-    <p class="hint">${parsed.features.length} rows in ${format.toUpperCase()}. Match columns to your fields.</p>
-    ${needsLngLat ? `<label>Longitude column</label><select data-map="lng">${opts(guess.lng)}</select><label>Latitude column</label><select data-map="lat">${opts(guess.lat)}</select>` : ''}
-    ${fields.map((f) => `<label>${escapeHtml(f.label)}${f.required ? ' *' : ''}</label><select data-field="${f.key}">${opts(guess.fields[f.key])}</select>`).join('')}
-    <button class="primary" id="do-import" style="margin-top:12px">Import ${parsed.features.length} rows</button>
+    <p class="hint"><strong>${n} row${n === 1 ? '' : 's'}</strong> found in your ${format.toUpperCase()} file. Match each map field to a column from the file — this applies to <strong>all ${n}</strong> at once, not one point.</p>
+    ${needsLngLat
+      ? `<div class="maplabel">Location <span class="hint">(a CSV keeps coordinates in columns)</span></div>
+         <div class="maprow"><span>Longitude</span><select data-map="lng">${opts(guess.lng)}</select></div>
+         <div class="maprow"><span>Latitude</span><select data-map="lat">${opts(guess.lat)}</select></div>`
+      : `<p class="hint">Locations come from the file's own geometry, so there's nothing to match for coordinates.</p>`}
+    <div class="maplabel">Fields <span class="hint">(which column fills each)</span></div>
+    ${fields.map((f) => `<div class="maprow"><span>${escapeHtml(f.label)}${f.required ? ' *' : ''}</span><select data-field="${f.key}">${opts(guess.fields[f.key])}</select></div>`).join('')}
+    <div id="map-preview" class="hint" style="margin:10px 0"></div>
+    <button class="primary" id="do-import">Import all ${n} rows</button>
     <div id="import-result"></div>`;
 
-  (document.getElementById('do-import') as HTMLButtonElement).onclick = async (ev) => {
-    const btn = ev.currentTarget as HTMLButtonElement;
+  const readMapping = (): Mapping => {
     const m: Mapping = { fields: {} };
     if (needsLngLat) {
       m.lng = (panel.querySelector('[data-map="lng"]') as HTMLSelectElement).value || undefined;
       m.lat = (panel.querySelector('[data-map="lat"]') as HTMLSelectElement).value || undefined;
     }
     panel.querySelectorAll<HTMLSelectElement>('[data-field]').forEach((s) => { if (s.value) m.fields[s.dataset.field!] = s.value; });
-    const { records, errors } = buildRecords(parsed.features, m, fields, meta.schema.geometry);
+    return m;
+  };
+  // Live preview of the first row so the mapping is tangible (bulk, not entry).
+  const preview = (): void => {
+    const el = document.getElementById('map-preview');
+    if (!el) return;
+    const { records, errors } = buildRecords(parsed.features.slice(0, 1), readMapping(), fields, meta.schema.geometry);
+    if (records.length) {
+      const g = records[0].geometry as { type: string; coordinates: number[] };
+      const props = records[0].properties as Record<string, unknown>;
+      const label = String(props.name ?? Object.values(props)[0] ?? '(unnamed)');
+      const where = g.type === 'Point' ? `${g.coordinates[0]}, ${g.coordinates[1]}` : g.type.toLowerCase();
+      el.innerHTML = `Preview · row 1 → <strong>${escapeHtml(label)}</strong> at ${escapeHtml(where)}`;
+    } else {
+      el.innerHTML = `<span class="warn">Row 1 won't import: ${escapeHtml(errors[0]?.error || 'check the mapping')}</span>`;
+    }
+  };
+  panel.querySelectorAll('select').forEach((s) => { (s as HTMLSelectElement).onchange = preview; });
+  preview();
+
+  (document.getElementById('do-import') as HTMLButtonElement).onclick = async (ev) => {
+    const btn = ev.currentTarget as HTMLButtonElement;
+    const { records, errors } = buildRecords(parsed.features, readMapping(), fields, meta.schema.geometry);
     const result = document.getElementById('import-result')!;
     if (!records.length) {
-      result.innerHTML = `<p class="warn">Nothing valid to import — ${errors.length} row${errors.length === 1 ? '' : 's'} had problems.</p><button id="dl-errors">Download error file</button>`;
-      (document.getElementById('dl-errors') as HTMLButtonElement).onclick = () => downloadText(errorsToCSV(errors), 'import-errors.csv', 'text/csv');
+      result.innerHTML = `<p class="warn">Nothing valid to import — ${errors.length} row${errors.length === 1 ? '' : 's'} had problems.</p>${errorsBlock()}`;
+      wireErrorDownload(errors);
       return;
     }
     btn.disabled = true;
@@ -496,11 +525,21 @@ async function importFlow(file: File): Promise<void> {
       await refreshCounts();
       void renderPoints();
       toast(`Imported ${res.imported} point${res.imported === 1 ? '' : 's'} ✓`);
-      result.innerHTML = `<p class="hint">Imported ${res.imported}.${errors.length ? ` ${errors.length} row${errors.length === 1 ? '' : 's'} skipped (bad data).` : ''}</p>`
-        + (errors.length ? `<button id="dl-errors">Download error file</button>` : '');
-      if (errors.length) (document.getElementById('dl-errors') as HTMLButtonElement).onclick = () => downloadText(errorsToCSV(errors), 'import-errors.csv', 'text/csv');
+      result.innerHTML = `<p class="hint">Imported ${res.imported}.${errors.length ? ` ${errors.length} row${errors.length === 1 ? '' : 's'} couldn't be read.` : ''}</p>`
+        + (errors.length ? errorsBlock() : '');
+      wireErrorDownload(errors);
     } catch (e) { toast((e as Error).message); btn.disabled = false; }
   };
+}
+
+// The rejected rows, as a spreadsheet to fix + re-import (with a plain-words prompt).
+function errorsBlock(): string {
+  return `<button id="dl-errors">Download the rows to fix</button>
+    <p class="hint" style="margin-top:6px">A spreadsheet of only the skipped rows, each with a <code>why</code> column. Fix them, delete that column, and import the file again.</p>`;
+}
+function wireErrorDownload(errors: { row: number; error: string; source: Record<string, string> }[]): void {
+  const b = document.getElementById('dl-errors') as HTMLButtonElement | null;
+  if (b) b.onclick = () => downloadText(errorsToCSV(errors), 'rows-to-fix.csv', 'text/csv');
 }
 
 function activeFilter(): string {

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -17,7 +17,7 @@ import { detectFormat, parseImport, type Parsed } from './import/parse';
 import { autoMapping, buildRecords, errorsToCSV, type Mapping } from './import/build';
 interface Counts { pending: number; published: number; total: number; rejected: number; }
 interface Meta {
-  id: string; name: string; purpose: string; status: string; moderation: number;
+  id: string; name: string; purpose: string; status: string; moderation: number; license: string;
   schema: { geometry: string[]; fields: Field[]; basemap?: string; reference_layer?: { id: string; pmtiles_url: string } | null }; counts: Counts;
 }
 interface Feature { id: string; geometry: { type: string; coordinates: number[] }; properties: Record<string, unknown>; }
@@ -480,7 +480,10 @@ async function importFlow(file: File): Promise<void> {
     <div class="maplabel">Fields <span class="hint">(which column fills each)</span></div>
     ${fields.map((f) => `<div class="maprow"><span>${escapeHtml(f.label)}${f.required ? ' *' : ''}</span><select data-field="${f.key}">${opts(guess.fields[f.key])}</select></div>`).join('')}
     <div id="map-preview" class="hint" style="margin:10px 0"></div>
-    <button class="primary" id="do-import">Import all ${n} rows</button>
+    <div class="maplabel">Where's this data from? <span class="hint">(the source, shown in the published credit)</span></div>
+    <input id="imp-source" placeholder="e.g. SOI Forest Atlas 2021, or a link" maxlength="200" />
+    <label class="chip" style="gap:8px;margin-top:10px;align-items:flex-start;border-radius:12px;padding:10px 12px"><input type="checkbox" id="imp-rights" style="width:auto;min-height:auto;margin-top:3px"><span style="white-space:normal;font-weight:400;font-size:13px">I have the right to publish this under the map's licence (${escapeHtml(meta.license)}): it's my own data, or from a source whose terms allow it.</span></label>
+    <button class="primary" id="do-import" style="margin-top:12px">Import all ${n} rows</button>
     <div id="import-result"></div>`;
 
   const readMapping = (): Mapping => {
@@ -512,6 +515,10 @@ async function importFlow(file: File): Promise<void> {
 
   (document.getElementById('do-import') as HTMLButtonElement).onclick = async (ev) => {
     const btn = ev.currentTarget as HTMLButtonElement;
+    const source = (document.getElementById('imp-source') as HTMLInputElement).value.trim();
+    const rights = (document.getElementById('imp-rights') as HTMLInputElement).checked;
+    if (!rights) { toast('Tick the box: you can publish this under the map licence'); return; }
+    if (!source) { toast('Name where this data comes from'); return; }
     const { records, errors } = buildRecords(parsed.features, readMapping(), fields, meta.schema.geometry);
     const result = document.getElementById('import-result')!;
     if (!records.length) {
@@ -521,7 +528,7 @@ async function importFlow(file: File): Promise<void> {
     }
     btn.disabled = true;
     try {
-      const res = await apiJson<{ imported: number; errors: unknown[] }>(`/collections/${ctx.id}/import`, ctx.token, { method: 'POST', body: JSON.stringify({ records }) });
+      const res = await apiJson<{ imported: number; errors: unknown[] }>(`/collections/${ctx.id}/import`, ctx.token, { method: 'POST', body: JSON.stringify({ records, source, rights_confirmed: true }) });
       await refreshCounts();
       void renderPoints();
       toast(`Imported ${res.imported} point${res.imported === 1 ? '' : 's'} ✓`);
@@ -594,8 +601,9 @@ async function renderPoints(): Promise<void> {
     const feats = fc.features || [];
     if (!feats.length) { q.innerHTML = '<p class="empty">No points here yet. Share the collect link and they will show up as people add them.</p>'; return; }
     q.innerHTML = feats.map((f) => {
-      const p = f.properties as { _status?: string; _contributor?: string; _admin_ctx?: AdminCtx };
+      const p = f.properties as { _status?: string; _contributor?: string; _admin_ctx?: AdminCtx; _source?: string };
       const st = p._status || 'published';
+      const origin = p._source ? `⇪ ${escapeHtml(p._source)}` : escapeHtml(p._contributor || 'anonymous');
       const geom = f.geometry?.type && f.geometry.type !== 'Point' ? `<span class="hint">${nounFor(f.geometry.type)}</span> ` : '';
       // Two action rows (max two buttons each) so labels never wrap: moderation
       // on top, then edit/delete. Better hierarchy, and it fits at 360px.
@@ -609,7 +617,7 @@ async function renderPoints(): Promise<void> {
           <strong style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${geom}${escapeHtml(cardTitle(f.properties))}</strong>
           <span class="badge badge--${st}">${st}</span>
         </div>
-        <div class="hint">${escapeHtml(p._contributor || 'anonymous')}${fmtAdminCtx(p._admin_ctx ?? null)}</div>
+        <div class="hint">${origin}${fmtAdminCtx(p._admin_ctx ?? null)}</div>
         ${mod ? `<div class="row" style="margin-top:8px">${mod}</div>` : ''}
         <div class="row" style="margin-top:8px">${crud}</div>
       </div>`;

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -13,6 +13,8 @@ import { orderedModes, drawGeometry, type GeomMode, type Coord } from './geo/dra
 import { representativeCoord } from './geo/admin-ctx';
 import { escapeHtml } from './util';
 import { toGeoJSON, toCSV, toKML, type ExportFeature } from './export/formats';
+import { detectFormat, parseImport, type Parsed } from './import/parse';
+import { autoMapping, buildRecords, errorsToCSV, type Mapping } from './import/build';
 interface Counts { pending: number; published: number; total: number; rejected: number; }
 interface Meta {
   id: string; name: string; purpose: string; status: string; moderation: number;
@@ -70,6 +72,14 @@ function toast(msg: string): void {
 
 function marker(coords: number[], color = ACCENT): void {
   if (coords.length >= 2) new maplibregl.Marker({ color }).setLngLat([coords[0], coords[1]]).addTo(map);
+}
+
+const TERMS = 'https://bharatlas.com/terms';
+// Content-safety: a report/takedown path (mailto, no accounts) + terms link.
+function safetyFooter(): string {
+  const subject = encodeURIComponent(`Report: collect map ${ctx.id}`);
+  const body = encodeURIComponent(`Reporting this map:\n${location.origin}/c/${ctx.id}\n\nReason:\n`);
+  return `<p class="hint" style="margin-top:12px">Public places and assets only, not people. <a href="mailto:sathya@urbanmorph.com?subject=${subject}&body=${body}">Report this map</a> · <a href="${TERMS}" target="_blank" rel="noopener">Terms</a></p>`;
 }
 
 async function boot(): Promise<void> {
@@ -145,6 +155,7 @@ function viewPanel(): void {
     <strong>${escapeHtml(meta.name)}</strong>
     ${meta.purpose ? `<p class="hint">${escapeHtml(meta.purpose)}</p>` : ''}
     <p class="hint">${n ? `${n} point${n === 1 ? '' : 's'} on the map.` : 'No points published yet.'}</p>
+    ${safetyFooter()}
   </div></div>`;
 }
 
@@ -278,7 +289,7 @@ function detailsSheet(geometry: GeoJSON.Geometry, modes: GeomMode[]): void {
   panel.innerHTML = `<div class="sheet">
     <form class="body" id="capform">
       <strong>${cap(noun)} details</strong>
-      <p class="hint">Placed on the map. Add the details, then save.</p>
+      <p class="hint">Placed on the map. Add the details, then save. Public places and assets only, not people.</p>
       ${fields.map((f) => `<label>${escapeHtml(f.label)}${f.required ? ' *' : ''}</label>${f.hint ? `<p class="hint" style="margin:-2px 0 4px">${escapeHtml(f.hint)}</p>` : ''}${fieldInput(f)}`).join('')}
       <label>Your name <span class="hint">(optional, published with the data)</span></label>
       <input id="contributor" />
@@ -362,6 +373,11 @@ async function manageSheet(): Promise<void> {
         <button data-dl="csv">CSV</button>
         <button data-dl="kml">KML</button>
       </div>
+      <strong style="display:block;margin-top:14px">Import data</strong>
+      <p class="hint">Add many points at once from a CSV, GeoJSON or KML file.</p>
+      <label class="btn wide" style="cursor:pointer">⬆ Choose a file<input id="import-file" type="file" accept=".csv,.geojson,.json,.kml" hidden></label>
+      <div id="import-panel"></div>
+      ${safetyFooter()}
     </div>
     <div class="foot row">
       <button id="back">+ Add points</button>
@@ -400,11 +416,23 @@ async function manageSheet(): Promise<void> {
   document.querySelectorAll<HTMLButtonElement>('button[data-dl]').forEach((b) => {
     b.onclick = () => void downloadData(b.dataset.dl as 'geojson' | 'csv' | 'kml');
   });
+  (document.getElementById('import-file') as HTMLInputElement).onchange = (e) => {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (file) void importFlow(file);
+  };
 
   void renderPoints();
 }
 
 const slug = (s: string): string => (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'collect-map';
+
+function downloadText(content: string, filename: string, mime: string): void {
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([content], { type: mime }));
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
 
 // Fetch every record and hand the author a file — no server round-trip.
 async function downloadData(format: 'geojson' | 'csv' | 'kml'): Promise<void> {
@@ -417,15 +445,62 @@ async function downloadData(format: 'geojson' | 'csv' | 'kml'): Promise<void> {
       format === 'geojson' ? [toGeoJSON(features, keys), 'application/geo+json', 'geojson']
       : format === 'csv' ? [toCSV(features, keys), 'text/csv', 'csv']
       : [toKML(features, keys, meta.name), 'application/vnd.google-earth.kml+xml', 'kml'];
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(new Blob([content], { type: mime }));
-    a.download = `${slug(meta.name)}.${ext}`;
-    a.click();
-    URL.revokeObjectURL(a.href);
+    downloadText(content, `${slug(meta.name)}.${ext}`, mime);
     toast(`Downloaded ${features.length} point${features.length === 1 ? '' : 's'} as ${ext.toUpperCase()}`);
   } catch (e) {
     toast((e as Error).message);
   }
+}
+
+// Import (Phase 5): parse a file → map columns to fields → validate → bulk POST.
+async function importFlow(file: File): Promise<void> {
+  const panel = document.getElementById('import-panel');
+  if (!panel) return;
+  const format = detectFormat(file.name);
+  if (!format) { panel.innerHTML = '<p class="warn">Use a .csv, .geojson or .kml file.</p>'; return; }
+  let parsed: Parsed;
+  try { parsed = parseImport(await file.text(), format); }
+  catch (e) { panel.innerHTML = `<p class="warn">Couldn't read the file: ${escapeHtml((e as Error).message)}</p>`; return; }
+  if (!parsed.features.length) { panel.innerHTML = '<p class="hint">No rows found in the file.</p>'; return; }
+
+  const fields = meta.schema.fields.filter((f) => !f.deleted);
+  const needsLngLat = format === 'csv';
+  const guess = autoMapping(fields, parsed.columns);
+  const opts = (sel?: string): string =>
+    `<option value="">— none —</option>` + parsed.columns.map((c) => `<option${c === sel ? ' selected' : ''}>${escapeHtml(c)}</option>`).join('');
+  panel.innerHTML = `
+    <p class="hint">${parsed.features.length} rows in ${format.toUpperCase()}. Match columns to your fields.</p>
+    ${needsLngLat ? `<label>Longitude column</label><select data-map="lng">${opts(guess.lng)}</select><label>Latitude column</label><select data-map="lat">${opts(guess.lat)}</select>` : ''}
+    ${fields.map((f) => `<label>${escapeHtml(f.label)}${f.required ? ' *' : ''}</label><select data-field="${f.key}">${opts(guess.fields[f.key])}</select>`).join('')}
+    <button class="primary" id="do-import" style="margin-top:12px">Import ${parsed.features.length} rows</button>
+    <div id="import-result"></div>`;
+
+  (document.getElementById('do-import') as HTMLButtonElement).onclick = async (ev) => {
+    const btn = ev.currentTarget as HTMLButtonElement;
+    const m: Mapping = { fields: {} };
+    if (needsLngLat) {
+      m.lng = (panel.querySelector('[data-map="lng"]') as HTMLSelectElement).value || undefined;
+      m.lat = (panel.querySelector('[data-map="lat"]') as HTMLSelectElement).value || undefined;
+    }
+    panel.querySelectorAll<HTMLSelectElement>('[data-field]').forEach((s) => { if (s.value) m.fields[s.dataset.field!] = s.value; });
+    const { records, errors } = buildRecords(parsed.features, m, fields, meta.schema.geometry);
+    const result = document.getElementById('import-result')!;
+    if (!records.length) {
+      result.innerHTML = `<p class="warn">Nothing valid to import — ${errors.length} row${errors.length === 1 ? '' : 's'} had problems.</p><button id="dl-errors">Download error file</button>`;
+      (document.getElementById('dl-errors') as HTMLButtonElement).onclick = () => downloadText(errorsToCSV(errors), 'import-errors.csv', 'text/csv');
+      return;
+    }
+    btn.disabled = true;
+    try {
+      const res = await apiJson<{ imported: number; errors: unknown[] }>(`/collections/${ctx.id}/import`, ctx.token, { method: 'POST', body: JSON.stringify({ records }) });
+      await refreshCounts();
+      void renderPoints();
+      toast(`Imported ${res.imported} point${res.imported === 1 ? '' : 's'} ✓`);
+      result.innerHTML = `<p class="hint">Imported ${res.imported}.${errors.length ? ` ${errors.length} row${errors.length === 1 ? '' : 's'} skipped (bad data).` : ''}</p>`
+        + (errors.length ? `<button id="dl-errors">Download error file</button>` : '');
+      if (errors.length) (document.getElementById('dl-errors') as HTMLButtonElement).onclick = () => downloadText(errorsToCSV(errors), 'import-errors.csv', 'text/csv');
+    } catch (e) { toast((e as Error).message); btn.disabled = false; }
+  };
 }
 
 function activeFilter(): string {

--- a/collect/src/export/formats.ts
+++ b/collect/src/export/formats.ts
@@ -15,6 +15,7 @@ function tidyProps(p: Record<string, unknown>, fieldKeys: string[]): Record<stri
   const out: Record<string, unknown> = {};
   for (const k of fieldKeys) if (p[k] != null) out[k] = p[k];
   if (p._contributor) out.contributor = p._contributor;
+  if (p._source) out.source = p._source;
   if (p._status) out.status = p._status;
   const ctx = p._admin_ctx as Record<string, string> | null | undefined;
   if (ctx) for (const [k, v] of Object.entries(ctx)) if (!(k in out)) out[k] = v;
@@ -36,7 +37,7 @@ function csvCell(v: unknown): string {
 }
 
 export function toCSV(features: ExportFeature[], fieldKeys: string[]): string {
-  const cols = ['lng', 'lat', 'geometry_type', ...fieldKeys, 'contributor', 'status', 'state', 'district'];
+  const cols = ['lng', 'lat', 'geometry_type', ...fieldKeys, 'contributor', 'source', 'status', 'state', 'district'];
   const lines = [cols.map(csvCell).join(',')];
   for (const f of features) {
     const p = f.properties || {};
@@ -45,7 +46,7 @@ export function toCSV(features: ExportFeature[], fieldKeys: string[]): string {
     const row = [
       c ? c[0] : '', c ? c[1] : '', f.geometry?.type ?? '',
       ...fieldKeys.map((k) => p[k]),
-      p._contributor ?? '', p._status ?? '', ctx.state ?? '', ctx.district ?? '',
+      p._contributor ?? '', p._source ?? '', p._status ?? '', ctx.state ?? '', ctx.district ?? '',
     ];
     lines.push(row.map(csvCell).join(','));
   }

--- a/collect/src/geo/reference.ts
+++ b/collect/src/geo/reference.ts
@@ -6,7 +6,9 @@
 import maplibregl from 'maplibre-gl';
 import { Protocol, PMTiles } from 'pmtiles';
 
-const ACCENT = '#4f46e5';
+// A distinct teal (not the indigo of the user's own markers) + a light fill,
+// so a reference layer reads as background context, never as collected data.
+const REF = '#0e7490';
 
 let protocol: Protocol | null = null;
 function proto(): Protocol {
@@ -28,9 +30,9 @@ export async function addReferenceOverlay(map: maplibregl.Map, pmtilesUrl: strin
   if (!sourceLayer) return;
   const header = await pm.getHeader();
   map.addSource('ref', { type: 'vector', url: `pmtiles://${pmtilesUrl}`, minzoom: header.minZoom, maxzoom: header.maxZoom });
-  map.addLayer({ id: 'ref-fill', type: 'fill', source: 'ref', 'source-layer': sourceLayer, filter: ['==', ['geometry-type'], 'Polygon'], paint: { 'fill-color': ACCENT, 'fill-opacity': 0.07 } });
-  map.addLayer({ id: 'ref-line', type: 'line', source: 'ref', 'source-layer': sourceLayer, paint: { 'line-color': ACCENT, 'line-width': 1.2, 'line-opacity': 0.5 } });
-  map.addLayer({ id: 'ref-pt', type: 'circle', source: 'ref', 'source-layer': sourceLayer, filter: ['==', ['geometry-type'], 'Point'], paint: { 'circle-radius': 3, 'circle-color': ACCENT, 'circle-opacity': 0.55 } });
+  map.addLayer({ id: 'ref-fill', type: 'fill', source: 'ref', 'source-layer': sourceLayer, filter: ['==', ['geometry-type'], 'Polygon'], paint: { 'fill-color': REF, 'fill-opacity': 0.04 } });
+  map.addLayer({ id: 'ref-line', type: 'line', source: 'ref', 'source-layer': sourceLayer, paint: { 'line-color': REF, 'line-width': 1.4, 'line-opacity': 0.7 } });
+  map.addLayer({ id: 'ref-pt', type: 'circle', source: 'ref', 'source-layer': sourceLayer, filter: ['==', ['geometry-type'], 'Point'], paint: { 'circle-radius': 3, 'circle-color': REF, 'circle-opacity': 0.6 } });
 }
 
 export function setReferenceVisible(map: maplibregl.Map, on: boolean): void {

--- a/collect/src/import/build.ts
+++ b/collect/src/import/build.ts
@@ -1,0 +1,89 @@
+// Map parsed rows onto the collection's schema and validate each — the same
+// checks the API applies (India bounds, declared geometry, field validation).
+// Valid rows become records to POST; invalid rows go to the error file.
+
+import { validateRecordProperties, type Field } from '../schema/validate-record';
+import { checkIndiaBounds } from '../geo/bounds';
+import type { ParsedFeature } from './parse';
+
+export interface Mapping {
+  fields: Record<string, string>; // fieldKey -> source column
+  lng?: string;                    // CSV point: longitude column
+  lat?: string;                    // CSV point: latitude column
+}
+export interface BuiltRecord { geometry: unknown; properties: Record<string, unknown>; }
+export interface ImportError { row: number; error: string; source: Record<string, string>; }
+export interface BuildResult { records: BuiltRecord[]; errors: ImportError[]; }
+
+const norm = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+function bucket(t: string): 'point' | 'line' | 'polygon' | null {
+  if (t === 'Point' || t === 'MultiPoint') return 'point';
+  if (t === 'LineString' || t === 'MultiLineString') return 'line';
+  if (t === 'Polygon' || t === 'MultiPolygon') return 'polygon';
+  return null;
+}
+
+/** Best-guess field↔column + lng/lat mapping by normalized name. */
+export function autoMapping(fields: Field[], columns: string[]): Mapping {
+  const byNorm = new Map(columns.map((c) => [norm(c), c]));
+  const fmap: Record<string, string> = {};
+  for (const f of fields) {
+    const hit = byNorm.get(norm(f.key)) || byNorm.get(norm(f.label));
+    if (hit) fmap[f.key] = hit;
+  }
+  return {
+    fields: fmap,
+    lng: byNorm.get('lng') || byNorm.get('lon') || byNorm.get('longitude') || byNorm.get('x'),
+    lat: byNorm.get('lat') || byNorm.get('latitude') || byNorm.get('y'),
+  };
+}
+
+export function buildRecords(
+  features: ParsedFeature[],
+  mapping: Mapping,
+  fields: Field[],
+  geometryTypes: string[],
+): BuildResult {
+  const records: BuiltRecord[] = [];
+  const errors: ImportError[] = [];
+  features.forEach((f, i) => {
+    let geometry = f.geometry as { type?: string } | null;
+    if (!geometry && mapping.lng && mapping.lat) {
+      const lng = Number(f.props[mapping.lng]);
+      const lat = Number(f.props[mapping.lat]);
+      if (Number.isFinite(lng) && Number.isFinite(lat)) geometry = { type: 'Point', coordinates: [lng, lat] } as { type: string };
+    }
+    if (!geometry) { errors.push({ row: i, error: 'no geometry (needs a geometry or lng/lat columns)', source: f.props }); return; }
+    const b = checkIndiaBounds(geometry);
+    if (!b.ok) { errors.push({ row: i, error: b.error, source: f.props }); return; }
+    const gb = bucket(geometry.type || '');
+    if (!gb || !geometryTypes.includes(gb)) { errors.push({ row: i, error: `geometry ${geometry.type} not allowed here`, source: f.props }); return; }
+
+    const raw: Record<string, unknown> = {};
+    for (const fl of fields) {
+      const col = mapping.fields[fl.key];
+      if (!col) continue;
+      const v = f.props[col];
+      if (v == null || v === '') continue;
+      raw[fl.key] = fl.type === 'multiselect' ? v.split('|').map((s) => s.trim()).filter(Boolean) : v;
+    }
+    const valid = validateRecordProperties(fields, raw);
+    if (!valid.ok) { errors.push({ row: i, error: valid.error, source: f.props }); return; }
+    records.push({ geometry, properties: valid.properties });
+  });
+  return { records, errors };
+}
+
+/** An error CSV the author can fix + re-upload: source columns + a `_error` column. */
+export function errorsToCSV(errors: ImportError[]): string {
+  if (!errors.length) return '';
+  const cols = [...new Set(errors.flatMap((e) => Object.keys(e.source)))];
+  const cell = (v: unknown): string => {
+    const s = String(v ?? '');
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const lines = [[...cols, '_error'].map(cell).join(',')];
+  for (const e of errors) lines.push([...cols.map((c) => e.source[c] ?? ''), e.error].map(cell).join(','));
+  return lines.join('\n');
+}

--- a/collect/src/import/build.ts
+++ b/collect/src/import/build.ts
@@ -75,7 +75,7 @@ export function buildRecords(
   return { records, errors };
 }
 
-/** An error CSV the author can fix + re-upload: source columns + a `_error` column. */
+/** A CSV of just the rejected rows the author can fix + re-upload: source columns + a `why` column. */
 export function errorsToCSV(errors: ImportError[]): string {
   if (!errors.length) return '';
   const cols = [...new Set(errors.flatMap((e) => Object.keys(e.source)))];
@@ -83,7 +83,7 @@ export function errorsToCSV(errors: ImportError[]): string {
     const s = String(v ?? '');
     return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
   };
-  const lines = [[...cols, '_error'].map(cell).join(',')];
+  const lines = [[...cols, 'why'].map(cell).join(',')];
   for (const e of errors) lines.push([...cols.map((c) => e.source[c] ?? ''), e.error].map(cell).join(','));
   return lines.join('\n');
 }

--- a/collect/src/import/infer.ts
+++ b/collect/src/import/infer.ts
@@ -1,0 +1,64 @@
+// "Start a map from a file": discover columns → guess a field per column + the
+// geometry, so the schema builder can be pre-filled. Pure + unit-tested. The
+// author still reviews/edits before creating; this is a head start, not magic.
+
+import { deriveKey } from '../schema/derive-key';
+import type { Parsed } from './parse';
+import type { BuilderField } from '../schema-builder';
+
+// Columns that describe location, not an attribute — never become fields.
+const COORD_KEYS = new Set(['lng', 'lon', 'long', 'longitude', 'x', 'lat', 'latitude', 'y', 'geometry', 'geom', 'wkt', 'thegeom', 'coordinates']);
+
+export interface Inferred {
+  geometry: string[];
+  fields: BuilderField[];
+  mapping: Record<string, string>; // fieldKey -> source column
+}
+
+function bucket(t?: string): string | null {
+  if (t === 'Point' || t === 'MultiPoint') return 'point';
+  if (t === 'LineString' || t === 'MultiLineString') return 'line';
+  if (t === 'Polygon' || t === 'MultiPolygon') return 'polygon';
+  return null;
+}
+
+export function guessType(values: string[]): { type: BuilderField['type']; options?: string[] } {
+  const vals = values.map((v) => (v ?? '').trim()).filter((v) => v !== '');
+  if (!vals.length) return { type: 'text' };
+  if (vals.every((v) => v !== '' && !Number.isNaN(Number(v)))) return { type: 'number' };
+  if (vals.every((v) => /^\d{4}-\d{2}-\d{2}/.test(v))) return { type: 'date' };
+  const distinct = [...new Set(vals)];
+  if (distinct.length >= 2 && distinct.length <= 12 && distinct.length <= Math.ceil(vals.length / 2)) {
+    return { type: 'select', options: distinct.slice(0, 20) };
+  }
+  const maxLen = Math.max(...vals.map((v) => v.length));
+  if (maxLen > 80) return { type: 'paragraph' };
+  return { type: 'text' };
+}
+
+export function inferSchema(parsed: Parsed, format: string): Inferred {
+  let geometry: string[];
+  if (format === 'csv') geometry = ['point'];
+  else {
+    const set = new Set<string>();
+    for (const f of parsed.features) { const b = bucket((f.geometry as { type?: string } | null)?.type); if (b) set.add(b); }
+    geometry = set.size ? [...set] : ['point'];
+  }
+
+  const dataCols = parsed.columns.filter((c) => !COORD_KEYS.has(c.toLowerCase().replace(/[^a-z]/g, '')));
+  const fields: BuilderField[] = [];
+  const mapping: Record<string, string> = {};
+  const used: string[] = [];
+  dataCols.forEach((col, i) => {
+    const samples = parsed.features.slice(0, 50).map((f) => f.props[col] ?? '');
+    const { type, options } = guessType(samples);
+    const key = deriveKey(col, used);
+    used.push(key);
+    const field: BuilderField = { key, label: col, type };
+    if (options) field.options = options;
+    if (i === 0) field.required = true; // first column is usually the name/id
+    fields.push(field);
+    mapping[key] = col;
+  });
+  return { geometry, fields, mapping };
+}

--- a/collect/src/import/parse.ts
+++ b/collect/src/import/parse.ts
@@ -1,0 +1,103 @@
+// Parse an uploaded file into a common shape for the import mapping step.
+// GeoJSON + CSV are pure (unit-tested in node); KML uses DOMParser (browser).
+
+export type ImportFormat = 'geojson' | 'csv' | 'kml';
+
+export interface ParsedFeature {
+  geometry: unknown | null; // GeoJSON geometry, or null for CSV (built from lng/lat)
+  props: Record<string, string>;
+}
+export interface Parsed { columns: string[]; features: ParsedFeature[]; }
+
+export function detectFormat(filename: string): ImportFormat | null {
+  const ext = filename.toLowerCase().split('.').pop();
+  if (ext === 'geojson' || ext === 'json') return 'geojson';
+  if (ext === 'csv') return 'csv';
+  if (ext === 'kml') return 'kml';
+  return null;
+}
+
+const asStr = (v: unknown): string => (v == null ? '' : Array.isArray(v) ? v.join('|') : String(v));
+
+export function parseGeoJSON(text: string): Parsed {
+  const doc = JSON.parse(text) as { type?: string; features?: unknown[]; properties?: unknown; geometry?: unknown };
+  const feats = doc.type === 'FeatureCollection' ? (doc.features || []) : doc.type === 'Feature' ? [doc] : [];
+  const columns = new Set<string>();
+  const features: ParsedFeature[] = (feats as Array<{ geometry?: unknown; properties?: Record<string, unknown> }>).map((f) => {
+    const props: Record<string, string> = {};
+    for (const [k, v] of Object.entries(f.properties || {})) { columns.add(k); props[k] = asStr(v); }
+    return { geometry: f.geometry ?? null, props };
+  });
+  return { columns: [...columns], features };
+}
+
+// Minimal RFC-4180-ish CSV: quoted cells, "" escape, CR/LF tolerant.
+export function parseCSVRows(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = '';
+  let quoted = false;
+  const s = text.replace(/\r\n?/g, '\n');
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (quoted) {
+      if (ch === '"') { if (s[i + 1] === '"') { cell += '"'; i++; } else quoted = false; }
+      else cell += ch;
+    } else if (ch === '"') quoted = true;
+    else if (ch === ',') { row.push(cell); cell = ''; }
+    else if (ch === '\n') { row.push(cell); rows.push(row); row = []; cell = ''; }
+    else cell += ch;
+  }
+  if (cell !== '' || row.length) { row.push(cell); rows.push(row); }
+  return rows;
+}
+
+export function parseCSV(text: string): Parsed {
+  const rows = parseCSVRows(text).filter((r) => r.some((c) => c.trim() !== ''));
+  if (!rows.length) return { columns: [], features: [] };
+  const header = rows[0].map((h) => h.trim());
+  const features: ParsedFeature[] = rows.slice(1).map((r) => {
+    const props: Record<string, string> = {};
+    header.forEach((h, i) => { props[h] = (r[i] ?? '').trim(); });
+    return { geometry: null, props };
+  });
+  return { columns: header, features };
+}
+
+// KML via DOMParser (browser only). Point / LineString / Polygon; ExtendedData
+// Data names + <name> become columns.
+export function parseKML(text: string): Parsed {
+  const doc = new DOMParser().parseFromString(text, 'application/xml');
+  const columns = new Set<string>();
+  const features: ParsedFeature[] = [];
+  doc.querySelectorAll('Placemark').forEach((pm) => {
+    const props: Record<string, string> = {};
+    const nm = pm.querySelector(':scope > name')?.textContent?.trim();
+    if (nm) { columns.add('name'); props.name = nm; }
+    pm.querySelectorAll('ExtendedData > Data').forEach((d) => {
+      const k = d.getAttribute('name');
+      if (k) { columns.add(k); props[k] = d.querySelector('value')?.textContent?.trim() || ''; }
+    });
+    features.push({ geometry: kmlGeometry(pm), props });
+  });
+  return { columns: [...columns], features };
+}
+
+function coordsText(t: string | null | undefined): number[][] {
+  return (t || '').trim().split(/\s+/).filter(Boolean).map((pair) => pair.split(',').slice(0, 2).map(Number));
+}
+function kmlGeometry(pm: Element): unknown | null {
+  const pt = pm.querySelector('Point > coordinates');
+  if (pt) { const c = coordsText(pt.textContent)[0]; return c ? { type: 'Point', coordinates: c } : null; }
+  const ls = pm.querySelector('LineString > coordinates');
+  if (ls) return { type: 'LineString', coordinates: coordsText(ls.textContent) };
+  const pg = pm.querySelector('Polygon outerBoundaryIs > LinearRing > coordinates');
+  if (pg) return { type: 'Polygon', coordinates: [coordsText(pg.textContent)] };
+  return null;
+}
+
+export function parseImport(text: string, format: ImportFormat): Parsed {
+  if (format === 'geojson') return parseGeoJSON(text);
+  if (format === 'csv') return parseCSV(text);
+  return parseKML(text);
+}

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -6,6 +6,10 @@ import { mountSchemaBuilder } from './schema-builder';
 import { escapeHtml } from './util';
 import { BASEMAPS } from './basemap';
 import { searchLayers, type RefLayer } from './geo/catalog';
+import { detectFormat, parseImport, type Parsed } from './import/parse';
+import { inferSchema } from './import/infer';
+import { autoMapping, buildRecords } from './import/build';
+import type { Field } from './schema/validate-record';
 
 // Catalogue facets a published map slots into ('other' first = the default).
 const CATEGORIES: [string, string][] = [
@@ -108,6 +112,9 @@ function createForm() {
   app.innerHTML = `
     <div class="topbar"><a href="#" id="tohome" aria-label="Back to your maps">←</a><span>New map</span><span class="muted" style="margin-left:auto">collect</span></div>
     <div class="pad">
+      <label>Start from a file <span class="hint">(optional, we read the columns for you)</span></label>
+      <label class="btn wide" style="cursor:pointer">⬆ Choose CSV, GeoJSON or KML<input id="seed-file" type="file" accept=".csv,.geojson,.json,.kml" hidden></label>
+      <p id="seed-note" class="hint"></p>
       <label>Name your map</label>
       <input id="name" maxlength="120" placeholder="Bengaluru footpath survey" />
       <label>What's it for? <span class="hint">(shown to contributors)</span></label>
@@ -132,6 +139,11 @@ function createForm() {
       <select id="license">${OPEN_LICENCES.map(([id, l]) => `<option value="${id}">${l}</option>`).join('')}</select>
       <label>Data year <span class="hint">(optional)</span></label>
       <input id="year" inputmode="numeric" placeholder="2026" />
+      <div id="seed-import" style="display:none">
+        <label>Where's this data from? <span class="hint">(source, shown in the published credit)</span></label>
+        <input id="seed-source" maxlength="200" placeholder="e.g. SOI Forest Atlas 2021, or a link" />
+        <label class="chip" style="gap:8px;margin-top:8px;align-items:flex-start;border-radius:12px;padding:10px 12px"><input type="checkbox" id="seed-rights" style="width:auto;min-height:auto;margin-top:3px"><span style="white-space:normal;font-weight:400;font-size:13px">I have the right to publish this data under the map's licence, and to load it here.</span></label>
+      </div>
       <div style="height:16px"></div>
       <p class="hint">Map <strong>public places and assets</strong>, not people or private details. You're responsible for what's collected and published. <a href="https://bharatlas.com/terms" target="_blank" rel="noopener">Terms</a>.</p>
       <button class="primary" id="create">Create map</button>
@@ -140,11 +152,14 @@ function createForm() {
 
   app.querySelector<HTMLAnchorElement>('#tohome')!.onclick = (e) => { e.preventDefault(); home(); };
 
-  const builder = mountSchemaBuilder(app.querySelector<HTMLElement>('#fields-builder')!, [
+  let builder = mountSchemaBuilder(app.querySelector<HTMLElement>('#fields-builder')!, [
     { key: 'name', label: 'Name of the place', type: 'text', required: true },
   ]);
 
   const geom = new Set(['point']);
+  const syncGeomChips = (): void => {
+    app.querySelectorAll<HTMLButtonElement>('#geom .chip').forEach((c) => c.classList.toggle('on', geom.has(c.dataset.g!)));
+  };
   app.querySelectorAll<HTMLButtonElement>('#geom .chip').forEach((c) => {
     c.onclick = () => {
       const g = c.dataset.g!;
@@ -152,6 +167,29 @@ function createForm() {
       else { geom.add(g); c.classList.add('on'); }
     };
   });
+
+  // "Start from a file": discover columns → seed the builder + geometry.
+  let seeded: { parsed: Parsed; format: string } | null = null;
+  app.querySelector<HTMLInputElement>('#seed-file')!.onchange = async (e) => {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    const note = app.querySelector('#seed-note')!;
+    if (!file) return;
+    const format = detectFormat(file.name);
+    if (!format) { note.textContent = 'Use a .csv, .geojson or .kml file.'; return; }
+    try {
+      const parsed = parseImport(await file.text(), format);
+      if (!parsed.features.length) { note.textContent = 'No rows found in that file.'; return; }
+      const inf = inferSchema(parsed, format);
+      seeded = { parsed, format };
+      builder = mountSchemaBuilder(app.querySelector<HTMLElement>('#fields-builder')!, inf.fields);
+      geom.clear(); inf.geometry.forEach((t) => geom.add(t)); syncGeomChips();
+      app.querySelector<HTMLElement>('#seed-import')!.style.display = '';
+      (app.querySelector('#create') as HTMLButtonElement).textContent = `Create map & import ${parsed.features.length} rows`;
+      note.innerHTML = `Read <strong>${parsed.features.length}</strong> row${parsed.features.length === 1 ? '' : 's'} and guessed <strong>${inf.fields.length}</strong> field${inf.fields.length === 1 ? '' : 's'}. Review them below, then create.`;
+    } catch (err) {
+      note.textContent = `Couldn't read the file: ${(err as Error).message}`;
+    }
+  };
 
   // Reference-layer picker: search the bharatlas catalogue, choose at most one.
   let chosenRef: RefLayer | null = null;
@@ -200,8 +238,21 @@ function createForm() {
       if (dataYear !== undefined && !Number.isInteger(dataYear)) {
         err.textContent = 'Data year must be a whole number like 2026.'; btn.disabled = false; return;
       }
+
+      // Seeded from a file: validate the disclaimers + build the rows up front.
+      let seedImport: { source: string; records: unknown[] } | null = null;
+      if (seeded) {
+        const source = (app.querySelector('#seed-source') as HTMLInputElement).value.trim();
+        const rights = (app.querySelector('#seed-rights') as HTMLInputElement).checked;
+        if (!rights) { err.textContent = 'Tick the box confirming you can publish this data under the licence.'; btn.disabled = false; return; }
+        if (!source) { err.textContent = 'Name where this data comes from.'; btn.disabled = false; return; }
+        const f = fields as unknown as Field[];
+        const built = buildRecords(seeded.parsed.features, autoMapping(f, seeded.parsed.columns), f, [...geom]);
+        seedImport = { source, records: built.records };
+      }
+
       const turnstile_token = await turnstileToken();
-      const links = (await apiJson<{ id: string; links: Record<string, string> }>('/collections', '', {
+      const res = await apiJson<{ id: string; links: Record<string, string>; tokens: { admin: string } }>('/collections', '', {
         method: 'POST',
         body: JSON.stringify({
           name,
@@ -218,9 +269,15 @@ function createForm() {
           },
           turnstile_token,
         }),
-      })).links;
-      saveMap(name, links);
-      done(links);
+      });
+      if (seedImport && seedImport.records.length) {
+        await apiJson(`/collections/${res.id}/import`, res.tokens.admin, {
+          method: 'POST',
+          body: JSON.stringify({ records: seedImport.records, source: seedImport.source, rights_confirmed: true }),
+        }).catch(() => { /* map is created; the rows can still be imported from Manage */ });
+      }
+      saveMap(name, res.links);
+      done(res.links);
     } catch (e) {
       err.textContent = (e as Error).message;
       btn.disabled = false;

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -7,6 +7,21 @@ import { escapeHtml } from './util';
 import { BASEMAPS } from './basemap';
 import { searchLayers, type RefLayer } from './geo/catalog';
 
+// Catalogue facets a published map slots into ('other' first = the default).
+const CATEGORIES: [string, string][] = [
+  ['other', 'Other'],
+  ['boundaries', 'Boundaries'],
+  ['city-wards', 'City wards'],
+  ['people', 'People & places'],
+  ['environment', 'Environment'],
+  ['water', 'Water'],
+  ['agriculture', 'Agriculture & land use'],
+  ['transport', 'Transport & mobility'],
+  ['infrastructure', 'Infrastructure & utilities'],
+  ['culture', 'Culture & heritage'],
+  ['health-edu', 'Health & education'],
+];
+
 const OPEN_LICENCES: [string, string][] = [
   ['CC-BY-4.0', 'CC BY 4.0 (credit required)'],
   ['CC0-1.0', 'CC0 (public domain)'],
@@ -97,6 +112,8 @@ function createForm() {
       <input id="name" maxlength="120" placeholder="Bengaluru footpath survey" />
       <label>What's it for? <span class="hint">(shown to contributors)</span></label>
       <textarea id="purpose" maxlength="2000" placeholder="Mapping footpath condition across the ward"></textarea>
+      <label>Category <span class="hint">(where it slots in the atlas when published)</span></label>
+      <select id="category">${CATEGORIES.map(([id, l]) => `<option value="${id}">${l}</option>`).join('')}</select>
       <label>What contributors fill in <span class="hint">(the form for each point)</span></label>
       <div id="fields-builder"></div>
       <label>Contributors add <span class="hint">(pick one or more)</span></label>
@@ -116,6 +133,7 @@ function createForm() {
       <label>Data year <span class="hint">(optional)</span></label>
       <input id="year" inputmode="numeric" placeholder="2026" />
       <div style="height:16px"></div>
+      <p class="hint">Map <strong>public places and assets</strong>, not people or private details. You're responsible for what's collected and published. <a href="https://bharatlas.com/terms" target="_blank" rel="noopener">Terms</a>.</p>
       <button class="primary" id="create">Create map</button>
       <p id="err" class="warn"></p>
     </div>`;
@@ -194,6 +212,7 @@ function createForm() {
             version: 1,
             geometry: [...geom],
             fields,
+            category: app.querySelector<HTMLSelectElement>('#category')!.value,
             basemap: app.querySelector<HTMLSelectElement>('#basemap')!.value,
             reference_layer: chosenRef ? { id: chosenRef.id, pmtiles_url: chosenRef.pmtiles_url } : undefined,
           },

--- a/collect/src/publish/attribution.ts
+++ b/collect/src/publish/attribution.ts
@@ -12,12 +12,14 @@ export interface ContributorTally {
 export interface ComposedAttribution {
   line: string;
   contributors: ContributorTally[];
+  sources: string[]; // distinct imported-data sources (field data has none)
 }
 
 export function composeAttribution(
   projectName: string,
   license: string,
   contributorNames: readonly (string | null | undefined)[],
+  importSources: readonly (string | null | undefined)[] = [],
 ): ComposedAttribution {
   const counts = new Map<string, number>();
   let anon = 0;
@@ -42,6 +44,12 @@ export function composeAttribution(
     if (anon > 0) who += ' + anonymous';
   }
 
-  const line = who ? `${projectName} — ${who} (${license})` : projectName;
-  return { line, contributors };
+  const sources = [...new Set(importSources.map((s) => (typeof s === 'string' ? s.trim() : '')).filter(Boolean))];
+
+  let line = who ? `${projectName} — ${who} (${license})` : projectName;
+  if (sources.length) {
+    if (!who) line = `${projectName} (${license})`; // still needs the licence
+    line += `. Includes data from ${sources.join(', ')}`;
+  }
+  return { line, contributors, sources };
 }

--- a/collect/src/schema/validate-collection.ts
+++ b/collect/src/schema/validate-collection.ts
@@ -10,6 +10,11 @@ export const FIELD_TYPES = [
 ] as const;
 export const GEOMETRY_TYPES = ['point', 'line', 'polygon'] as const;
 export const BASEMAP_IDS = ['positron', 'satellite', 'topo'] as const;
+// Catalogue facets a published collection can slot into (mirrors catalog.json).
+export const CATEGORY_IDS = [
+  'boundaries', 'city-wards', 'people', 'environment', 'water',
+  'agriculture', 'transport', 'infrastructure', 'culture', 'health-edu', 'other',
+] as const;
 
 const KEY_RE = /^[a-z][a-z0-9_]*$/;
 const MAX_FIELDS = 20;
@@ -64,6 +69,10 @@ export function validateSchemaDoc(input: unknown): Result<Record<string, unknown
   if (refs !== undefined) {
     if (!Array.isArray(refs) || !refs.every(isStr)) return fail('reference_layers must be a string array');
     if (refs.length > MAX_REF_LAYERS) return fail(`too many reference layers (max ${MAX_REF_LAYERS})`);
+  }
+
+  if (doc.category !== undefined && !CATEGORY_IDS.includes(doc.category as (typeof CATEGORY_IDS)[number])) {
+    return fail(`unknown category: ${String(doc.category)}`);
   }
 
   // Map options (Phase 4/5): an author-chosen basemap + one bharatlas overlay.

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -150,6 +150,13 @@ textarea { min-height: 92px; line-height: 1.5; }
 }
 .link-box .btn, .link-box button { min-height: 40px; padding: 0 12px; }
 
+/* import column-mapping rows (field ← column) */
+.maplabel { font-size: 13px; font-weight: 600; color: var(--fg); margin: 14px 0 6px; }
+.maplabel .hint { font-weight: 400; }
+.maprow { display: flex; align-items: center; gap: 10px; margin: 6px 0; }
+.maprow > span { flex: 0 0 42%; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.maprow > select { flex: 1; min-width: 0; }
+
 /* reference-layer search results (create form) */
 .ref-results { display: flex; flex-direction: column; gap: 6px; margin-top: 6px; max-height: 230px; overflow: auto; }
 .ref-opt { width: 100%; justify-content: space-between; gap: 10px; }

--- a/collect/tests/attribution.test.ts
+++ b/collect/tests/attribution.test.ts
@@ -29,4 +29,15 @@ describe('composeAttribution', () => {
     const { contributors } = composeAttribution('S', 'CC-BY-4.0', ['B', 'A', 'A', 'C', 'C']);
     expect(contributors.map((c) => c.name)).toEqual(['A', 'C', 'B']);
   });
+
+  it('credits distinct imported sources alongside field contributors', () => {
+    const r = composeAttribution('Trees', 'CC-BY-4.0', ['Asha', null], ['SOI Atlas', 'SOI Atlas', 'FSI']);
+    expect(r.sources).toEqual(['SOI Atlas', 'FSI']);
+    expect(r.line).toBe('Trees — 1 contributor + anonymous (CC-BY-4.0). Includes data from SOI Atlas, FSI');
+  });
+
+  it('names the source even when there are no field contributors', () => {
+    const r = composeAttribution('Trees', 'CC-BY-4.0', [], ['FSI']);
+    expect(r.line).toBe('Trees (CC-BY-4.0). Includes data from FSI');
+  });
 });

--- a/collect/tests/formats.test.ts
+++ b/collect/tests/formats.test.ts
@@ -30,8 +30,8 @@ describe('toGeoJSON', () => {
 describe('toCSV', () => {
   it('has a header + one row per feature, with representative lng/lat', () => {
     const rows = toCSV(FEATURES, FIELDS).split('\n');
-    expect(rows[0]).toBe('lng,lat,geometry_type,name,cond,tags,contributor,status,state,district');
-    expect(rows[1]).toBe('77.61,12.98,Point,MG Road,Good,a|b,Ravi,published,KARNATAKA,Bengaluru Urban');
+    expect(rows[0]).toBe('lng,lat,geometry_type,name,cond,tags,contributor,source,status,state,district');
+    expect(rows[1]).toBe('77.61,12.98,Point,MG Road,Good,a|b,Ravi,,published,KARNATAKA,Bengaluru Urban');
     expect(rows).toHaveLength(3);
   });
   it('quotes cells with commas/quotes and uses the line first vertex', () => {

--- a/collect/tests/import.test.ts
+++ b/collect/tests/import.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { parseGeoJSON, parseCSV, parseCSVRows } from '../src/import/parse';
+import { autoMapping, buildRecords, errorsToCSV } from '../src/import/build';
+import type { Field } from '../src/schema/validate-record';
+
+const FIELDS: Field[] = [
+  { key: 'name', label: 'Name of the place', type: 'text', required: true },
+  { key: 'cond', label: 'Condition', type: 'select', options: ['Good', 'Bad'] },
+];
+
+describe('parseCSVRows', () => {
+  it('handles quotes, embedded commas + newlines', () => {
+    expect(parseCSVRows('a,b\n1,"x,y"\n2,"li\nne"')).toEqual([['a', 'b'], ['1', 'x,y'], ['2', 'li\nne']]);
+  });
+});
+
+describe('parseGeoJSON / parseCSV', () => {
+  it('reads a FeatureCollection', () => {
+    const p = parseGeoJSON(JSON.stringify({ type: 'FeatureCollection', features: [
+      { type: 'Feature', geometry: { type: 'Point', coordinates: [77.6, 12.9] }, properties: { name: 'A', cond: 'Good' } },
+    ] }));
+    expect(p.columns.sort()).toEqual(['cond', 'name']);
+    expect(p.features[0].geometry).toEqual({ type: 'Point', coordinates: [77.6, 12.9] });
+    expect(p.features[0].props).toEqual({ name: 'A', cond: 'Good' });
+  });
+  it('reads CSV headers + rows, geometry null', () => {
+    const p = parseCSV('name,cond,lng,lat\nA,Good,77.6,12.9\n');
+    expect(p.columns).toEqual(['name', 'cond', 'lng', 'lat']);
+    expect(p.features).toHaveLength(1);
+    expect(p.features[0].geometry).toBeNull();
+  });
+});
+
+describe('autoMapping', () => {
+  it('matches fields by key/label and finds lng/lat', () => {
+    const m = autoMapping(FIELDS, ['Name of the place', 'cond', 'longitude', 'latitude']);
+    expect(m.fields).toEqual({ name: 'Name of the place', cond: 'cond' });
+    expect(m.lng).toBe('longitude');
+    expect(m.lat).toBe('latitude');
+  });
+});
+
+describe('buildRecords', () => {
+  const geom = ['point'];
+  it('builds a Point from lng/lat columns and validates fields', () => {
+    const p = parseCSV('name,cond,lng,lat\nA,Good,77.6,12.9\nB,Nope,77.7,12.8\n');
+    const r = buildRecords(p.features, autoMapping(FIELDS, p.columns), FIELDS, geom);
+    expect(r.records).toHaveLength(1);
+    expect(r.records[0].geometry).toEqual({ type: 'Point', coordinates: [77.6, 12.9] });
+    expect(r.errors).toHaveLength(1); // "Nope" is not a valid Condition option
+    expect(r.errors[0].error).toMatch(/cond/i);
+  });
+  it('flags out-of-India + missing geometry', () => {
+    const p = parseCSV('name,lng,lat\nX,10,10\nY,,\n');
+    const r = buildRecords(p.features, autoMapping(FIELDS, p.columns), FIELDS, geom);
+    expect(r.records).toHaveLength(0);
+    expect(r.errors.map((e) => e.error).join(' ')).toMatch(/India|no geometry/);
+  });
+  it('rejects a geometry type the collection does not allow', () => {
+    const p = parseGeoJSON(JSON.stringify({ type: 'FeatureCollection', features: [
+      { type: 'Feature', geometry: { type: 'LineString', coordinates: [[77.6, 12.9], [77.7, 12.8]] }, properties: { name: 'L' } },
+    ] }));
+    const r = buildRecords(p.features, autoMapping(FIELDS, p.columns), FIELDS, ['point']);
+    expect(r.records).toHaveLength(0);
+    expect(r.errors[0].error).toMatch(/not allowed/);
+  });
+});
+
+describe('errorsToCSV', () => {
+  it('produces a re-uploadable file with an _error column', () => {
+    const csv = errorsToCSV([{ row: 0, error: 'bad', source: { name: 'A', lng: '10' } }]);
+    expect(csv.split('\n')[0]).toBe('name,lng,_error');
+    expect(csv.split('\n')[1]).toBe('A,10,bad');
+  });
+});

--- a/collect/tests/import.test.ts
+++ b/collect/tests/import.test.ts
@@ -69,7 +69,7 @@ describe('buildRecords', () => {
 describe('errorsToCSV', () => {
   it('produces a re-uploadable file with an _error column', () => {
     const csv = errorsToCSV([{ row: 0, error: 'bad', source: { name: 'A', lng: '10' } }]);
-    expect(csv.split('\n')[0]).toBe('name,lng,_error');
+    expect(csv.split('\n')[0]).toBe('name,lng,why');
     expect(csv.split('\n')[1]).toBe('A,10,bad');
   });
 });

--- a/collect/tests/infer.test.ts
+++ b/collect/tests/infer.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { guessType, inferSchema } from '../src/import/infer';
+import { parseCSV, parseGeoJSON } from '../src/import/parse';
+
+describe('guessType', () => {
+  it('detects number, date, select, paragraph, text', () => {
+    expect(guessType(['1', '2', '3']).type).toBe('number');
+    expect(guessType(['2021-01-01', '2022-05-09']).type).toBe('date');
+    const sel = guessType(['Good', 'Bad', 'Good', 'Bad', 'Good', 'Bad']);
+    expect(sel.type).toBe('select');
+    expect(sel.options).toEqual(['Good', 'Bad']);
+    expect(guessType(['x'.repeat(120)]).type).toBe('paragraph');
+    expect(guessType(['Kaveri footpath', 'MG Road', 'Church St']).type).toBe('text');
+  });
+  it('falls back to text on empty', () => {
+    expect(guessType(['', '  ']).type).toBe('text');
+  });
+});
+
+describe('inferSchema', () => {
+  it('CSV: point geometry, coordinate columns dropped, first col required', () => {
+    const p = parseCSV('name,condition,height_m,lng,lat\nA,Good,3,77.6,12.9\nB,Bad,5,77.7,12.8\nC,Good,4,77.8,12.7\nD,Bad,6,77.9,12.6\n');
+    const inf = inferSchema(p, 'csv');
+    expect(inf.geometry).toEqual(['point']);
+    expect(inf.fields.map((f) => f.key)).toEqual(['name', 'condition', 'height_m']); // lng/lat excluded
+    expect(inf.fields[0].required).toBe(true);
+    expect(inf.fields.find((f) => f.key === 'condition')?.type).toBe('select');
+    expect(inf.fields.find((f) => f.key === 'height_m')?.type).toBe('number');
+    expect(inf.mapping).toMatchObject({ name: 'name', condition: 'condition', height_m: 'height_m' });
+  });
+  it('GeoJSON: geometry taken from features', () => {
+    const p = parseGeoJSON(JSON.stringify({ type: 'FeatureCollection', features: [
+      { type: 'Feature', geometry: { type: 'Polygon', coordinates: [[[77, 12], [78, 12], [78, 13], [77, 12]]] }, properties: { name: 'Ward 1' } },
+    ] }));
+    expect(inferSchema(p, 'geojson').geometry).toEqual(['polygon']);
+  });
+});

--- a/collect/tests/validate-collection.test.ts
+++ b/collect/tests/validate-collection.test.ts
@@ -76,6 +76,11 @@ describe('validateSchemaDoc (the meta-schema check)', () => {
     expect(validateSchemaDoc({ ...goodSchema, reference_layers: ['a', 'b', 'c', 'd'] }).ok).toBe(false);
   });
 
+  it('accepts a known category, rejects an unknown one', () => {
+    expect(validateSchemaDoc({ ...goodSchema, category: 'environment' }).ok).toBe(true);
+    expect(validateSchemaDoc({ ...goodSchema, category: 'made-up' }).ok).toBe(false);
+  });
+
   it('accepts a valid basemap + reference_layer, rejects bad ones', () => {
     expect(validateSchemaDoc({ ...goodSchema, basemap: 'satellite' }).ok).toBe(true);
     expect(validateSchemaDoc({ ...goodSchema, basemap: 'streets' }).ok).toBe(false);

--- a/scripts/verify_migrations.py
+++ b/scripts/verify_migrations.py
@@ -65,6 +65,7 @@ def main():
     checks += [
         ("records has edit_token_hash", "edit_token_hash" in r),
         ("records has admin_ctx", "admin_ctx" in r),
+        ("records gained source (0008)", "source" in r),
     ]
 
     idx = conn.execute(

--- a/web/migrations/0008_record_source.sql
+++ b/web/migrations/0008_record_source.sql
@@ -1,0 +1,7 @@
+-- collect Phase 5: per-record provenance.
+-- `source` distinguishes field-collected records (NULL — the contributor's own
+-- observation) from bulk-imported records (the source the importer attested at
+-- import time). Per-record, so ONE collection can honestly mix collected +
+-- imported data, and publish can credit field contributors and imported sources
+-- separately in the attribution.
+ALTER TABLE records ADD COLUMN source TEXT;


### PR DESCRIPTION
Collect-side items from the "what's left" list (all under `collect/`, plus one shared migration).

## Publish category
Create form gains a **Category** select (11 catalogue facets); stored in `schema_doc`, used at publish — published layers stop defaulting to `other`.

## Content-safety / takedown
Acceptable-use notices ("public places and assets, not people") at create + contribute; a **Report this map** (mailto) + **Terms** link (to the apex `/terms`) on the view + admin screens.

## Phase 5 — Import (with a licence gate)
The admin **Manage** screen gains **Import data**: upload **CSV / GeoJSON / KML**, **auto-map columns → fields** (a bulk column-map with a live row-1 preview, not a single-record form), **validate every row**, **bulk-import** the valid ones, and **download the rejected rows** (a `why` column) to fix + re-import. New admin-only `POST /collections/:id/import` re-validates server-side and skips the per-contributor rate limit.

**Licence gate (prevents license laundering):**
- **Rights attestation** — import requires a ticked "I have the right to publish this under the map's licence" *and* a named **source**; the server rejects either missing.
- **Per-record provenance** — new `records.source` (**migration 0008**). Field-collected records have no source (credited to the contributor); imported records carry the attested source, so **one collection can mix collected + imported data** and each point is labelled honestly ("⇪ *source*" vs contributor in the review list).
- **Attribution credits both, separately** — imported records are named as *sources*, not folded into the contributor tally: *"… — 1 contributor (CC-BY-4.0). Includes data from SOI Atlas."* `contributors.json` gains `sources`; exports gain a `source` column.

## Overlay polish
Reference overlays recolour to a distinct **teal** with a lighter fill, so they read as context, not the user's own indigo data.

## ⚠️ Deploy step — apply migration 0008 to the shared REMOTE D1 BEFORE this merges
`insertRecord` now writes `records.source`; without the column every record insert (incl. normal contributions) 500s. Apply once (backward-compatible — a nullable column, safe to run against live before the code ships):
```
cd collect && npx wrangler d1 execute geodata-submissions --remote --file ../web/migrations/0008_record_source.sql
```

## Verification
**71 vitest** green · typecheck + build clean · `verify_migrations.py` asserts the new column · e2e-verified (import gate 400s without attestation/source; mixed field+imported provenance; attribution credits both) · verified in Chrome (mapping UI, source + attestation, category, safety footers) with **no console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)