### PR TITLE
chore(mcp): publish under personal namespace io.github.sathya-sankaran (v1.1.1)

### DIFF
--- a/mcp/index.js
+++ b/mcp/index.js
@@ -597,7 +597,7 @@ async function handleTool(name, args) {
 }
 
 const server = new Server(
-  { name: "bharatlas-mcp", version: "1.1.0" },
+  { name: "bharatlas-mcp", version: "1.1.1" },
   { capabilities: { tools: {} }, instructions: SERVER_INSTRUCTIONS },
 );
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,11 +1,11 @@
 {
   "name": "bharatlas-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MCP server for India's open geo data. Query layers, locate points, find nearby features, filter and group data. Also authors collect maps: register a share link, moderate contributions, and publish to the catalog.",
   "keywords": ["mcp", "india", "geo", "geospatial", "gis", "boundaries", "parquet", "pmtiles", "llm", "claude", "bharatlas", "collect"],
   "repository": { "type": "git", "url": "git+https://github.com/urbanmorph/geodata.git", "directory": "mcp" },
   "homepage": "https://bharatlas.com/mcp",
-  "mcpName": "io.github.urbanmorph/bharatlas-mcp",
+  "mcpName": "io.github.sathya-sankaran/bharatlas-mcp",
   "type": "module",
   "main": "index.js",
   "bin": {

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.urbanmorph/bharatlas-mcp",
+  "name": "io.github.sathya-sankaran/bharatlas-mcp",
   "description": "Query India's open geo data, and author collect maps: register a link, moderate, publish.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "bharatlas-mcp",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "transport": { "type": "stdio" }
     }
   ]

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -2,7 +2,7 @@
   "name": "bharatlas",
   "description": "India's open atlas. Query geo layers (locate, filter, nearby, download), and author your own maps with collect.",
   "url": "https://bharatlas.com",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "server": {
     "command": "npx",
     "args": ["-y", "bharatlas-mcp"],


### PR DESCRIPTION
The MCP registry won't grant `io.github.urbanmorph/*` (org membership isn't verifiable through its OAuth app — confirmed public membership + owner role + OAuth restrictions removed, still 403). This matches how **mdshare-mcp** was already published: under the personal namespace `io.github.sathya-sankaran/*` from the org repo.

- `server.json` `name` + `package.json` `mcpName` → `io.github.sathya-sankaran/bharatlas-mcp`
- Bump `1.1.0` → `1.1.1` (package.json, server.json, index.js, .well-known/mcp.json) — an npm republish is required because the published `mcpName` must match `server.json`, and npm versions are immutable.

`mcp-publisher validate` passes. After merge, publish npm `1.1.1` then `mcp-publisher publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)