### PR TITLE
web: add collect to the apex — nav link, mobile hamburger, about/docs/mcp

### DIFF
--- a/web/about.template.html
+++ b/web/about.template.html
@@ -93,6 +93,7 @@
       <li>Compare what each authoritative source (LGD vs SOI vs Bhuvan vs geoBoundaries) says about the same admin level by clicking the alternate-source links on any card.</li>
       <li>Download any layer whole as <strong>Parquet</strong>, <strong>PMTiles</strong>, <strong>GeoJSON</strong>, <strong>KML</strong> or <strong>Shapefile</strong> direct from the card. Or filter by what the columns actually contain (state, zone, area) and export just the slice.</li>
       <li><a href="/preview">Drop a file</a> to see it on a map and validate it. Optionally publish under an open licence. No signup; you get an admin token to keep forever.</li>
+      <li><a href="https://collect.bharatlas.com">Make a map anyone can add to</a> with <strong>collect</strong>: design a small form, share a link, and people add points in the field with no accounts. Review what comes in and publish it to the atlas. Built for the phone.</li>
       <li>Embed any map in a blog post or report (iframe snippet + PNG export, one click each).</li>
       <li><strong>Ask questions</strong> instead of downloading maps. Connect your AI assistant to the <a href="/mcp">bharatlas MCP server</a> and ask: "How many villages in my district?", "Which hospitals are near me?", "What flood zone is this area in?"</li>
       <li>Query any layer programmatically via the <a href="/docs">REST API</a>: filter, group, locate a point, find nearby features.</li>

--- a/web/docs.template.html
+++ b/web/docs.template.html
@@ -226,6 +226,23 @@ curl https://bharatlas.com/api/v1/layers/wards_pcmc/counts?group_by=zone</code><
       </table>
 
 <!-- DOCS_FAQ_HTML -->
+      <h2>collect API (write) <span class="badge badge--stable">stable</span></h2>
+      <p><a href="https://collect.bharatlas.com">collect</a> is the write side: design a map form, collect points from contributors, and publish into this catalogue. Separate origin, token-authed, its own contract.</p>
+      <p>Base URL: <code>https://collect.bharatlas.com/api/collect/v1</code></p>
+      <p>Auth is a bearer token in the URL fragment of each share link (kept out of server logs); the field-definition contract is the public meta-schema at <code>https://collect.bharatlas.com/schema/v1.json</code>. Creating a map programmatically needs an API key (the anti-abuse gate) via the <code>X-API-Key</code> header, since there is no browser Turnstile.</p>
+      <table>
+        <tr><th>Method</th><th>Endpoint</th><th>What</th></tr>
+        <tr><td>POST</td><td class="endpoint">/collections</td><td>create a map (Turnstile or X-API-Key); returns admin / collect / view links</td></tr>
+        <tr><td>GET</td><td class="endpoint">/collections/:id</td><td>map metadata + counts</td></tr>
+        <tr><td>PATCH</td><td class="endpoint">/collections/:id</td><td>edit settings (admin)</td></tr>
+        <tr><td>POST</td><td class="endpoint">/collections/:id/records</td><td>add one point (contributor)</td></tr>
+        <tr><td>GET</td><td class="endpoint">/collections/:id/records</td><td>records as GeoJSON (scoped by token)</td></tr>
+        <tr><td>POST</td><td class="endpoint">/collections/:id/import</td><td>bulk import with a source + rights attestation (admin)</td></tr>
+        <tr><td>POST</td><td class="endpoint">/records/:id/moderate</td><td>approve / reject (admin)</td></tr>
+        <tr><td>POST</td><td class="endpoint">/collections/:id/publish</td><td>bake approved points into a catalogue submission (admin)</td></tr>
+      </table>
+      <p>Or drive it from an LLM with the <a href="/mcp">collect MCP</a> (<code>npx collect-mcp</code>), the author-side counterpart to the read-only bharatlas MCP.</p>
+
       <h2>For LLMs</h2>
       <p>Use the <a href="/mcp">bharatlas MCP server</a> (<code>npx bharatlas-mcp</code>) to connect Claude, GPT, Gemini, or any MCP-compatible LLM directly to this API. 8 tools with built-in instructions for schema-first querying, spatial joins, and multi-source awareness.</p>
     </main>

--- a/web/mcp.template.html
+++ b/web/mcp.template.html
@@ -134,6 +134,21 @@
         <li><strong>list_submissions</strong> -- community-contributed layers under open licenses</li>
       </ul>
 
