### PR TITLE
chore(collect): allow Cloudflare Web Analytics beacon in CSP

### DIFF
--- a/collect/public/_headers
+++ b/collect/public/_headers
@@ -1,6 +1,7 @@
 # Cloudflare Pages security headers for collect. CSP allows exactly what the app
 # needs: self, Turnstile, the basemap tile hosts (CARTO / Esri imagery / OpenTopo),
-# the bharatlas catalogue API + its R2 host for pmtiles reference overlays.
+# the bharatlas catalogue API + its R2 host for pmtiles reference overlays, and the
+# Cloudflare Web Analytics beacon (edge-injected script + its cross-origin report).
 # noindex keeps unlisted collections off search (spec). Verify in prod after
 # the first deploy — a too-strict CSP would break the map, tiles, or Turnstile.
 /*
@@ -9,4 +10,4 @@
   X-Frame-Options: DENY
   X-Robots-Tag: noindex
   Permissions-Policy: geolocation=(self), camera=()
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://services.arcgisonline.com https://*.tile.opentopomap.org; connect-src 'self' https://*.basemaps.cartocdn.com https://challenges.cloudflare.com https://bharatlas.com https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://services.arcgisonline.com https://*.tile.opentopomap.org; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com; form-action 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; script-src 'self' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://services.arcgisonline.com https://*.tile.opentopomap.org; connect-src 'self' https://*.basemaps.cartocdn.com https://challenges.cloudflare.com https://cloudflareinsights.com https://bharatlas.com https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://services.arcgisonline.com https://*.tile.opentopomap.org; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com; form-action 'self'


### PR DESCRIPTION
## What
Widen collect's Content-Security-Policy so the browser accepts Cloudflare's
edge-injected Web Analytics beacon, once Web Analytics is enabled on the
collect Pages project (Automatic setup):

- `script-src`  += `https://static.cloudflareinsights.com` (beacon.min.js)
- `connect-src` += `https://cloudflareinsights.com` (RUM report endpoint)

No `<script>` tag in our HTML — Cloudflare injects the beacon at the edge for
the proxied custom domain `collect.bharatlas.com`.

## Why
Mirrors the apex: `web/public/_headers` already whitelists
`static.cloudflareinsights.com`, which is exactly why `bharatlas.com`'s
automatic beacon works under a strict CSP. This brings collect to parity so
the ops-dashboard can read collect's pageviews / Core Web Vitals / visitor
geography (its RUM config is already wired: host `collect.bharatlas.com`,
auto-resolve).

## Verify
- `npm run build` clean; `dist/_headers` carries both beacon hosts.
- After deploy: enable Web Analytics → collect Pages project → Automatic, then
  confirm the beacon loads without a CSP violation in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)