### PR TITLE
PDGI re-evaluation: honest privacy disclosure + machine-readable rights signals

### DIFF
--- a/PDGI.md
+++ b/PDGI.md
@@ -32,9 +32,9 @@ Evidence: [/privacy](https://bharatlas.com/privacy), the anonymous token flow.
 Anyone can publish open geo data here for free and anonymously. Community layers are permanent and credited to the contributor, on their terms.
 Evidence: the submit flow, community cards, contributor attribution.
 
-### Humans in the loop (AI does not cut people out) — 🟡
-The MCP server and REST API expose data to AI agents with their source and licence, and the published-page provenance lets answers trace back to the origin. But the machine-readable rights signals that make this enforceable (attribution that travels with the data, an honor-the-terms norm for agents) are not shipped yet.
-Direction: add schema.org `creditText`, `conditionsOfAccess` and `usageInfo` to the view-page structured data, one line in the MCP instructions, and a usage stanza in `robots.txt`. A small change that closes this gap.
+### Humans in the loop (AI does not cut people out) — ✅
+The MCP server and REST API expose data to AI agents with their source and licence, and the published-page provenance lets answers trace back to the origin. The machine-readable rights signals now travel with the data: every /view page's Dataset JSON-LD carries `creditText` (the credit to reproduce), `conditionsOfAccess` and `usageInfo` (a link to the terms); `robots.txt` states the reuse-and-attribution norm for crawlers; and the MCP instructions tell agents to credit the source and honor the licence.
+Evidence: the /view page Dataset structured data, [/robots.txt](https://bharatlas.com/robots.txt), the MCP server instructions.
 
 ### A non-digital alternative must exist — 🟡
 Every layer is downloadable as files you can use offline and print, and view pages are plain HTML readable without JavaScript. But bharatlas is a data tool, not a citizen-facing service, so the true non-digital fallback for an end-need (for example, "which ward am I in") is the government office, not us.

--- a/PDGI.md
+++ b/PDGI.md
@@ -25,8 +25,8 @@ MIT code. Open data under open licences only: the submission form rejects propri
 Evidence: [LICENSE](./LICENSE), the open-licence allowlist in the submit flow.
 
 ### Privacy — ✅
-No third-party analytics, no tracking, no ad tech; first-party metrics only. Contribution is anonymous: no account, no email, no personal data collected.
-Evidence: [/about](https://bharatlas.com/about) ("no tracking, no third-party analytics"), the anonymous token flow.
+No ad-tech, no behavioural or cross-site tracking, no tracking cookies, no fingerprinting. The only measurement is Cloudflare Web Analytics: cookieless, aggregate page counts with no personal data, disclosed on the privacy page. Contribution is anonymous: no account, no email, no personal data collected.
+Evidence: [/privacy](https://bharatlas.com/privacy), the anonymous token flow.
 
 ### Platform cooperativism — ✅
 Anyone can publish open geo data here for free and anonymously. Community layers are permanent and credited to the contributor, on their terms.

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -36,6 +36,7 @@ Workflow patterns:
   3. For precise spatial containment, test individual points via locate against the target layer
 - **Community layers**: list_submissions returns user-contributed datasets. These work with query_layer and get_layer_schema exactly like curated layers.
 - **Downloads**: get_layer_detail returns direct URLs for parquet, pmtiles, geojson, kml, and shapefile formats.
+- **Honor the terms**: every layer and community submission carries its own source and open licence. When you use, quote, or publish results from a layer, credit its source and respect that licence; get_layer_detail returns the attribution and licence, and each /view page's Dataset JSON-LD carries a creditText to reproduce.
 
 Source preference (multiple layers often cover the same level):
 - **Admin boundaries** (state, district, subdistrict, block, village): prefer LGD (lgd_*) as the authoritative source. SOI, Bhuvan, and geoBoundaries are cross-reference alternates with slightly different counts/boundaries. Mention alternates if the user asks about discrepancies.

--- a/web/functions/lib/view-dataset.ts
+++ b/web/functions/lib/view-dataset.ts
@@ -265,6 +265,10 @@ export function buildViewDataset(
   const ogImage = `${origin}/og/view/${layer.id}.png`;
   const distribution = buildDistribution(layer);
   const wardListJsonLd = buildWardTable(wardIndex).jsonLd;
+  // Machine-readable rights that travel with the data to AI agents and dataset
+  // crawlers (PDGI "humans in the loop"): the credit to reproduce, that access
+  // is unrestricted, and where the usage terms live.
+  const creditText = `Source: ${layer.source}. Published via bharatlas (bharatlas.com).${layer.licence ? ` Licence: ${layer.licence}.` : ''}`;
 
   return {
     title,
@@ -280,6 +284,9 @@ export function buildViewDataset(
       url: canonical,
       license: layer.licence ? mapLicenceUrl(layer.licence) : undefined,
       isAccessibleForFree: true,
+      creditText,
+      conditionsOfAccess: 'Free and open. No account or API key required.',
+      usageInfo: `${origin}/terms`,
       creator: { '@type': 'Organization', name: layer.source },
       publisher: { '@type': 'Organization', name: 'bharatlas', url: 'https://bharatlas.com' },
       spatialCoverage: { '@type': 'Place', name: 'India' },

--- a/web/functions/robots.txt.ts
+++ b/web/functions/robots.txt.ts
@@ -10,6 +10,11 @@ const ROBOTS = `# bharatlas is open data — search engines, AI assistants and d
 # crawlers are all welcome. The catalog is CC0/CC-BY upstream sources;
 # community submissions carry their own open licence on each card.
 
+# Usage: reuse is welcome under each layer's stated open licence. When you use or
+# quote a layer, reproduce its attribution (the creditText in the page's Dataset
+# JSON-LD) and keep the source link. Full terms: https://bharatlas.com/terms
+# LLM guidance: https://bharatlas.com/llms.txt
+
 User-agent: *
 Allow: /
 

--- a/web/privacy.template.html
+++ b/web/privacy.template.html
@@ -31,8 +31,10 @@
     <main id="main">
     <h1 class="hero">Privacy</h1>
     <p class="lede">
-      bharatlas runs without accounts, without third-party analytics, and without tracking
-      cookies. This page is short because we collect little.
+      bharatlas runs without accounts and without tracking cookies, ad-tech, or
+      behavioural profiling. The only thing we measure is cookieless, aggregate traffic
+      (Cloudflare Web Analytics), with no personal data. This page is short because we
+      collect little.
     </p>
 
     <h2>What we store</h2>
@@ -45,7 +47,7 @@
     <h2>What we don't do</h2>
     <ul>
       <li>No accounts. No email collection. No name collection.</li>
-      <li>No third-party analytics (no Google Analytics, no Hotjar, no Mixpanel, no fingerprinting libraries).</li>
+      <li>No behavioural, cross-site, or ad-tech analytics (no Google Analytics, no Hotjar, no Mixpanel, no fingerprinting libraries).</li>
       <li>No advertising. No data sharing. No data sale.</li>
       <li>No social-network embed pixels.</li>
     </ul>
@@ -54,6 +56,7 @@
     <ul>
       <li><strong>Cloudflare</strong> (Pages, R2, D1, Turnstile) hosts everything. Their <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">privacy policy</a> covers their edge logs.</li>
       <li><strong>Turnstile</strong> (a CAPTCHA replacement, also Cloudflare) runs on the publish form to deter automated abuse. No personal data is sent to it.</li>
+      <li><strong>Cloudflare Web Analytics</strong> counts aggregate page views and load performance so we can see what gets used. It is cookieless, sets nothing on your device, collects no personal data, and cannot follow you across sites.</li>
       <li>The maps you browse stream from R2 with no usage tracking by us.</li>
     </ul>
 

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -2,6 +2,11 @@
 # crawlers are all welcome. The catalog is CC0/CC-BY upstream sources;
 # community submissions carry their own open licence on each card.
 
+# Usage: reuse is welcome under each layer's stated open licence. When you use or
+# quote a layer, reproduce its attribution (the creditText in the page's Dataset
+# JSON-LD) and keep the source link. Full terms: https://bharatlas.com/terms
+# LLM guidance: https://bharatlas.com/llms.txt
+
 # Catch-all
 User-agent: *
 Allow: /

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -1040,7 +1040,7 @@ const WEBSITE_REF = { '@type': 'WebSite', name: 'bharatlas', url: ORIGIN + '/' }
 await renderPage('privacy', {
   title: 'Privacy',
   description:
-    "Bharatlas runs without accounts, third-party analytics or tracking cookies. This page explains what we store (very little) and what we don't.",
+    "Bharatlas runs without accounts, ad-tech or tracking cookies (only cookieless, aggregate traffic counts). This page explains what we store (very little) and what we don't.",
   url: ORIGIN + '/privacy',
   image: ORIGIN + '/og-default.png',
   structuredData: {
@@ -1058,7 +1058,7 @@ await renderPage('privacy', {
         name: 'Privacy',
         url: ORIGIN + '/privacy',
         isPartOf: WEBSITE_REF,
-        about: 'Privacy practices for bharatlas: no accounts, no third-party analytics, no tracking cookies.',
+        about: 'Privacy practices for bharatlas: no accounts, no ad-tech, no tracking cookies, cookieless aggregate analytics only.',
       },
     ],
   },

--- a/web/tests/view-dataset.test.ts
+++ b/web/tests/view-dataset.test.ts
@@ -171,6 +171,14 @@ describe('buildViewDataset — Dataset distribution (Google Dataset Search)', ()
     expect(v.jsonLd.isAccessibleForFree).toBe(true);
     expect(v.jsonLd.publisher).toMatchObject({ '@type': 'Organization', name: 'bharatlas' });
   });
+
+  it('carries machine-readable rights (creditText, conditionsOfAccess, usageInfo)', () => {
+    const v = buildViewDataset({ ...layer, source: 'LGD', licence: 'CC-BY-4.0' }, { label: 'X' }, ORIGIN);
+    expect(v.jsonLd.creditText).toContain('Source: LGD');
+    expect(v.jsonLd.creditText).toContain('Licence: CC-BY-4.0');
+    expect(v.jsonLd.conditionsOfAccess).toBe('Free and open. No account or API key required.');
+    expect(v.jsonLd.usageInfo).toBe(`${ORIGIN}/terms`);
+  });
 });
 
 describe('resolveLevelMeta', () => {


### PR DESCRIPTION
Two fixes from re-evaluating the deployment against `PDGI.md`.

## 1. Privacy — corrected to honest (stays ✅)
The `/privacy` page claimed **"No third-party analytics"** while bharatlas.com + collect.bharatlas.com run **Cloudflare Web Analytics** (cookieless, aggregate, no PII, but a third-party service). Chose to keep the analytics and make the claims accurate:
- `/privacy`: reworded to "no ad-tech / behavioural / cross-site tracking / fingerprinting / cookies"; **Cloudflare Web Analytics disclosed under "Third parties involved."**
- `prerender.mjs`: same correction in the `/privacy` meta + JSON-LD.
- `PDGI.md` Privacy row: states the measurement honestly, links `/privacy`.

## 2. Humans-in-the-loop — 🟡 → ✅
Shipped the machine-readable rights signals so attribution + terms travel with the data to AI agents:
- **view-page Dataset JSON-LD** now carries `creditText` (credit to reproduce), `conditionsOfAccess` (free/open), and `usageInfo` (link to `/terms`). Unit test added.
- **robots.txt** (dynamic + static): a usage stanza stating the reuse-and-attribution norm + links to `/terms` and `/llms.txt`.
- **MCP instructions**: an "Honor the terms" line (in source; ships with the next `bharatlas-mcp` release — not worth a single-line republish now).
- `PDGI.md`: Humans-in-the-loop row moved to ✅ with evidence.

## Verified
- 673/673 tests pass (incl. a new rights-fields test), prerender builds, no em-dashes in the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)