### PR TITLE
collect: cross-device link sharing, tabbed admin panel, full-bleed map

### DIFF
--- a/collect/package-lock.json
+++ b/collect/package-lock.json
@@ -7,10 +7,12 @@
       "name": "collect",
       "dependencies": {
         "maplibre-gl": "^4.7.1",
-        "pmtiles": "^3.2.1"
+        "pmtiles": "^3.2.1",
+        "qrcode-generator": "^2.0.4"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260520.1",
+        "@types/qrcode-generator": "^0.0.16",
         "typescript": "^5.6.3",
         "vite": "^5.4.10",
         "vitest": "^2.1.9"
@@ -926,6 +928,13 @@
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
       "license": "MIT"
     },
+    "node_modules/@types/qrcode-generator": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@types/qrcode-generator/-/qrcode-generator-0.0.16.tgz",
+      "integrity": "sha512-i+wPpeHH64qJHUIz51+tPq5FRkgMxE9/uhDE5eSlj3qujIjHm3U1wHfy8nMD/m1VKaXHO/uDjHamPVz2Fr4IPA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
@@ -1498,6 +1507,12 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
       "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode-generator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-2.0.4.tgz",
+      "integrity": "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==",
       "license": "MIT"
     },
     "node_modules/quickselect": {

--- a/collect/package.json
+++ b/collect/package.json
@@ -12,10 +12,12 @@
   },
   "dependencies": {
     "maplibre-gl": "^4.7.1",
-    "pmtiles": "^3.2.1"
+    "pmtiles": "^3.2.1",
+    "qrcode-generator": "^2.0.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260520.1",
+    "@types/qrcode-generator": "^0.0.16",
     "typescript": "^5.6.3",
     "vite": "^5.4.10",
     "vitest": "^2.1.9"

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -18,6 +18,8 @@ import { toGeoJSON, toCSV, toKML, type ExportFeature } from './export/formats';
 import { detectFormat, parseImport, type Parsed } from './import/parse';
 import { autoMapping, buildRecords, errorsToCSV, type Mapping } from './import/build';
 import { rememberMap } from './maps-store';
+import { linksMailtoHref, type MapLinks } from './share';
+import { shareItemHtml, wireShareItems } from './share-ui';
 interface Counts { pending: number; published: number; total: number; rejected: number; }
 interface Meta {
   id: string; name: string; purpose: string; description: string | null; data_year: number | null; status: string; moderation: number; license: string;
@@ -77,6 +79,52 @@ function marker(coords: number[], color = ACCENT): void {
   if (coords.length >= 2) new maplibregl.Marker({ color }).setLngLat([coords[0], coords[1]]).addTo(map);
 }
 
+// A grab handle — the first child of every collapsible bottom sheet.
+const GRAB = '<button type="button" class="grab" aria-label="Collapse or expand this panel"></button>';
+
+// ── sheet metrics ────────────────────────────────────────────────────────
+// Keep --sheet-h current so the crosshair + floating map buttons sit above the
+// panel, and let the grab handle collapse the sheet to a peek (map takes over).
+function setSheetVar(px: number): void {
+  document.getElementById('app')?.style.setProperty('--sheet-h', `${Math.max(0, Math.round(px))}px`);
+}
+function updateSheetMetrics(): void {
+  const sheet = document.querySelector('#panel .sheet, #panel .bar') as HTMLElement | null;
+  if (!sheet) { setSheetVar(0); return; }
+  if (sheet.classList.contains('collapsed')) { setSheetVar(30); return; }
+  setSheetVar(sheet.getBoundingClientRect().height);
+}
+let sheetMetricsInstalled = false;
+function installSheetMetrics(): void {
+  if (sheetMetricsInstalled) return;
+  sheetMetricsInstalled = true;
+  const appEl = document.getElementById('app')!;
+  new MutationObserver(() => requestAnimationFrame(updateSheetMetrics)).observe(appEl, { childList: true, subtree: true });
+  appEl.addEventListener('click', (e) => {
+    const grab = (e.target as HTMLElement).closest('.grab');
+    if (!grab) return;
+    grab.closest('.sheet')?.classList.toggle('collapsed');
+    updateSheetMetrics();
+  });
+  window.addEventListener('resize', () => requestAnimationFrame(updateSheetMetrics));
+  requestAnimationFrame(updateSheetMetrics);
+}
+
+// The lng/lat under the crosshair. The crosshair rides above the sheet (not at
+// the map's geometric centre), so read its real screen position and unproject:
+// the placed point is exactly what the user sees targeted.
+function crosshairLngLat(): [number, number] {
+  const ch = document.querySelector('.crosshair') as HTMLElement | null;
+  const cr = map.getCanvas().getBoundingClientRect();
+  if (ch) {
+    const r = ch.getBoundingClientRect();
+    const ll = map.unproject([r.left + r.width / 2 - cr.left, r.top + r.height / 2 - cr.top]);
+    return [ll.lng, ll.lat];
+  }
+  const c = map.getCenter();
+  return [c.lng, c.lat];
+}
+
 const TERMS = 'https://bharatlas.com/terms';
 // Content-safety: a report/takedown path (mailto, no accounts) + terms link.
 function safetyFooter(): string {
@@ -104,9 +152,10 @@ async function boot(): Promise<void> {
       <div class="map-loading" id="maploading"><span class="spinner"></span> Loading map…</div>
       ${isView ? '' : '<button class="locate" id="locate" aria-label="Use my location">◎</button>'}
       ${meta.schema.reference_layer ? '<button class="locate" id="reftoggle" aria-pressed="true" style="left:12px;top:12px;right:auto;bottom:auto;width:auto;padding:0 12px">◪ Layer</button>' : ''}
-      ${isAdmin ? `<button class="locate" id="manage" aria-label="Manage map${meta.counts.pending ? `, ${meta.counts.pending} pending review` : ''}" style="left:12px;right:auto;bottom:76px;width:auto;padding:0 14px">⚙${meta.counts.pending ? ` ${meta.counts.pending}` : ''}</button>` : ''}
+      ${isAdmin ? `<button class="locate" id="manage" aria-label="Manage map${meta.counts.pending ? `, ${meta.counts.pending} pending review` : ''}" style="left:12px;right:auto;bottom:calc(76px + var(--sheet-h,0px));width:auto;padding:0 14px">⚙${meta.counts.pending ? ` ${meta.counts.pending}` : ''}</button>` : ''}
     </div>
     <div id="panel"></div>`;
+  installSheetMetrics();
 
   map = new maplibregl.Map({
     container: 'map', style: styleFor(meta.schema.basemap), center: INDIA_CENTER, zoom: 4,
@@ -156,7 +205,7 @@ async function boot(): Promise<void> {
 function viewPanel(): void {
   const panel = document.getElementById('panel')!;
   const n = meta.counts.published;
-  panel.innerHTML = `<div class="sheet"><div class="body">
+  panel.innerHTML = `<div class="sheet">${GRAB}<div class="body">
     <strong>${escapeHtml(meta.name)}</strong>
     ${meta.purpose ? `<p class="hint">${escapeHtml(meta.purpose)}</p>` : ''}
     <p class="hint">${n ? `${n} point${n === 1 ? '' : 's'} on the map.` : 'No points published yet.'}</p>
@@ -276,14 +325,13 @@ function renderPlaceBar(modes: GeomMode[]): void {
     b.onclick = () => { drawMode = b.dataset.m as GeomMode; verts = []; redrawDraw(); syncDrawUI(); };
   });
   (document.getElementById('vadd') as HTMLButtonElement).onclick = () => {
-    const c = map.getCenter(); verts.push([c.lng, c.lat]); redrawDraw(); syncDrawUI();
+    verts.push(crosshairLngLat()); redrawDraw(); syncDrawUI();
   };
   (document.getElementById('vundo') as HTMLButtonElement).onclick = () => {
     verts.pop(); redrawDraw(); syncDrawUI();
   };
   (document.getElementById('place') as HTMLButtonElement).onclick = () => {
-    const c = map.getCenter();
-    const geometry = drawGeometry(drawMode, verts, [c.lng, c.lat]);
+    const geometry = drawGeometry(drawMode, verts, crosshairLngLat());
     if (!geometry) { toast(`A ${NOUN[drawMode]} needs ${drawMode === 'line' ? '2' : '3'} points or more`); return; }
     detailsSheet(geometry, modes);
   };
@@ -294,6 +342,7 @@ function detailsSheet(geometry: GeoJSON.Geometry, modes: GeomMode[]): void {
   const noun = NOUN[drawMode];
   const panel = document.getElementById('panel')!;
   panel.innerHTML = `<div class="sheet">
+    ${GRAB}
     <form class="body" id="capform">
       <strong>${cap(noun)} details</strong>
       <p class="hint">Placed on the map. Add the details, then save. Public places and assets only, not people.</p>
@@ -359,6 +408,7 @@ async function editSettings(): Promise<void> {
   const locked = meta.counts.total > 0;
   const sel = (v: string, cur: string): string => (v === cur ? ' selected' : '');
   panel.innerHTML = `<div class="sheet">
+    ${GRAB}
     <form class="body" id="editform">
       <strong>Edit map settings</strong>
       <label>Name</label><input id="e-name" maxlength="120" value="${escapeHtml(meta.name)}" required />
@@ -437,44 +487,33 @@ async function editSettings(): Promise<void> {
   };
 }
 
+// The admin sheet is tabbed so each job stands alone (the old one-scroll panel
+// stacked review + share + download + import together). Review is the daily job
+// and stays the default; Share and Data sit one tap away. Publish + Add points
+// stay in the footer, reachable from any tab.
+type ManageTab = 'review' | 'share' | 'data';
+let manageTab: ManageTab = 'review';
+// Links minted this session, so switching tabs (or coming back) re-shows them.
+const minted: { edit?: string; view?: string } = {};
+
 async function manageSheet(): Promise<void> {
   clearHighlight(); // leaving a review detail clears the map highlight
   meta = await apiJson<Meta>(`/collections/${ctx.id}`, ctx.token).catch(() => meta);
   const c = meta.counts;
   const panel = document.getElementById('panel')!;
   panel.innerHTML = `<div class="sheet">
+    ${GRAB}
     <div class="body">
       <div class="row" style="justify-content:space-between;align-items:center">
         <strong>Manage map</strong>
         <button id="edit-settings" style="min-height:36px;font-size:13px">✎ Settings</button>
       </div>
-      <p class="hint" id="mcounts">${c.published} approved · ${c.pending} pending · ${c.rejected} rejected</p>
-      <div class="row" id="pfilter" style="margin:8px 0 4px">
-        <button type="button" class="chip on" data-s="">All ${c.total}</button>
-        <button type="button" class="chip" data-s="pending">Pending ${c.pending}</button>
-        <button type="button" class="chip" data-s="published">Approved ${c.published}</button>
-        ${c.rejected ? `<button type="button" class="chip" data-s="rejected">Rejected ${c.rejected}</button>` : ''}
+      <div class="tabs" id="mtabs">
+        <button type="button" data-t="review">Review${c.pending ? ` · ${c.pending}` : ''}</button>
+        <button type="button" data-t="share">Share</button>
+        <button type="button" data-t="data">Data</button>
       </div>
-      <div id="points"><p class="hint">Loading points…</p></div>
-      <strong style="display:block;margin-top:14px">Share links</strong>
-      <p class="hint">Mint a fresh link to share. The original links can't be shown again.</p>
-      <div class="row">
-        <button id="mint-edit">+ Collect link</button>
-        <button id="mint-view">+ View-only link</button>
-      </div>
-      <div id="minted"></div>
-      <strong style="display:block;margin-top:14px">Download the data</strong>
-      <p class="hint">Every collected point, to use anywhere.</p>
-      <div class="row">
-        <button data-dl="geojson">GeoJSON</button>
-        <button data-dl="csv">CSV</button>
-        <button data-dl="kml">KML</button>
-      </div>
-      <strong style="display:block;margin-top:14px">Import data</strong>
-      <p class="hint">Add many points at once from a CSV, GeoJSON or KML file.</p>
-      <label class="btn wide" style="cursor:pointer">⬆ Choose a file<input id="import-file" type="file" accept=".csv,.geojson,.json,.kml" hidden></label>
-      <div id="import-panel"></div>
-      ${safetyFooter()}
+      <div id="tabbody"></div>
     </div>
     <div class="foot row">
       <button id="back">+ Add points</button>
@@ -484,6 +523,33 @@ async function manageSheet(): Promise<void> {
   (document.getElementById('back') as HTMLButtonElement).onclick = captureSheet;
   (document.getElementById('publish') as HTMLButtonElement).onclick = doPublish;
   (document.getElementById('edit-settings') as HTMLButtonElement).onclick = () => void editSettings();
+  document.querySelectorAll<HTMLButtonElement>('#mtabs button').forEach((b) => {
+    b.onclick = () => { manageTab = b.dataset.t as ManageTab; renderManageTab(); };
+  });
+  renderManageTab();
+}
+
+function renderManageTab(): void {
+  document.querySelectorAll<HTMLElement>('#mtabs button').forEach((b) => b.classList.toggle('on', b.dataset.t === manageTab));
+  const body = document.getElementById('tabbody');
+  if (!body) return;
+  if (manageTab === 'share') return renderShareTab(body);
+  if (manageTab === 'data') return renderDataTab(body);
+  return renderReviewTab(body);
+}
+
+// Review: moderate the points. The counts line + filter chips + tappable list.
+function renderReviewTab(body: HTMLElement): void {
+  const c = meta.counts;
+  body.innerHTML = `
+    <p class="hint" id="mcounts">${c.published} approved · ${c.pending} pending · ${c.rejected} rejected</p>
+    <div class="row" id="pfilter" style="margin:8px 0 4px">
+      <button type="button" class="chip on" data-s="">All ${c.total}</button>
+      <button type="button" class="chip" data-s="pending">Pending ${c.pending}</button>
+      <button type="button" class="chip" data-s="published">Approved ${c.published}</button>
+      ${c.rejected ? `<button type="button" class="chip" data-s="rejected">Rejected ${c.rejected}</button>` : ''}
+    </div>
+    <div id="points"><p class="hint">Loading points…</p></div>`;
   document.querySelectorAll<HTMLButtonElement>('#pfilter .chip').forEach((b) => {
     b.onclick = () => {
       document.querySelectorAll('#pfilter .chip').forEach((x) => x.classList.remove('on'));
@@ -491,35 +557,76 @@ async function manageSheet(): Promise<void> {
       void renderPoints();
     };
   });
+  void renderPoints();
+}
 
-  const mint = async (permission: 'edit' | 'view') => {
+// Share: hand a link to another device. The admin link (this device's URL) gets
+// Copy / Share / QR so the owner can open the same map on their phone or laptop;
+// collect / view links are minted on demand; and every link can be mailed to self.
+function renderShareTab(body: HTMLElement): void {
+  const title = meta.name || 'bharatlas collect map';
+  const adminLink = location.href;
+  body.innerHTML = `
+    <p class="hint">Hand a link to another device or person. No accounts, so the link is the key: whoever holds it can use it at that level.</p>
+    ${shareItemHtml('admin', 'Admin link (this device, keep secret)', adminLink, 'Open the same map on your other device: Share it to yourself, or scan the QR. Keep it private.')}
+    <div class="row" style="margin-top:4px">
+      <button id="mint-edit">+ Collect link</button>
+      <button id="mint-view">+ View-only link</button>
+    </div>
+    <p class="hint">Collect links let people add points; view links are read only. Mint fresh ones anytime.</p>
+    <div id="minted"></div>
+    <a class="btn wide" id="email-links" style="margin-top:12px">✉ Email these links to me</a>`;
+  wireShareItems(body, title);
+
+  const mintedBox = document.getElementById('minted')!;
+  const emailA = document.getElementById('email-links') as HTMLAnchorElement;
+  const refreshEmail = (): void => { emailA.href = linksMailtoHref({ admin: adminLink, ...minted } as MapLinks, meta.name); };
+  const addMinted = (key: 'edit' | 'view', label: string, url: string): void => {
+    const wrap = document.createElement('div');
+    wrap.innerHTML = shareItemHtml(key, label, url);
+    wireShareItems(wrap, title);
+    mintedBox.prepend(wrap.firstElementChild!);
+    refreshEmail();
+  };
+  refreshEmail();
+  if (minted.view) addMinted('view', 'View-only link', minted.view);
+  if (minted.edit) addMinted('edit', 'Collect link', minted.edit);
+
+  const mint = async (permission: 'edit' | 'view'): Promise<void> => {
     try {
       const res = await apiJson<{ link: string }>(`/collections/${ctx.id}/tokens`, ctx.token, {
         method: 'POST', body: JSON.stringify({ permission }),
       });
-      const box = document.getElementById('minted')!;
-      const row = document.createElement('div');
-      row.className = 'link-box';
-      row.innerHTML = `<code></code><button>Copy</button>`;
-      row.querySelector('code')!.textContent = res.link; // textContent — never innerHTML a URL
-      const btn = row.querySelector('button')!;
-      btn.onclick = () => { navigator.clipboard?.writeText(res.link); btn.textContent = '✓'; };
-      box.prepend(row);
-    } catch (e) {
-      toast((e as Error).message);
-    }
+      minted[permission] = res.link;
+      addMinted(permission, permission === 'edit' ? 'Collect link' : 'View-only link', res.link);
+    } catch (e) { toast((e as Error).message); }
   };
-  (document.getElementById('mint-edit') as HTMLButtonElement).onclick = () => mint('edit');
-  (document.getElementById('mint-view') as HTMLButtonElement).onclick = () => mint('view');
-  document.querySelectorAll<HTMLButtonElement>('button[data-dl]').forEach((b) => {
+  (document.getElementById('mint-edit') as HTMLButtonElement).onclick = () => void mint('edit');
+  (document.getElementById('mint-view') as HTMLButtonElement).onclick = () => void mint('view');
+}
+
+// Data: download every point, or bulk-import a file.
+function renderDataTab(body: HTMLElement): void {
+  body.innerHTML = `
+    <strong style="display:block">Download the data</strong>
+    <p class="hint">Every collected point, to use anywhere.</p>
+    <div class="row">
+      <button data-dl="geojson">GeoJSON</button>
+      <button data-dl="csv">CSV</button>
+      <button data-dl="kml">KML</button>
+    </div>
+    <strong style="display:block;margin-top:14px">Import data</strong>
+    <p class="hint">Add many points at once from a CSV, GeoJSON or KML file.</p>
+    <label class="btn wide" style="cursor:pointer">⬆ Choose a file<input id="import-file" type="file" accept=".csv,.geojson,.json,.kml" hidden></label>
+    <div id="import-panel"></div>
+    ${safetyFooter()}`;
+  body.querySelectorAll<HTMLButtonElement>('button[data-dl]').forEach((b) => {
     b.onclick = () => void downloadData(b.dataset.dl as 'geojson' | 'csv' | 'kml');
   });
   (document.getElementById('import-file') as HTMLInputElement).onchange = (e) => {
     const file = (e.target as HTMLInputElement).files?.[0];
     if (file) void importFlow(file);
   };
-
-  void renderPoints();
 }
 
 const slug = (s: string): string => (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'collect-map';
@@ -736,7 +843,8 @@ function openReview(idx: number): void {
   clearHighlight();
   if (c) {
     reviewMarker = new maplibregl.Marker({ color: '#d97706' }).setLngLat(c).addTo(map);
-    map.flyTo({ center: c, zoom: Math.max(map.getZoom(), 14), offset: [0, -70] });
+    // Lift the point into the band above the review sheet (which floats over the map).
+    map.flyTo({ center: c, zoom: Math.max(map.getZoom(), 14), offset: [0, -Math.round(window.innerHeight * 0.2)] });
   }
 
   const attrs = fields
@@ -745,6 +853,7 @@ function openReview(idx: number): void {
   const origin = p._source ? `⇪ from ${escapeHtml(p._source)}` : `by ${escapeHtml(p._contributor || 'anonymous')}`;
   const panel = document.getElementById('panel')!;
   panel.innerHTML = `<div class="sheet">
+    ${GRAB}
     <div class="body">
       <div class="row" style="justify-content:space-between;align-items:flex-start;gap:8px">
         <strong style="flex:1">${escapeHtml(cardTitle(p))}</strong>
@@ -794,7 +903,7 @@ async function doPublish(ev: Event): Promise<void> {
     );
     toast(`Published v${res.version} · ${res.feature_count} features`);
     const panel = document.getElementById('panel')!;
-    panel.innerHTML = `<div class="sheet"><div class="body">
+    panel.innerHTML = `<div class="sheet">${GRAB}<div class="body">
       <strong>Published to the catalog 🎉</strong>
       <p class="hint">Version ${res.version} · ${res.feature_count} features.</p>
       <a class="btn primary" href="${res.share_url}" target="_blank" rel="noopener">View on bharatlas →</a>
@@ -829,6 +938,7 @@ async function recordEditor(): Promise<void> {
       ${isPoint ? '<button class="locate" id="locate" aria-label="Use my location">◎</button>' : ''}
     </div>
     <div id="panel"><div class="sheet">
+      ${GRAB}
       <form class="body" id="recform">
         <strong>Edit your ${noun}</strong>
         <p class="hint">${isPoint ? 'Move the map to reposition; update the details.' : 'Update the details below.'} Status: ${rec.status}.</p>
@@ -842,6 +952,7 @@ async function recordEditor(): Promise<void> {
         </div>
       </div>
     </div></div>`;
+  installSheetMetrics();
 
   map = new maplibregl.Map({ container: 'map', style: styleFor(rec.schema.basemap), center, zoom: isPoint ? 16 : 14, attributionControl: false });
   map.addControl(new maplibregl.AttributionControl({ compact: true }), 'bottom-left');
@@ -899,7 +1010,7 @@ async function recordEditor(): Promise<void> {
       if (!valid.ok) { toast(valid.error); btn.disabled = false; return; }
       // Points can be repositioned by panning; shapes edit properties only.
       const body: Record<string, unknown> = { properties: valid.properties };
-      if (isPoint) { const c = map.getCenter(); body.geometry = { type: 'Point', coordinates: [c.lng, c.lat] }; }
+      if (isPoint) body.geometry = { type: 'Point', coordinates: crosshairLngLat() };
       await apiJson(`/records/${ctx.recordId}`, ctx.token, { method: 'PATCH', body: JSON.stringify(body) });
       toast('Saved ✓');
     } catch (e) { toast((e as Error).message); }

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -80,7 +80,7 @@ function marker(coords: number[], color = ACCENT): void {
 }
 
 // A grab handle — the first child of every collapsible bottom sheet.
-const GRAB = '<button type="button" class="grab" aria-label="Collapse or expand this panel"></button>';
+const GRAB = '<button type="button" class="grab" aria-expanded="true" aria-label="Collapse or expand this panel"></button>';
 
 // ── sheet metrics ────────────────────────────────────────────────────────
 // Keep --sheet-h current so the crosshair + floating map buttons sit above the
@@ -91,7 +91,11 @@ function setSheetVar(px: number): void {
 function updateSheetMetrics(): void {
   const sheet = document.querySelector('#panel .sheet, #panel .bar') as HTMLElement | null;
   if (!sheet) { setSheetVar(0); return; }
-  if (sheet.classList.contains('collapsed')) { setSheetVar(30); return; }
+  if (sheet.classList.contains('collapsed')) {
+    // match the CSS peek strip, so the crosshair/buttons line up with the handle
+    setSheetVar(parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--peek-h')) || 30);
+    return;
+  }
   setSheetVar(sheet.getBoundingClientRect().height);
 }
 let sheetMetricsInstalled = false;
@@ -103,7 +107,13 @@ function installSheetMetrics(): void {
   appEl.addEventListener('click', (e) => {
     const grab = (e.target as HTMLElement).closest('.grab');
     if (!grab) return;
-    grab.closest('.sheet')?.classList.toggle('collapsed');
+    const sheet = grab.closest('.sheet');
+    const collapsed = sheet?.classList.toggle('collapsed') ?? false;
+    grab.setAttribute('aria-expanded', String(!collapsed));
+    // keep the grab operable, but pull the now-offscreen content out of the tab order
+    sheet?.querySelectorAll('.body, .foot').forEach((el) => {
+      if (collapsed) el.setAttribute('inert', ''); else el.removeAttribute('inert');
+    });
     updateSheetMetrics();
   });
   window.addEventListener('resize', () => requestAnimationFrame(updateSheetMetrics));
@@ -112,17 +122,32 @@ function installSheetMetrics(): void {
 
 // The lng/lat under the crosshair. The crosshair rides above the sheet (not at
 // the map's geometric centre), so read its real screen position and unproject:
-// the placed point is exactly what the user sees targeted.
+// the placed point is exactly what the user sees targeted. Falls back to the map
+// centre when there is no visible crosshair (missing, or display:none in view mode).
 function crosshairLngLat(): [number, number] {
   const ch = document.querySelector('.crosshair') as HTMLElement | null;
   const cr = map.getCanvas().getBoundingClientRect();
   if (ch) {
     const r = ch.getBoundingClientRect();
-    const ll = map.unproject([r.left + r.width / 2 - cr.left, r.top + r.height / 2 - cr.top]);
-    return [ll.lng, ll.lat];
+    if (r.width !== 0) {
+      const ll = map.unproject([r.left + r.width / 2 - cr.left, r.top + r.height / 2 - cr.top]);
+      return [ll.lng, ll.lat];
+    }
   }
   const c = map.getCenter();
   return [c.lng, c.lat];
+}
+
+// The crosshair's offset from the map centre, in screen px. Pass as a flyTo/easeTo
+// `offset` to bring a coordinate UNDER the crosshair (locate, or framing an edited
+// point). [0,0] when there is no visible crosshair, so it is a safe no-op.
+function crosshairScreenOffset(): [number, number] {
+  const ch = document.querySelector('.crosshair') as HTMLElement | null;
+  if (!ch) return [0, 0];
+  const r = ch.getBoundingClientRect();
+  if (r.width === 0) return [0, 0];
+  const cr = map.getCanvas().getBoundingClientRect();
+  return [r.left + r.width / 2 - cr.left - cr.width / 2, r.top + r.height / 2 - cr.top - cr.height / 2];
 }
 
 const TERMS = 'https://bharatlas.com/terms';
@@ -186,7 +211,7 @@ async function boot(): Promise<void> {
     locate.onclick = () => {
       if (!navigator.geolocation) return toast('Location not available');
       navigator.geolocation.getCurrentPosition(
-        (pos) => map.flyTo({ center: [pos.coords.longitude, pos.coords.latitude], zoom: 16 }),
+        (pos) => map.flyTo({ center: [pos.coords.longitude, pos.coords.latitude], zoom: 16, offset: crosshairScreenOffset() }),
         () => toast("Couldn't get your location"),
         { enableHighAccuracy: true, timeout: 8000 },
       );
@@ -495,6 +520,7 @@ type ManageTab = 'review' | 'share' | 'data';
 let manageTab: ManageTab = 'review';
 // Links minted this session, so switching tabs (or coming back) re-shows them.
 const minted: { edit?: string; view?: string } = {};
+const MINT_LABEL = { edit: 'Collect link', view: 'View-only link' } as const;
 
 async function manageSheet(): Promise<void> {
   clearHighlight(); // leaving a review detail clears the map highlight
@@ -508,12 +534,12 @@ async function manageSheet(): Promise<void> {
         <strong>Manage map</strong>
         <button id="edit-settings" style="min-height:36px;font-size:13px">✎ Settings</button>
       </div>
-      <div class="tabs" id="mtabs">
-        <button type="button" data-t="review">Review${c.pending ? ` · ${c.pending}` : ''}</button>
-        <button type="button" data-t="share">Share</button>
-        <button type="button" data-t="data">Data</button>
+      <div class="tabs" id="mtabs" role="tablist" aria-label="Manage sections">
+        <button type="button" role="tab" data-t="review">Review${c.pending ? ` · ${c.pending}` : ''}</button>
+        <button type="button" role="tab" data-t="share">Share</button>
+        <button type="button" role="tab" data-t="data">Data</button>
       </div>
-      <div id="tabbody"></div>
+      <div id="tabbody" role="tabpanel" tabindex="0"></div>
     </div>
     <div class="foot row">
       <button id="back">+ Add points</button>
@@ -530,7 +556,11 @@ async function manageSheet(): Promise<void> {
 }
 
 function renderManageTab(): void {
-  document.querySelectorAll<HTMLElement>('#mtabs button').forEach((b) => b.classList.toggle('on', b.dataset.t === manageTab));
+  document.querySelectorAll<HTMLElement>('#mtabs button').forEach((b) => {
+    const on = b.dataset.t === manageTab;
+    b.classList.toggle('on', on);
+    b.setAttribute('aria-selected', String(on));
+  });
   const body = document.getElementById('tabbody');
   if (!body) return;
   if (manageTab === 'share') return renderShareTab(body);
@@ -582,6 +612,7 @@ function renderShareTab(body: HTMLElement): void {
   const emailA = document.getElementById('email-links') as HTMLAnchorElement;
   const refreshEmail = (): void => { emailA.href = linksMailtoHref({ admin: adminLink, ...minted } as MapLinks, meta.name); };
   const addMinted = (key: 'edit' | 'view', label: string, url: string): void => {
+    mintedBox.querySelector(`.share-item[data-share="${key}"]`)?.remove(); // replace, never stack a stale token
     const wrap = document.createElement('div');
     wrap.innerHTML = shareItemHtml(key, label, url);
     wireShareItems(wrap, title);
@@ -589,8 +620,8 @@ function renderShareTab(body: HTMLElement): void {
     refreshEmail();
   };
   refreshEmail();
-  if (minted.view) addMinted('view', 'View-only link', minted.view);
-  if (minted.edit) addMinted('edit', 'Collect link', minted.edit);
+  if (minted.view) addMinted('view', MINT_LABEL.view, minted.view);
+  if (minted.edit) addMinted('edit', MINT_LABEL.edit, minted.edit);
 
   const mint = async (permission: 'edit' | 'view'): Promise<void> => {
     try {
@@ -598,7 +629,7 @@ function renderShareTab(body: HTMLElement): void {
         method: 'POST', body: JSON.stringify({ permission }),
       });
       minted[permission] = res.link;
-      addMinted(permission, permission === 'edit' ? 'Collect link' : 'View-only link', res.link);
+      addMinted(permission, MINT_LABEL[permission], res.link);
     } catch (e) { toast((e as Error).message); }
   };
   (document.getElementById('mint-edit') as HTMLButtonElement).onclick = () => void mint('edit');
@@ -956,9 +987,19 @@ async function recordEditor(): Promise<void> {
 
   map = new maplibregl.Map({ container: 'map', style: styleFor(rec.schema.basemap), center, zoom: isPoint ? 16 : 14, attributionControl: false });
   map.addControl(new maplibregl.AttributionControl({ compact: true }), 'bottom-left');
+  // Only rewrite the point's location if the user actually repositioned it — a
+  // plain "fix a typo and Save" must leave the point exactly where it was.
+  let moved = false;
+  map.on('dragstart', () => { moved = true; });
   map.on('load', () => {
     document.getElementById('maploading')?.remove();
-    if (isPoint) { marker(center); return; }
+    if (isPoint) {
+      marker(center);
+      // Sit the point UNDER the crosshair (which rides above map centre), so the
+      // marker and the target line up and repositioning reads true.
+      map.easeTo({ center, offset: crosshairScreenOffset(), duration: 0 });
+      return;
+    }
     map.addSource('rec', { type: 'geojson', data: { type: 'Feature', geometry: rec.geometry as GeoJSON.Geometry, properties: {} } });
     map.addLayer({ id: 'rec-fill', type: 'fill', source: 'rec', filter: ['==', '$type', 'Polygon'], paint: { 'fill-color': ACCENT, 'fill-opacity': 0.15 } });
     map.addLayer({ id: 'rec-line', type: 'line', source: 'rec', filter: ['!=', '$type', 'Point'], paint: { 'line-color': ACCENT, 'line-width': 2.5 } });
@@ -984,7 +1025,7 @@ async function recordEditor(): Promise<void> {
   if (locateBtn) locateBtn.onclick = () => {
     if (!navigator.geolocation) return toast('Location not available');
     navigator.geolocation.getCurrentPosition(
-      (pos) => map.flyTo({ center: [pos.coords.longitude, pos.coords.latitude], zoom: 16 }),
+      (pos) => { moved = true; map.flyTo({ center: [pos.coords.longitude, pos.coords.latitude], zoom: 16, offset: crosshairScreenOffset() }); },
       () => toast("Couldn't get your location"), { enableHighAccuracy: true, timeout: 8000 },
     );
   };
@@ -1008,9 +1049,10 @@ async function recordEditor(): Promise<void> {
       }
       const valid = validateRecordProperties(fields, raw);
       if (!valid.ok) { toast(valid.error); btn.disabled = false; return; }
-      // Points can be repositioned by panning; shapes edit properties only.
+      // Points can be repositioned by panning; shapes edit properties only. Only
+      // write geometry when the user actually moved the map (else leave it put).
       const body: Record<string, unknown> = { properties: valid.properties };
-      if (isPoint) body.geometry = { type: 'Point', coordinates: crosshairLngLat() };
+      if (isPoint && moved) body.geometry = { type: 'Point', coordinates: crosshairLngLat() };
       await apiJson(`/records/${ctx.recordId}`, ctx.token, { method: 'PATCH', body: JSON.stringify(body) });
       toast('Saved ✓');
     } catch (e) { toast((e as Error).message); }

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -12,6 +12,8 @@ import { autoMapping, buildRecords } from './import/build';
 import type { Field } from './schema/validate-record';
 import { myMaps, saveOwnedMap, replaceMaps, openLink, type SavedMap, type MapRole } from './maps-store';
 import { CATEGORIES, OPEN_LICENCES } from './options';
+import { linksMailtoHref } from './share';
+import { shareItemHtml, wireShareItems, toggleQr } from './share-ui';
 
 const app = document.getElementById('app')!;
 
@@ -272,30 +274,27 @@ function createForm() {
   };
 }
 
-function linkRow(label: string, url: string): string {
-  return `<label>${label}</label><div class="link-box"><code>${url}</code><button data-copy="${encodeURIComponent(url)}">Copy</button></div>`;
-}
-
 function done(links: Record<string, string>) {
+  const mapLinks = { edit: links.edit, view: links.view, admin: links.admin };
   app.innerHTML = `
-    <div class="topbar"><span>Your map is live</span></div>
+    <div class="topbar"><span>Your map is live</span><a class="brand" href="https://bharatlas.com">bhar<span class="brand-accent">atlas</span></a></div>
     <div class="pad">
-      ${linkRow('🔗 Collect link, share this', links.edit)}
-      <p class="hint">Anyone with this can add points. No login.</p>
-      ${linkRow('👁 View-only', links.view)}
-      ${linkRow('🔑 Admin, keep secret', links.admin)}
-      <p class="warn">⚠ The <strong>admin</strong> link is shown once and can't be recovered, so save it. Fresh collect / view links can always be minted from the admin screen.</p>
-      <button id="dl">⬇ Download my links</button>
-      <div style="height:10px"></div>
+      <h1>Your map is live 🎉</h1>
+      <p class="hint">Share the collect link to gather points. To open this map on another device, Share a link to yourself or scan its QR. No accounts, so keep the admin link safe.</p>
+      ${shareItemHtml('edit', '🔗 Collect link (share this)', links.edit, 'Anyone with this can add points. No login.')}
+      ${shareItemHtml('view', '👁 View-only', links.view)}
+      ${shareItemHtml('admin', '🔑 Admin link (keep secret)', links.admin, 'Full control: moderate, edit, publish. Shown once and cannot be recovered, so save it now.')}
+      <button class="wide" id="dl">⬇ Download my links</button>
+      <a class="btn wide" id="email-links" style="margin-top:8px">✉ Email these links to me</a>
+      <div style="height:12px"></div>
       <a class="btn primary" href="${links.edit}">Open the map →</a>
       <div style="height:8px"></div>
-      <a class="btn" href="#" id="tohome-done">← Your maps</a>
+      <a class="btn wide" href="#" id="tohome-done">← Your maps</a>
     </div>`;
+  wireShareItems(app, 'bharatlas collect map');
+  (document.getElementById('email-links') as HTMLAnchorElement).href = linksMailtoHref(mapLinks);
   app.querySelector<HTMLAnchorElement>('#tohome-done')!.onclick = (e) => { e.preventDefault(); home(); };
 
-  app.querySelectorAll<HTMLButtonElement>('[data-copy]').forEach((b) => {
-    b.onclick = () => { navigator.clipboard?.writeText(decodeURIComponent(b.dataset.copy!)); b.textContent = '✓'; };
-  });
   app.querySelector<HTMLButtonElement>('#dl')!.onclick = () => {
     const text = `collect.bharatlas.com links\n\nCollect (share): ${links.edit}\nView-only: ${links.view}\nAdmin (secret): ${links.admin}\n`;
     const a = document.createElement('a');
@@ -303,6 +302,10 @@ function done(links: Record<string, string>) {
     a.download = 'collect-links.txt';
     a.click();
   };
+
+  // Pre-open the admin QR: the fastest path to "open this on my other device".
+  const adminSlot = app.querySelector<HTMLElement>('.share-item[data-share="admin"] .qr-slot');
+  if (adminSlot) void toggleQr(adminSlot, links.admin);
 }
 
 home();

--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -12,7 +12,7 @@ import { autoMapping, buildRecords } from './import/build';
 import type { Field } from './schema/validate-record';
 import { myMaps, saveOwnedMap, replaceMaps, openLink, type SavedMap, type MapRole } from './maps-store';
 import { CATEGORIES, OPEN_LICENCES } from './options';
-import { linksMailtoHref } from './share';
+import { linksMailtoHref, linksText } from './share';
 import { shareItemHtml, wireShareItems, toggleQr } from './share-ui';
 
 const app = document.getElementById('app')!;
@@ -296,7 +296,7 @@ function done(links: Record<string, string>) {
   app.querySelector<HTMLAnchorElement>('#tohome-done')!.onclick = (e) => { e.preventDefault(); home(); };
 
   app.querySelector<HTMLButtonElement>('#dl')!.onclick = () => {
-    const text = `collect.bharatlas.com links\n\nCollect (share): ${links.edit}\nView-only: ${links.view}\nAdmin (secret): ${links.admin}\n`;
+    const text = linksText(mapLinks); // same block the email body uses, so the two never drift
     const a = document.createElement('a');
     a.href = URL.createObjectURL(new Blob([text], { type: 'text/plain' }));
     a.download = 'collect-links.txt';
@@ -304,8 +304,12 @@ function done(links: Record<string, string>) {
   };
 
   // Pre-open the admin QR: the fastest path to "open this on my other device".
-  const adminSlot = app.querySelector<HTMLElement>('.share-item[data-share="admin"] .qr-slot');
-  if (adminSlot) void toggleQr(adminSlot, links.admin);
+  const adminItem = app.querySelector<HTMLElement>('.share-item[data-share="admin"]');
+  const adminSlot = adminItem?.querySelector<HTMLElement>('.qr-slot');
+  if (adminSlot) {
+    void toggleQr(adminSlot, links.admin);
+    adminItem?.querySelector('[data-act="qr"]')?.setAttribute('aria-expanded', 'true');
+  }
 }
 
 home();

--- a/collect/src/qr.ts
+++ b/collect/src/qr.ts
@@ -1,0 +1,32 @@
+// A QR code as a scalable, dark-on-white SVG string. Used to hand a collect
+// link from one screen to another (laptop -> phone camera) with no accounts and
+// no server. The encoder (qrcode-generator, MIT) is dynamically imported so it
+// only loads the first time a QR is shown — the lean landing bundle stays lean.
+//
+// Colours are fixed #000-on-#fff regardless of theme: a QR must stay dark
+// modules on a light ground to scan, so this never follows prefers-color-scheme.
+
+export async function qrSvg(text: string, opts: { margin?: number } = {}): Promise<string> {
+  const qrcode = (await import('qrcode-generator')).default;
+  const qr = qrcode(0, 'M'); // type 0 = auto-pick the smallest version that fits; EC level M
+  qr.addData(text);
+  qr.make();
+
+  const count = qr.getModuleCount();
+  const margin = opts.margin ?? 4; // 4-module quiet zone (spec minimum)
+  const size = count + margin * 2;
+
+  // One <path> of unit squares for the dark modules — compact and crisp.
+  let d = '';
+  for (let row = 0; row < count; row++) {
+    for (let col = 0; col < count; col++) {
+      if (qr.isDark(row, col)) d += `M${col + margin} ${row + margin}h1v1h-1z`;
+    }
+  }
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${size} ${size}" width="100%" height="100%"` +
+    ` shape-rendering="crispEdges" role="img" aria-label="QR code for this link">` +
+    `<rect width="${size}" height="${size}" fill="#fff"/>` +
+    `<path d="${d}" fill="#000"/></svg>`
+  );
+}

--- a/collect/src/share-ui.ts
+++ b/collect/src/share-ui.ts
@@ -9,15 +9,16 @@ import { qrSvg } from './qr';
 
 // One link block. `key` disambiguates items; `note` is an optional caption.
 export function shareItemHtml(key: string, label: string, url: string, note?: string): string {
+  const slotId = `qr-slot-${escapeHtml(key)}`;
   return `<div class="share-item" data-share="${escapeHtml(key)}">
     <div class="share-item__label"><span>${escapeHtml(label)}</span></div>
     <code>${escapeHtml(url)}</code>
     <div class="share-item__actions">
       <button type="button" data-act="copy">Copy</button>
       <button type="button" data-act="share">⇪ Share</button>
-      <button type="button" data-act="qr" aria-expanded="false">▦ QR</button>
+      <button type="button" data-act="qr" aria-expanded="false" aria-controls="${slotId}">▦ QR</button>
     </div>
-    <div class="qr-slot" hidden></div>
+    <div class="qr-slot" id="${slotId}" hidden></div>
     ${note ? `<p class="hint" style="margin:8px 0 0">${escapeHtml(note)}</p>` : ''}
   </div>`;
 }

--- a/collect/src/share-ui.ts
+++ b/collect/src/share-ui.ts
@@ -34,11 +34,13 @@ export async function toggleQr(slot: HTMLElement, url: string): Promise<void> {
   slot.removeAttribute('hidden');
   slot.innerHTML = '<div class="qr"><span class="spinner"></span></div>';
   try {
+    const svg = await qrSvg(url);
+    if (slot.hasAttribute('hidden')) return; // closed again while the encoder loaded
     slot.innerHTML =
-      `<div class="qr">${await qrSvg(url)}</div>` +
+      `<div class="qr">${svg}</div>` +
       `<p class="hint" style="text-align:center;margin:6px 0 0">Point a phone camera here to open on another device.</p>`;
   } catch {
-    slot.innerHTML = '<p class="hint">Could not draw the QR code.</p>';
+    if (!slot.hasAttribute('hidden')) slot.innerHTML = '<p class="hint">Could not draw the QR code.</p>';
   }
 }
 

--- a/collect/src/share-ui.ts
+++ b/collect/src/share-ui.ts
@@ -1,0 +1,64 @@
+// The DOM for handing a link to another device: a labelled link with Copy,
+// Share (native sheet), and QR. Shared by the create-success screen (landing)
+// and the admin Share tab (app) so the two never drift. Pure string builders +
+// event wiring; the encoder and share/clipboard calls live in qr.ts / share.ts.
+
+import { escapeHtml } from './util';
+import { shareOrCopy } from './share';
+import { qrSvg } from './qr';
+
+// One link block. `key` disambiguates items; `note` is an optional caption.
+export function shareItemHtml(key: string, label: string, url: string, note?: string): string {
+  return `<div class="share-item" data-share="${escapeHtml(key)}">
+    <div class="share-item__label"><span>${escapeHtml(label)}</span></div>
+    <code>${escapeHtml(url)}</code>
+    <div class="share-item__actions">
+      <button type="button" data-act="copy">Copy</button>
+      <button type="button" data-act="share">⇪ Share</button>
+      <button type="button" data-act="qr" aria-expanded="false">▦ QR</button>
+    </div>
+    <div class="qr-slot" hidden></div>
+    ${note ? `<p class="hint" style="margin:8px 0 0">${escapeHtml(note)}</p>` : ''}
+  </div>`;
+}
+
+// Toggle a QR under a link. The encoder loads on first use (dynamic import), so
+// show a spinner while it arrives.
+export async function toggleQr(slot: HTMLElement, url: string): Promise<void> {
+  if (!slot.hasAttribute('hidden')) {
+    slot.setAttribute('hidden', '');
+    slot.innerHTML = '';
+    return;
+  }
+  slot.removeAttribute('hidden');
+  slot.innerHTML = '<div class="qr"><span class="spinner"></span></div>';
+  try {
+    slot.innerHTML =
+      `<div class="qr">${await qrSvg(url)}</div>` +
+      `<p class="hint" style="text-align:center;margin:6px 0 0">Point a phone camera here to open on another device.</p>`;
+  } catch {
+    slot.innerHTML = '<p class="hint">Could not draw the QR code.</p>';
+  }
+}
+
+// Wire Copy / Share / QR for every .share-item under root. The URL is read from
+// each item's own <code>, so callers only build the HTML.
+export function wireShareItems(root: ParentNode, title: string): void {
+  root.querySelectorAll<HTMLElement>('.share-item').forEach((item) => {
+    const url = item.querySelector('code')?.textContent || '';
+    const copy = item.querySelector<HTMLButtonElement>('[data-act="copy"]');
+    if (copy) copy.onclick = () => {
+      void navigator.clipboard?.writeText(url).catch(() => {});
+      copy.textContent = '✓';
+      setTimeout(() => { copy.textContent = 'Copy'; }, 1400);
+    };
+    const share = item.querySelector<HTMLButtonElement>('[data-act="share"]');
+    if (share) share.onclick = () => { void shareOrCopy(url, title); };
+    const qrBtn = item.querySelector<HTMLButtonElement>('[data-act="qr"]');
+    const slot = item.querySelector<HTMLElement>('.qr-slot');
+    if (qrBtn && slot) qrBtn.onclick = () => {
+      void toggleQr(slot, url);
+      qrBtn.setAttribute('aria-expanded', slot.hasAttribute('hidden') ? 'false' : 'true');
+    };
+  });
+}

--- a/collect/src/share.ts
+++ b/collect/src/share.ts
@@ -1,0 +1,58 @@
+// Moving a map's links between devices, with no accounts. The link IS the
+// credential, so there is nothing to sync — instead we make the hand-off easy:
+//   · shareOrCopy  — the native share sheet (AirDrop / message / mail yourself),
+//                    falling back to the clipboard where share is unavailable.
+//   · linksMailtoHref — mail every link to yourself; email reaches any device.
+//   · a QR of a link (see qr.ts) covers laptop -> phone.
+// linksText is the shared plain-text block used by both the mail body and the
+// "download my links" file, so the two never drift.
+
+export interface MapLinks {
+  edit?: string;
+  admin?: string;
+  view?: string;
+}
+
+// Present links only, each labelled in plain words. Admin last, with a secrecy
+// note when it is included. No em-dashes (public-facing copy).
+export function linksText(links: MapLinks, mapName?: string): string {
+  const head = mapName ? `collect.bharatlas.com links for "${mapName}"` : 'collect.bharatlas.com map links';
+  const lines: string[] = [head, ''];
+  if (links.edit) lines.push(`Collect link (share to add points): ${links.edit}`);
+  if (links.view) lines.push(`View only: ${links.view}`);
+  if (links.admin) lines.push(`Admin (keep secret, full control): ${links.admin}`);
+  if (links.admin) {
+    lines.push('', 'Keep the admin link private. Anyone who has it can moderate and publish this map.');
+  }
+  return lines.join('\n') + '\n';
+}
+
+// A mailto: to send the links to yourself (no recipient prefilled). Email is the
+// natural cross-device home for a secret like the admin link.
+export function linksMailtoHref(links: MapLinks, mapName?: string): string {
+  const subject = mapName ? `collect map links: ${mapName}` : 'collect map links';
+  return `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(linksText(links, mapName))}`;
+}
+
+// Share one link via the native share sheet; fall back to the clipboard. Both
+// must run inside the user's tap (iOS/Safari drop a share/clipboard call made
+// after an await), so keep the call synchronous with the gesture at the caller.
+export async function shareOrCopy(url: string, title: string): Promise<'shared' | 'copied' | 'failed'> {
+  const nav = navigator as Navigator & { share?: (d: ShareData) => Promise<void> };
+  if (typeof nav.share === 'function') {
+    try {
+      await nav.share({ title, url });
+      return 'shared';
+    } catch (e) {
+      // AbortError = the user dismissed the sheet; treat as a no-op, not a copy.
+      if (e instanceof DOMException && e.name === 'AbortError') return 'shared';
+      // otherwise fall through to clipboard
+    }
+  }
+  try {
+    await navigator.clipboard?.writeText(url);
+    return 'copied';
+  } catch {
+    return 'failed';
+  }
+}

--- a/collect/src/share.ts
+++ b/collect/src/share.ts
@@ -50,8 +50,11 @@ export async function shareOrCopy(url: string, title: string): Promise<'shared' 
     }
   }
   try {
-    await navigator.clipboard?.writeText(url);
-    return 'copied';
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(url);
+      return 'copied';
+    }
+    return 'failed';
   } catch {
     return 'failed';
   }

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -34,6 +34,8 @@
   --shadow-card: 0 1px 2px rgba(15, 17, 21, .05);
   --shadow-pop: 0 6px 22px rgba(15, 17, 21, .16);
   --ring: 0 0 0 3px rgba(79, 70, 229, .40);
+  --sheet-h: 0px;            /* live height of the bottom sheet; JS keeps it current
+                                so the map's crosshair + floating controls sit above it */
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -67,7 +69,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -webkit-text-size-adjust: 100%;
 }
-#app { height: 100dvh; display: flex; flex-direction: column; }
+#app { height: 100dvh; display: flex; flex-direction: column; position: relative; }
 strong { font-weight: 650; letter-spacing: -.01em; }
 
 /* top bar */
@@ -165,6 +167,38 @@ textarea { min-height: 92px; line-height: 1.5; }
 }
 .link-box .btn, .link-box button { min-height: 40px; padding: 0 12px; }
 
+/* ── share a link to another device (Copy / Share / QR) ────────────────── */
+.share-item {
+  border: 1px solid var(--line); border-radius: var(--radius); background: var(--card);
+  padding: 11px 12px; margin: 9px 0; box-shadow: var(--shadow-card);
+}
+.share-item__label { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; font-size: 13px; font-weight: 600; color: var(--fg); }
+.share-item code {
+  display: block; margin: 8px 0; padding: 9px 11px; background: var(--surface); border-radius: 9px;
+  font-size: 12px; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.share-item__actions { display: flex; gap: 8px; }
+.share-item__actions button { flex: 1; min-height: 42px; padding: 0 8px; }
+/* the QR itself is always dark-on-white so it scans in any theme */
+.qr {
+  width: 172px; max-width: 60vw; aspect-ratio: 1; margin: 10px auto 0; padding: 10px;
+  background: #fff; border-radius: var(--radius); box-shadow: var(--shadow-card);
+  display: flex; align-items: center; justify-content: center;
+}
+.qr svg { display: block; width: 100%; height: 100%; }
+.qr-slot[hidden] { display: none; }
+
+/* ── tabs (admin Manage: Review / Share / Data) ────────────────────────── */
+.tabs {
+  display: flex; gap: 4px; margin: 10px 0 12px; padding: 3px;
+  border: 1px solid var(--line-strong); border-radius: var(--radius); background: var(--surface);
+}
+.tabs button {
+  flex: 1; min-height: 36px; border: 0; border-radius: 9px; background: transparent;
+  font-size: 13px; font-weight: 600; padding: 0 6px; color: var(--muted);
+}
+.tabs button.on { background: var(--accent-solid); color: #fff; box-shadow: var(--shadow-card); }
+
 /* import column-mapping rows (field ← column) */
 .maplabel { font-size: 13px; font-weight: 600; color: var(--fg); margin: 14px 0 6px; }
 .maplabel .hint { font-weight: 400; }
@@ -186,9 +220,14 @@ textarea { min-height: 92px; line-height: 1.5; }
 /* ── map + capture ─────────────────────────────────────────────────────── */
 .map { position: relative; flex: 1; min-height: 0; }
 #map { position: absolute; inset: 0; }
+/* The panel floats OVER a full-bleed map (not squeezing it), so plotting always
+   has the whole screen. The crosshair + map buttons ride above it via --sheet-h. */
+#panel { position: absolute; left: 0; right: 0; bottom: 0; z-index: 10; }
 .crosshair {
-  position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
+  position: absolute; left: 50%; top: calc(50% - var(--sheet-h, 0px) / 2);
+  transform: translate(-50%, -50%);
   width: 34px; height: 34px; pointer-events: none; z-index: 5;
+  transition: top .2s ease;
 }
 .crosshair::before, .crosshair::after { content: ""; position: absolute; background: var(--accent); border-radius: 2px; }
 .crosshair::before { left: 16px; top: 0; width: 2px; height: 34px; }
@@ -201,9 +240,10 @@ textarea { min-height: 92px; line-height: 1.5; }
 }
 @keyframes pulse { 0%, 100% { outline-color: var(--accent-strong); } 50% { outline-color: color-mix(in srgb, var(--accent-strong) 45%, transparent); } }
 .locate {
-  position: absolute; right: 14px; bottom: 14px; z-index: 6;
+  position: absolute; right: 14px; bottom: calc(14px + var(--sheet-h, 0px)); z-index: 6;
   min-width: var(--ctl-h); padding: 0; font-size: 18px;
   background: var(--card); box-shadow: var(--shadow-pop);
+  transition: bottom .2s ease;
 }
 
 /* ── bottom sheet ──────────────────────────────────────────────────────── */
@@ -212,11 +252,26 @@ textarea { min-height: 92px; line-height: 1.5; }
   box-shadow: var(--shadow-sheet); border-radius: 18px 18px 0 0;
   max-height: 64dvh; display: flex; flex-direction: column;
   animation: sheet-in .22s cubic-bezier(.2, .7, .3, 1);
+  transition: transform .26s cubic-bezier(.2, .7, .3, 1);
 }
-.sheet::before, .bar::before {
+/* collapse to a peek: the map takes the whole screen, the grab stays reachable */
+.sheet.collapsed { transform: translateY(calc(100% - 30px)); }
+.bar::before {
   content: ""; position: absolute; top: 7px; left: 50%; transform: translateX(-50%);
   width: 36px; height: 4px; border-radius: 999px; background: var(--line-strong); opacity: .8;
 }
+/* tappable grab handle — drag the sheet out of the way to see more map */
+.grab {
+  position: relative; flex: 0 0 auto; width: 100%; height: 26px; min-height: 26px;
+  padding: 0; margin: 0; border: 0; background: transparent; cursor: pointer; border-radius: 18px 18px 0 0;
+}
+.grab::before {
+  content: ""; position: absolute; top: 9px; left: 50%; transform: translateX(-50%);
+  width: 40px; height: 4px; border-radius: 999px; background: var(--line-strong); opacity: .85;
+  transition: background .15s ease, width .15s ease;
+}
+.grab:hover::before { width: 48px; }
+.grab:active::before, .sheet.collapsed .grab::before { background: var(--accent); }
 
 /* compact placing controls — keeps the map the centre-piece while marking */
 .bar {
@@ -228,7 +283,7 @@ textarea { min-height: 92px; line-height: 1.5; }
 }
 .bar #cap-help { margin: 0; }
 .bar .seg { align-self: center; }
-.sheet .body { padding: 20px 16px 14px; overflow: auto; }
+.sheet .body { padding: 4px 16px 14px; overflow: auto; }
 .sheet .body > strong { font-size: 17px; }
 .sheet .foot {
   padding: 12px 16px calc(12px + env(safe-area-inset-bottom));

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -36,6 +36,7 @@
   --ring: 0 0 0 3px rgba(79, 70, 229, .40);
   --sheet-h: 0px;            /* live height of the bottom sheet; JS keeps it current
                                 so the map's crosshair + floating controls sit above it */
+  --peek-h: 30px;            /* visible strip when a sheet is collapsed (CSS + JS read this) */
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -255,7 +256,7 @@ textarea { min-height: 92px; line-height: 1.5; }
   transition: transform .26s cubic-bezier(.2, .7, .3, 1);
 }
 /* collapse to a peek: the map takes the whole screen, the grab stays reachable */
-.sheet.collapsed { transform: translateY(calc(100% - 30px)); }
+.sheet.collapsed { transform: translateY(calc(100% - var(--peek-h))); }
 .bar::before {
   content: ""; position: absolute; top: 7px; left: 50%; transform: translateX(-50%);
   width: 36px; height: 4px; border-radius: 999px; background: var(--line-strong); opacity: .8;

--- a/collect/tests/qr.test.ts
+++ b/collect/tests/qr.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { qrSvg } from '../src/qr';
+
+describe('qrSvg', () => {
+  it('returns a scalable dark-on-white svg for a url', async () => {
+    const svg = await qrSvg('https://collect.bharatlas.com/c/abc/admin#adm_token123');
+    expect(svg.startsWith('<svg')).toBe(true);
+    expect(svg).toContain('viewBox="0 0');
+    expect(svg).toContain('<path');
+    expect(svg).toContain('#fff'); // white ground for scannability
+  });
+
+  it('grows the module grid for longer input', async () => {
+    const short = await qrSvg('hi');
+    const long = await qrSvg('x'.repeat(300));
+    const box = (s: string): number => Number(/viewBox="0 0 (\d+)/.exec(s)![1]);
+    expect(box(long)).toBeGreaterThan(box(short));
+  });
+});

--- a/collect/tests/share.test.ts
+++ b/collect/tests/share.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { linksText, linksMailtoHref } from '../src/share';
+
+const links = {
+  edit: 'https://collect.bharatlas.com/c/abc#edt_1',
+  view: 'https://collect.bharatlas.com/c/abc/view#viw_1',
+  admin: 'https://collect.bharatlas.com/c/abc/admin#adm_1',
+};
+
+describe('linksText', () => {
+  it('includes every present link, labelled', () => {
+    const t = linksText(links, 'Footpaths');
+    expect(t).toContain('edt_1');
+    expect(t).toContain('viw_1');
+    expect(t).toContain('adm_1');
+    expect(t).toContain('Footpaths');
+  });
+
+  it('omits links that are absent', () => {
+    const t = linksText({ edit: 'https://collect.bharatlas.com/c/x#edt_2' });
+    expect(t).toContain('edt_2');
+    expect(t).not.toContain('adm_'); // no admin line
+    expect(t).not.toContain('viw_'); // no view line
+  });
+
+  it('warns the admin link is secret when present', () => {
+    expect(linksText(links).toLowerCase()).toContain('secret');
+    expect(linksText({ view: 'https://collect.bharatlas.com/c/x/view#viw_3' }).toLowerCase()).not.toContain('secret');
+  });
+
+  it('has no em-dashes (public-facing copy)', () => {
+    expect(linksText(links, 'Trees')).not.toContain('—');
+  });
+});
+
+describe('linksMailtoHref', () => {
+  it('is a mailto with encoded subject + body carrying the links', () => {
+    const href = linksMailtoHref(links, 'Footpaths');
+    expect(href.startsWith('mailto:?')).toBe(true);
+    expect(href).toContain('subject=');
+    expect(href).toContain('body=');
+    expect(decodeURIComponent(href)).toContain('adm_1');
+    expect(decodeURIComponent(href)).toContain('Footpaths');
+  });
+
+  it('leaves the recipient empty (send to yourself)', () => {
+    expect(linksMailtoHref(links).startsWith('mailto:?')).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes three field complaints about collect: links are hard to move between phone and laptop (especially admin links), the admin panel is cluttered, and the map is too small to plot on.

## 1. Sharing links across devices
collect has no accounts, so the link *is* the credential and nothing syncs. The only cross-device path was an export/import JSON chore. Now:
- Every link has **Copy · ⇪ Share · ▦ QR**. Share opens the native sheet (AirDrop / message / mail yourself → reaches the other device); QR handles laptop → phone.
- **Email these links to me** (mailto with all links) puts them in an inbox reachable anywhere.
- The **create-success screen** auto-opens the admin QR.
- The admin **Share tab** surfaces *this device's* admin link with the same actions, so an owner opens the same map on phone and laptop, no accounts.

## 2. Declutter the admin panel
The Manage sheet stacked review + share + download + import in one scroll. Now three tabs — **Review / Share / Data** — with a persistent `+ Add points | Publish → catalog` footer.

## 3. More map for plotting
The sheet was a flow sibling that squeezed the map. Now the panel **floats over a full-bleed map**; the crosshair and the floating map buttons ride above it via a live `--sheet-h` var; a **grab handle collapses any sheet to a peek** so the map takes the whole screen. Placement reads the crosshair's real screen position (`unproject`) so the point matches exactly what's targeted.

## New modules
- `qr.ts` — QR as a scalable dark-on-white SVG; `qrcode-generator` is **dynamically imported** so it splits into its own 21KB chunk and the lean landing bundle stays lean.
- `share.ts` — `linksText` / `linksMailtoHref` / `shareOrCopy` (pure helpers red-green tested).
- `share-ui.ts` — the shared link-card UI used by both the success screen and the Share tab.

## Verification
- `npm run build` green: 92 tests pass, both tsconfigs typecheck, Vite build clean.
- Visually verified at 390px (iPhone 12 Pro class): success screen, tabbed map view, and collapse-to-peek.

No accounts added, no new server surface. Not merging — flagging for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)