### PR TITLE
feat(collect): public masthead counter + clearer home/publish copy

### DIFF
--- a/collect/functions/api/collect/[[path]].ts
+++ b/collect/functions/api/collect/[[path]].ts
@@ -28,6 +28,11 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
   const { env, request } = ctx;
   const defer = (promise: Promise<unknown>): void => ctx.waitUntil(promise);
 
+  // /v1/stats — public masthead counts
+  if (p.length === 1 && p[0] === 'stats') {
+    return method === 'GET' ? h.getStats(env) : bad(405, 'method not allowed');
+  }
+
   // /v1/collections
   if (p.length === 1 && p[0] === 'collections') {
     return method === 'POST' ? h.createCollection(env, request) : bad(405, 'method not allowed');

--- a/collect/functions/lib/handlers.ts
+++ b/collect/functions/lib/handlers.ts
@@ -170,6 +170,25 @@ export async function getCollectionMeta(env: Env, req: Request, id: string): Pro
   });
 }
 
+// ---- GET /stats ------------------------------------------------------------
+// Public aggregate counts for the home masthead (no PII: distinct ip_hash only).
+// Edge-cached so the home page load never waits on a fresh count.
+
+export async function getStats(env: Env): Promise<Response> {
+  const row = (await env.DB.prepare(
+    `SELECT
+       (SELECT COUNT(*) FROM collections) AS maps,
+       (SELECT COUNT(*) FROM records WHERE status = 'published') AS points,
+       (SELECT COUNT(DISTINCT ip_hash) FROM records) AS contributors,
+       (SELECT COUNT(DISTINCT json_extract(admin_ctx, '$.state')) FROM records
+          WHERE admin_ctx IS NOT NULL AND json_extract(admin_ctx, '$.state') IS NOT NULL) AS states`,
+  ).first()) as { maps: number; points: number; contributors: number; states: number } | null;
+  return new Response(
+    JSON.stringify({ maps: row?.maps ?? 0, points: row?.points ?? 0, contributors: row?.contributors ?? 0, states: row?.states ?? 0 }),
+    { status: 200, headers: { 'content-type': 'application/json', 'access-control-allow-origin': '*', 'cache-control': 'public, max-age=300' } },
+  );
+}
+
 // ---- PATCH /collections/:id ------------------------------------------------
 // Admin "Edit map settings": name/description/purpose/data_year/category/basemap/
 // reference_layer (+ licence only while the map has no records). Fields untouched.

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -478,7 +478,7 @@ async function manageSheet(): Promise<void> {
     </div>
     <div class="foot row">
       <button id="back">+ Add points</button>
-      <button class="primary" id="publish" style="flex:1">Publish → atlas</button>
+      <button class="primary" id="publish" style="flex:1">Publish → catalog</button>
     </div>
   </div>`;
   (document.getElementById('back') as HTMLButtonElement).onclick = captureSheet;
@@ -795,7 +795,7 @@ async function doPublish(ev: Event): Promise<void> {
     toast(`Published v${res.version} · ${res.feature_count} features`);
     const panel = document.getElementById('panel')!;
     panel.innerHTML = `<div class="sheet"><div class="body">
-      <strong>Published to the atlas 🎉</strong>
+      <strong>Published to the catalog 🎉</strong>
       <p class="hint">Version ${res.version} · ${res.feature_count} features.</p>
       <a class="btn primary" href="${res.share_url}" target="_blank" rel="noopener">View on bharatlas →</a>
       </div><div class="foot"><button id="back">← Back to capture</button></div></div>`;

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -50,7 +50,7 @@ function home() {
     <div class="topbar"><span>collect</span><a class="brand" href="https://bharatlas.com">bhar<span class="brand-accent">atlas</span></a></div>
     <div class="pad">
       <h1>Make a map, collect together</h1>
-      <p class="hint">Here you <strong>design</strong> a small form and share a link. <strong>Anyone with the link</strong> can <strong>add points</strong> on the map, no accounts. Publish to the bharatlas atlas when it's ready.</p>
+      <p class="hint">Here you <strong>design</strong> a small form and share a link. <strong>Anyone with the link</strong> can <strong>add points</strong> on the map, no accounts. Download the data, or publish it to the bharatlas catalog when it's ready.</p>
       <p id="masthead-stat" class="masthead-stat"></p>
       <button class="primary" id="start">＋ Make a new map</button>
       <div style="height:18px"></div>
@@ -106,7 +106,7 @@ function createForm() {
       <input id="name" maxlength="120" placeholder="Bengaluru footpath survey" />
       <label>What's it for? <span class="hint">(shown to contributors)</span></label>
       <textarea id="purpose" maxlength="2000" placeholder="Mapping footpath condition across the ward"></textarea>
-      <label>Category <span class="hint">(where it slots in the atlas when published)</span></label>
+      <label>Category <span class="hint">(where it slots in the catalog when published)</span></label>
       <select id="category">${CATEGORIES.map(([id, l]) => `<option value="${id}">${l}</option>`).join('')}</select>
       <label>What contributors fill in <span class="hint">(the form for each point)</span></label>
       <div id="fields-builder"></div>

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -15,6 +15,21 @@ import { CATEGORIES, OPEN_LICENCES } from './options';
 
 const app = document.getElementById('app')!;
 
+// Public masthead counter (like the atlas's download counts): points collected
+// so far, best-effort. Hidden until there's something to show.
+async function fillMasthead(): Promise<void> {
+  try {
+    const s = await apiJson<{ points: number; contributors: number; states: number }>('/stats', '');
+    const el = document.getElementById('masthead-stat');
+    if (!el || !s.points) return;
+    const n = (x: number): string => x.toLocaleString('en-IN');
+    const parts = [`<strong>${n(s.points)}</strong> point${s.points === 1 ? '' : 's'} collected`];
+    if (s.contributors > 1) parts.push(`by ${n(s.contributors)} people`);
+    if (s.states > 1) parts.push(`across ${n(s.states)} states`);
+    el.innerHTML = parts.join(' · ');
+  } catch { /* best-effort */ }
+}
+
 const ROLE_PILL: Record<MapRole, string> = { owner: 'Owner', collect: 'Collect', view: 'View' };
 
 function mapsSection(): string {
@@ -35,7 +50,8 @@ function home() {
     <div class="topbar"><span>collect</span><a class="brand" href="https://bharatlas.com">bhar<span class="brand-accent">atlas</span></a></div>
     <div class="pad">
       <h1>Make a map, collect together</h1>
-      <p class="hint">Here you <strong>design</strong> a small form. Share the collect link and anyone <strong>adds points</strong> on the map, no accounts. Publish to the bharatlas atlas when it's ready.</p>
+      <p class="hint">Here you <strong>design</strong> a small form and share a link. <strong>Anyone with the link</strong> can <strong>add points</strong> on the map, no accounts. Publish to the bharatlas atlas when it's ready.</p>
+      <p id="masthead-stat" class="masthead-stat"></p>
       <button class="primary" id="start">＋ Make a new map</button>
       <div style="height:18px"></div>
       ${mapsSection()}
@@ -50,6 +66,7 @@ function home() {
       </footer>
     </div>`;
   app.querySelector<HTMLButtonElement>('#start')!.onclick = createForm;
+  void fillMasthead();
 
   app.querySelector<HTMLButtonElement>('#export')!.onclick = () => {
     const a = document.createElement('a');

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -150,6 +150,9 @@ textarea { min-height: 92px; line-height: 1.5; }
 .pad { padding: 20px 16px calc(20px + env(safe-area-inset-bottom)); overflow: auto; }
 .pad h1 { font-size: 23px; font-weight: 700; letter-spacing: -.025em; line-height: 1.15; margin: 6px 0 8px; }
 .hint { color: var(--muted); font-size: 13px; line-height: 1.5; font-variant-numeric: tabular-nums; }
+.masthead-stat { color: var(--muted); font-size: 13px; margin: 2px 0 14px; }
+.masthead-stat:empty { display: none; }
+.masthead-stat strong { color: var(--accent); font-weight: 700; font-variant-numeric: tabular-nums; }
 .warn { color: var(--danger); font-size: 13px; line-height: 1.5; }
 
 .link-box {


### PR DESCRIPTION
## What

Public-facing stats + copy polish for collect.bharatlas.com.

### Masthead counter
- New `GET /api/collect/v1/stats` (public, edge-cached 5min, no PII): `{maps, points, contributors, states}`.
- Home masthead shows a live "N points collected · by M people" line (`en-IN` formatted, hides itself when points = 0).

### Home + publish copy
- Home: "**Anyone with the link** can add points on the map, no accounts. **Download the data, or publish it to the bharatlas catalog** when it's ready." (fixes the earlier "anyone adds points, no accounts" phrasing — only link-holders can collect).
- "atlas" → "catalog" for the publish destination: the Manage `Publish → catalog` button, the `Published to the catalog 🎉` screen, and the category hint.

## Verify
- `npm run build` clean.
- `/stats` returns the counts shape; masthead renders and hides at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)