+      <h2>Also: collect MCP (write side)</h2>
+      <p>This server is <strong>read-only</strong>. Its author-side counterpart, <strong>collect-mcp</strong>, drives <a href="https://collect.bharatlas.com">collect</a>: design a map form, review contributions, and publish into this catalogue, all from your LLM.</p>
+      <div class="install-box">
+        <pre><code>{
+  "mcpServers": {
+    "collect": {
+      "command": "npx",
+      "args": ["-y", "collect-mcp"],
+      "env": { "COLLECT_API_KEY": "cak_…" }
+    }
+  }
+}</code></pre>
+      </div>
+      <p style="font-size:13px;color:var(--muted)">Tools: create_collection, edit_collection, list_records, moderate_record, import_records, publish. Creating maps needs an API key (the anti-abuse gate). It is deliberately not a bulk-contribution surface — human field contributors are the source; published maps then show up here via <code>list_submissions</code>.</p>
+
       <h2>How it works</h2>
       <p>The MCP server is a thin wrapper over the <a href="/docs">bharatlas REST API</a>. It translates LLM tool calls into API requests and returns structured JSON. No API key needed. All data is read-only and openly licensed.</p>
       <p>The server sends instructions to the LLM at connection time that teach it:</p>

--- a/web/scripts/shared-chrome.mjs
+++ b/web/scripts/shared-chrome.mjs
@@ -68,11 +68,21 @@ export const TOKENS = `
   }
   .site-nav a:hover { color: var(--fg); }
   .site-nav a[data-active] { color: var(--fg); font-weight: 500; }
-  @media (max-width: 480px) {
-    .site-header { gap: var(--sp-2); margin-bottom: var(--sp-4); }
+  /* mobile hamburger (CSS-only, checkbox toggle) */
+  .nav-toggle { position: absolute; width: 1px; height: 1px; opacity: 0; overflow: hidden; }
+  .nav-burger {
+    display: none; align-items: center; justify-content: center;
+    min-width: 44px; min-height: 44px; font-size: 20px; line-height: 1;
+    color: var(--fg); cursor: pointer; border: 1px solid var(--line); border-radius: var(--radius-md);
+  }
+  .nav-toggle:focus-visible ~ .nav-burger { outline: 2px solid var(--accent-strong); outline-offset: 2px; }
+  @media (max-width: 640px) {
+    .site-header { gap: var(--sp-2); margin-bottom: var(--sp-4); position: relative; align-items: center; }
     .site-brand .tagline { display: none; }
-    .site-nav { gap: var(--sp-2); }
-    .site-nav a { font-size: var(--fs-sm); }
+    .nav-burger { display: inline-flex; }
+    .site-nav { display: none; flex-direction: column; align-items: stretch; gap: 0; width: 100%; margin-top: var(--sp-2); }
+    .nav-toggle:checked ~ .site-nav { display: flex; }
+    .site-nav a { width: 100%; padding: 12px 4px; min-height: 48px; border-top: 1px solid var(--line); }
   }
   .site-footer {
     margin-top: var(--sp-8); padding-top: var(--sp-5);
@@ -87,6 +97,7 @@ export const TOKENS = `
 export const NAV_LINKS = [
   { k: 'catalog', href: '/', label: 'catalog' },
   { k: 'preview', href: '/preview', label: 'contribute' },
+  { k: 'collect', href: 'https://collect.bharatlas.com', label: 'collect' },
   { k: 'docs', href: '/docs', label: 'docs' },
   { k: 'mcp', href: '/mcp', label: 'mcp' },
   { k: 'about', href: '/about', label: 'about' },
@@ -96,7 +107,9 @@ export function renderNav(activeKey) {
   return `<a class="skip-link" href="#main">Skip to content</a>
     <header class="site-header">
       <a class="site-brand" href="/">bhar<span class="mark-accent">atlas</span><span class="tagline">India's open atlas</span></a>
-      <nav class="site-nav">
+      <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+      <label for="nav-toggle" class="nav-burger" aria-label="Menu">☰</label>
+      <nav class="site-nav" id="site-nav" aria-label="Primary">
         ${NAV_LINKS.map(
           (l) =>
             `<a href="${l.href}"${l.k === activeKey ? ' data-active' : ''}${l.href.startsWith('http') ? ' target="_blank" rel="noopener"' : ''}>${l.label}</a>`,


### PR DESCRIPTION
Surfaces collect on the main bharatlas.com site (all under `web/`; templates + shared-chrome only, prerendered `*.html` are gitignored).

- **Nav:** a **collect** link next to **contribute** (→ collect.bharatlas.com). Six items made the mobile nav too long, so it collapses to a **CSS-only hamburger** (checkbox toggle, no JS) below 640px; full nav on desktop.
- **/about:** a line under "What you can do today" — make a map anyone can add to with collect.
- **/docs:** a **collect API (write)** section — the token-authed contribution API (create / records / import / moderate / publish), the meta-schema, and the `X-API-Key` create gate.
- **/mcp:** an **Also: collect MCP** section with its install snippet + the read-only vs author-side split.

The shared nav is a pure module (`renderNav`) — **672 web tests pass**. Verified in Chrome: desktop shows all six links; mobile collapses to the hamburger and opens to the full menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)