### PR TITLE
fix(mcp): registry-valid server.json + refresh .well-known/mcp.json to 1.1.0

### DIFF
--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.urbanmorph/bharatlas-mcp",
-  "description": "Query India's open geo data (locate, filter, nearby), and author collect maps: register a share link, moderate contributions, and publish to the catalog.",
+  "description": "Query India's open geo data, and author collect maps: register a link, moderate, publish.",
   "version": "1.1.0",
   "packages": [
     {

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -1,8 +1,8 @@
 {
   "name": "bharatlas",
-  "description": "India's open atlas. Query geo layers, locate points, find nearby features, filter and download data.",
+  "description": "India's open atlas. Query geo layers (locate, filter, nearby, download), and author your own maps with collect.",
   "url": "https://bharatlas.com",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "server": {
     "command": "npx",
     "args": ["-y", "bharatlas-mcp"],
@@ -16,7 +16,16 @@
     "nearby",
     "get_layer_detail",
     "list_categories",
-    "list_submissions"
+    "list_submissions",
+    "register_map",
+    "list_my_maps",
+    "get_map",
+    "get_records",
+    "moderate_record",
+    "import_points",
+    "edit_map",
+    "publish",
+    "create_map"
   ],
   "links": {
     "npm": "https://www.npmjs.com/package/bharatlas-mcp",


### PR DESCRIPTION
Prep for the MCP-registry submission + fixes a stale discovery asset.

- **server.json**: `mcp-publisher validate` failed (registry caps `description` at 100 chars). Trimmed to a valid ≤100-char description; validation now passes.
- **.well-known/mcp.json**: was stale at `1.0.1` and listed only the 8 read tools. Bumped to `1.1.0` and now lists all 17 tools including the collect authoring set (register_map, get_records, moderate_record, import_points, edit_map, publish, create_map, …).

After merge, the registry submission is just `mcp-publisher login github` + `mcp-publisher publish` from `mcp/` (interactive GitHub auth — owner only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)