### PR TITLE
fix(collect): funnel logging was dropped (fire-and-forget); register via waitUntil

### DIFF
--- a/collect/functions/api/collect/[[path]].ts
+++ b/collect/functions/api/collect/[[path]].ts
@@ -35,7 +35,7 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
 
   // /v1/collections
   if (p.length === 1 && p[0] === 'collections') {
-    return method === 'POST' ? h.createCollection(env, request) : bad(405, 'method not allowed');
+    return method === 'POST' ? h.createCollection(env, request, defer) : bad(405, 'method not allowed');
   }
 
   // /v1/collections/:id[/records|/publish]
@@ -52,10 +52,10 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
       return bad(405, 'method not allowed');
     }
     if (p.length === 3 && p[2] === 'publish') {
-      return method === 'POST' ? h.publish(env, request, id) : bad(405, 'method not allowed');
+      return method === 'POST' ? h.publish(env, request, id, defer) : bad(405, 'method not allowed');
     }
     if (p.length === 3 && p[2] === 'import') {
-      return method === 'POST' ? h.importRecords(env, request, id) : bad(405, 'method not allowed');
+      return method === 'POST' ? h.importRecords(env, request, id, defer) : bad(405, 'method not allowed');
     }
     if (p.length === 3 && p[2] === 'tokens') {
       return method === 'POST' ? h.mintToken(env, request, id) : bad(405, 'method not allowed');

--- a/collect/functions/lib/collect-log.ts
+++ b/collect/functions/lib/collect-log.ts
@@ -2,6 +2,8 @@
 // attempt (spec → Deployment checklist item 8). Coarse facts only — no field
 // values, no names. Best-effort; never blocks the request.
 
+import type { D1Database } from '@cloudflare/workers-types';
+
 export type CollectEvent = 'create' | 'contribute' | 'publish' | 'import';
 
 export interface CollectAttempt {
@@ -25,4 +27,19 @@ export async function logCollectAttempt(db: D1Database, row: CollectAttempt): Pr
   } catch {
     // instrumentation must never break a request
   }
+}
+
+// Register the async log with ctx.waitUntil (via the handler's `defer`) so the
+// D1 write survives the response. A bare `void logCollectAttempt(...)` is a
+// dangling promise the Workers runtime cancels once the Response is returned,
+// which is why collect_attempts stayed empty. `defer` keeps the request alive
+// until the write lands; without it we fall back to best-effort (never blocks).
+export function deferLog(
+  defer: ((p: Promise<unknown>) => void) | undefined,
+  db: D1Database,
+  row: CollectAttempt,
+): void {
+  const p = logCollectAttempt(db, row);
+  if (defer) defer(p);
+  else void p;
 }

--- a/collect/functions/lib/handlers.ts
+++ b/collect/functions/lib/handlers.ts
@@ -10,7 +10,7 @@ import { bad, json } from './http';
 import { generateToken, tokenPrefix, hashToken, generateRecordToken, verifyToken } from './tokens';
 import { bearer, permissionFor, atLeast } from './auth';
 import { checkCreateRate, checkRecordRate, checkKeyDayRate } from './ratelimit';
-import { logCollectAttempt } from './collect-log';
+import { deferLog } from './collect-log';
 import { nanoid, sha256Hex, ipHashFor, verifyTurnstile, insertSubmission, insertToken } from './reuse';
 import * as db from './db';
 import { validateNewCollection, validateCollectionEdit } from '../../src/schema/validate-collection';
@@ -87,7 +87,7 @@ async function verifyApiKey(env: Env, key: string): Promise<{ id: string; daily_
   return null;
 }
 
-export async function createCollection(env: Env, req: Request): Promise<Response> {
+export async function createCollection(env: Env, req: Request, defer?: Defer): Promise<Response> {
   const ipHash = await ipHashFor(req, salt(env));
   const body = await readJson(req);
   if (!body) return bad(400, 'invalid JSON body');
@@ -97,27 +97,27 @@ export async function createCollection(env: Env, req: Request): Promise<Response
   if (apiKey) {
     const k = await verifyApiKey(env, apiKey);
     if (!k) {
-      void logCollectAttempt(env.DB, { event: 'create', outcome: 'rejected', gate: 'apiKey', ip_hash: ipHash });
+      deferLog(defer, env.DB, { event: 'create', outcome: 'rejected', gate: 'apiKey', ip_hash: ipHash });
       return bad(401, 'invalid API key');
     }
     if (!(await checkKeyDayRate(env.DB, k.hash, k.daily_limit))) {
-      void logCollectAttempt(env.DB, { event: 'create', outcome: 'rejected', gate: 'rateLimit', ip_hash: ipHash });
+      deferLog(defer, env.DB, { event: 'create', outcome: 'rejected', gate: 'rateLimit', ip_hash: ipHash });
       return bad(429, `API key daily limit (${k.daily_limit}) reached`);
     }
   } else {
     if (!(await turnstileOk(env, body.turnstile_token))) {
-      void logCollectAttempt(env.DB, { event: 'create', outcome: 'rejected', gate: 'captcha', ip_hash: ipHash });
+      deferLog(defer, env.DB, { event: 'create', outcome: 'rejected', gate: 'captcha', ip_hash: ipHash });
       return bad(403, 'captcha failed');
     }
     if (!(await checkCreateRate(env.DB, ipHash))) {
-      void logCollectAttempt(env.DB, { event: 'create', outcome: 'rejected', gate: 'rateLimit', ip_hash: ipHash });
+      deferLog(defer, env.DB, { event: 'create', outcome: 'rejected', gate: 'rateLimit', ip_hash: ipHash });
       return bad(429, 'rate limit: 5 collections per day');
     }
   }
 
   const v = validateNewCollection(body);
   if (!v.ok) {
-    void logCollectAttempt(env.DB, { event: 'create', outcome: 'rejected', gate: 'schema', reason: v.error, ip_hash: ipHash });
+    deferLog(defer, env.DB, { event: 'create', outcome: 'rejected', gate: 'schema', reason: v.error, ip_hash: ipHash });
     return bad(400, v.error);
   }
 
@@ -135,7 +135,7 @@ export async function createCollection(env: Env, req: Request): Promise<Response
     });
   }
 
-  void logCollectAttempt(env.DB, { event: 'create', outcome: 'ok', collection_id: id, ip_hash: ipHash });
+  deferLog(defer, env.DB, { event: 'create', outcome: 'ok', collection_id: id, ip_hash: ipHash });
   const origin = new URL(req.url).origin;
   return json(200, {
     id,
@@ -289,18 +289,18 @@ export async function addRecord(env: Env, req: Request, id: string, defer?: Defe
   if (!body) return bad(400, 'invalid JSON body');
 
   if (!(await turnstileOk(env, body.turnstile_token))) {
-    void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'rejected', gate: 'captcha', collection_id: id, ip_hash: ipHash });
+    deferLog(defer, env.DB, { event: 'contribute', outcome: 'rejected', gate: 'captcha', collection_id: id, ip_hash: ipHash });
     return bad(403, 'captcha failed');
   }
   if (!(await checkRecordRate(env.DB, ipHash))) {
-    void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'rejected', gate: 'rateLimit', collection_id: id, ip_hash: ipHash });
+    deferLog(defer, env.DB, { event: 'contribute', outcome: 'rejected', gate: 'rateLimit', collection_id: id, ip_hash: ipHash });
     return bad(429, 'rate limit: 200 records per hour');
   }
 
   const geometry = body.geometry;
   const bounds = checkIndiaBounds(geometry);
   if (!bounds.ok) {
-    void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'rejected', gate: 'bounds', reason: bounds.error, collection_id: id, ip_hash: ipHash });
+    deferLog(defer, env.DB, { event: 'contribute', outcome: 'rejected', gate: 'bounds', reason: bounds.error, collection_id: id, ip_hash: ipHash });
     return bad(400, bounds.error);
   }
 
@@ -312,7 +312,7 @@ export async function addRecord(env: Env, req: Request, id: string, defer?: Defe
 
   const validated = validateRecordProperties(schema.fields, body.properties);
   if (!validated.ok) {
-    void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'rejected', gate: 'schema', reason: validated.error, collection_id: id, ip_hash: ipHash });
+    deferLog(defer, env.DB, { event: 'contribute', outcome: 'rejected', gate: 'schema', reason: validated.error, collection_id: id, ip_hash: ipHash });
     return bad(400, validated.error);
   }
 
@@ -337,7 +337,7 @@ export async function addRecord(env: Env, req: Request, id: string, defer?: Defe
   const task = enrichRecord(env, recId, geometry).catch(() => {});
   if (defer) defer(task); else await task;
 
-  void logCollectAttempt(env.DB, { event: 'contribute', outcome: 'ok', collection_id: id, ip_hash: ipHash });
+  deferLog(defer, env.DB, { event: 'contribute', outcome: 'ok', collection_id: id, ip_hash: ipHash });
   return json(200, { id: recId, status, edit_token: recToken });
 }
 
@@ -454,7 +454,7 @@ export async function deidentifyRecordHandler(env: Env, req: Request, recordId: 
 // A throwaway edit-token hash means imported records have no contributor owner
 // (admin manages them). Enrichment is skipped in bulk (admin_ctx stays null).
 
-export async function importRecords(env: Env, req: Request, id: string): Promise<Response> {
+export async function importRecords(env: Env, req: Request, id: string, defer?: Defer): Promise<Response> {
   const perm = await permissionFor(env.DB, id, bearer(req));
   if (!atLeast(perm, 'admin')) return bad(401, 'unauthorised');
   const c = await db.getCollection(env.DB, id);
@@ -499,13 +499,13 @@ export async function importRecords(env: Env, req: Request, id: string): Promise
     imported++;
   }
   await db.touchCollection(env.DB, id);
-  void logCollectAttempt(env.DB, { event: 'import', outcome: imported ? 'ok' : 'rejected', collection_id: id, ip_hash: ipHash });
+  deferLog(defer, env.DB, { event: 'import', outcome: imported ? 'ok' : 'rejected', collection_id: id, ip_hash: ipHash });
   return json(200, { imported, errors });
 }
 
 // ---- POST /collections/:id/publish -----------------------------------------
 
-export async function publish(env: Env, req: Request, id: string): Promise<Response> {
+export async function publish(env: Env, req: Request, id: string, defer?: Defer): Promise<Response> {
   const perm = await permissionFor(env.DB, id, bearer(req));
   if (!atLeast(perm, 'admin')) return bad(401, 'unauthorised');
 
@@ -514,7 +514,7 @@ export async function publish(env: Env, req: Request, id: string): Promise<Respo
 
   const rows = await db.listRecords(env.DB, id, { status: 'published', limit: 100000, offset: 0 });
   if (rows.length === 0) {
-    void logCollectAttempt(env.DB, { event: 'publish', outcome: 'rejected', gate: 'empty', collection_id: id });
+    deferLog(defer, env.DB, { event: 'publish', outcome: 'rejected', gate: 'empty', collection_id: id });
     return bad(409, 'nothing approved to publish yet');
   }
 
@@ -607,7 +607,7 @@ export async function publish(env: Env, req: Request, id: string): Promise<Respo
     r2Key,
   });
 
-  void logCollectAttempt(env.DB, { event: 'publish', outcome: 'ok', collection_id: id });
+  deferLog(defer, env.DB, { event: 'publish', outcome: 'ok', collection_id: id });
   return json(200, {
     version,
     submission_id: submissionId,

--- a/collect/tests/collect-log.test.ts
+++ b/collect/tests/collect-log.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { deferLog } from '../functions/lib/collect-log';
+
+// Minimal D1 stub: prepare -> bind -> run. deferLog only needs the chain to
+// exist; the run() promise is what must reach `defer`.
+const mockDb = () =>
+  ({ prepare: () => ({ bind: () => ({ run: async () => ({}) }) }) }) as unknown as Parameters<typeof deferLog>[1];
+
+describe('deferLog', () => {
+  it('registers the log promise with defer, so waitUntil keeps it alive (not fire-and-forget)', () => {
+    // This is the regression guard: the old `void logCollectAttempt(...)` was a
+    // dangling promise the runtime cancelled before the D1 write committed,
+    // which is why collect_attempts stayed empty.
+    const captured: Promise<unknown>[] = [];
+    const defer = (p: Promise<unknown>) => {
+      captured.push(p);
+    };
+    deferLog(defer, mockDb(), { event: 'create', outcome: 'ok', collection_id: 'abc' });
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toBeInstanceOf(Promise);
+  });
+
+  it('falls back to best-effort (never throws) when no defer is provided', () => {
+    expect(() => deferLog(undefined, mockDb(), { event: 'contribute', outcome: 'ok' })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## The bug
`collect_attempts` had **0 rows** despite a real map existing (the "Mangalore" map). Every `logCollectAttempt` call was fire-and-forget (`void`), and the logging handlers (`createCollection`, `publish`, `importRecords`) never received the `defer` / `ctx.waitUntil()` helper. In Cloudflare Pages Functions, a promise that is neither awaited nor registered with `ctx.waitUntil()` is **cancelled when the Response returns** — so the async D1 write never committed. The awaited `collections` INSERT persisted (map exists); the `void`'d `collect_attempts` INSERT was dropped. The funnel instrumentation had effectively never worked.

## The fix
- **`collect-log.ts`**: new `deferLog(defer, db, row)` that registers the log promise with `defer` (`ctx.waitUntil`), with a best-effort fallback when `defer` is absent. Plus a type-only `D1Database` import so the module typechecks under the test (DOM) config too.
- **`handlers.ts`**: all **14** `void logCollectAttempt(...)` → `deferLog(defer, ...)`; thread `defer?: Defer` into `createCollection` / `importRecords` / `publish`.
- **router**: pass `defer` to those three (`addRecord`/`editRecord` already had it).
- **test**: `collect-log.test.ts` asserts `deferLog` hands the promise to `defer` (regression guard on the exact bug).

## Verify
- Build passes: 84 tests (incl. 2 new) + typecheck + vite.
- After deploy: create a map on collect.bharatlas.com and confirm a `create/ok` row appears in `collect_attempts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)