### PR TITLE
collect: linked map<->list review + inline-editable form fields

### DIFF
--- a/collect/package-lock.json
+++ b/collect/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260520.1",
         "@types/qrcode-generator": "^0.0.16",
+        "happy-dom": "^20.11.6",
         "typescript": "^5.6.3",
         "vite": "^5.4.10",
         "vitest": "^2.1.9"
@@ -922,6 +923,16 @@
         "@types/pbf": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/pbf": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
@@ -942,6 +953,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1067,6 +1095,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1137,6 +1178,19 @@
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
       "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1261,6 +1315,25 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.6.tgz",
+      "integrity": "sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ieee754": {
@@ -1686,6 +1759,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
@@ -1846,6 +1926,16 @@
         "pbf": "^3.2.1"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -1876,6 +1966,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/collect/package.json
+++ b/collect/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260520.1",
     "@types/qrcode-generator": "^0.0.16",
+    "happy-dom": "^20.11.6",
     "typescript": "^5.6.3",
     "vite": "^5.4.10",
     "vitest": "^2.1.9"

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -195,7 +195,8 @@ async function boot(): Promise<void> {
     document.getElementById('maploading')?.remove();
     if (!isView && allowsShapes) setupDrawLayers();
     if (meta.schema.reference_layer) void addReferenceOverlay(map, meta.schema.reference_layer.pmtiles_url).catch(() => {});
-    void loadRecords();
+    if (isAdmin) syncReviewLayer();   // admin: the clickable, status-coloured review layer (driven by the list)
+    else void loadRecords();          // view / collect: published points as context
   });
 
   const reftoggle = document.getElementById('reftoggle') as HTMLButtonElement | null;
@@ -241,6 +242,110 @@ function viewPanel(): void {
 let recordShapes: GeoJSON.Feature[] = [];
 let reviewFeats: Feature[] = [];               // the admin review list, for tap-to-review
 let reviewMarker: maplibregl.Marker | undefined; // highlight on the map during review
+let selectedIdx: number | null = null;         // the linked map<->list selection
+let recordPopup: maplibregl.Popup | undefined; // the on-map attribute tooltip
+
+// ── linked map <-> list (admin review) ───────────────────────────────────
+// The review features get their own clickable, status-coloured layer keyed to the
+// list rows, so clicking a marker highlights + scrolls its entry (and pops a
+// tooltip), and clicking a row flies to and highlights the marker.
+const STATUS_COLOR = ['match', ['get', 'status'], 'pending', '#d97706', 'rejected', '#dc2626', ACCENT] as maplibregl.ExpressionSpecification;
+
+function reviewFC(): GeoJSON.FeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features: reviewFeats.map((f, idx) => ({
+      type: 'Feature',
+      id: idx, // numeric id so feature-state (the selection highlight) works
+      geometry: f.geometry as GeoJSON.Geometry,
+      properties: { idx, status: (f.properties as { _status?: string })._status || 'published' },
+    })),
+  };
+}
+
+// Draw / update the review layer from reviewFeats. Safe to call before the style
+// loads (it no-ops, and the map-load handler calls it again) or repeatedly.
+function syncReviewLayer(): void {
+  if (!map.isStyleLoaded()) return;
+  const src = map.getSource('review') as maplibregl.GeoJSONSource | undefined;
+  if (src) { src.setData(reviewFC()); return; }
+  map.addSource('review', { type: 'geojson', data: reviewFC() });
+  map.addLayer({
+    id: 'review-fill', type: 'fill', source: 'review', filter: ['==', '$type', 'Polygon'],
+    paint: { 'fill-color': STATUS_COLOR, 'fill-opacity': ['case', ['boolean', ['feature-state', 'sel'], false], 0.3, 0.12] },
+  });
+  map.addLayer({
+    id: 'review-line', type: 'line', source: 'review', filter: ['!=', '$type', 'Point'],
+    paint: { 'line-color': STATUS_COLOR, 'line-width': ['case', ['boolean', ['feature-state', 'sel'], false], 4, 2] },
+  });
+  map.addLayer({
+    id: 'review-pt', type: 'circle', source: 'review', filter: ['==', '$type', 'Point'],
+    paint: {
+      'circle-radius': ['case', ['boolean', ['feature-state', 'sel'], false], 9, 6],
+      'circle-color': STATUS_COLOR,
+      'circle-stroke-color': '#ffffff',
+      'circle-stroke-width': ['case', ['boolean', ['feature-state', 'sel'], false], 3, 2],
+    },
+  });
+  for (const id of ['review-pt', 'review-fill', 'review-line']) {
+    map.on('click', id, (e) => {
+      const idx = e.features?.[0]?.properties?.idx;
+      if (typeof idx === 'number') selectFromMap(idx);
+    });
+    map.on('mouseenter', id, () => { map.getCanvas().style.cursor = 'pointer'; });
+    map.on('mouseleave', id, () => { map.getCanvas().style.cursor = ''; });
+  }
+}
+
+// Set (or clear, with null) the map-side selection highlight via feature-state.
+function selectReviewFeature(idx: number | null): void {
+  if (map.getSource('review')) {
+    if (selectedIdx !== null) map.removeFeatureState({ source: 'review', id: selectedIdx }, 'sel');
+    if (idx !== null) map.setFeatureState({ source: 'review', id: idx }, { sel: true });
+  }
+  selectedIdx = idx;
+}
+
+function clearSelection(): void {
+  recordPopup?.remove();
+  recordPopup = undefined;
+  selectReviewFeature(null);
+  clearRowSelection();
+}
+
+// The on-map attribute tooltip for a record, with a "Review" button into the
+// full detail + moderation sheet.
+function showRecordPopup(idx: number, coord: [number, number]): void {
+  const f = reviewFeats[idx];
+  if (!f) return;
+  const p = f.properties as { _status?: string; [k: string]: unknown };
+  const st = p._status || 'published';
+  const rows = attrRowsHtml(p, 'pop-attr');
+  const html = `<div class="pop">
+      <div class="pop-head"><strong>${escapeHtml(cardTitle(p))}</strong><span class="badge badge--${st}">${st}</span></div>
+      <div class="pop-attrs">${rows || '<p class="hint" style="margin:0">No fields on this map.</p>'}</div>
+      <button type="button" class="pop-review">Review${st === 'pending' ? ' / moderate' : ''} →</button>
+    </div>`;
+  recordPopup?.remove();
+  recordPopup = new maplibregl.Popup({ closeOnClick: false, maxWidth: '260px', offset: 14 })
+    .setLngLat(coord).setHTML(html).addTo(map);
+  recordPopup.getElement()?.querySelector('.pop-review')?.addEventListener('click', () => openReview(idx));
+  recordPopup.on('close', () => { if (selectedIdx === idx) clearSelection(); });
+}
+
+// A marker/shape was tapped: highlight it, pop the tooltip, and highlight +
+// scroll the matching list row (when the review list is showing).
+function selectFromMap(idx: number): void {
+  selectReviewFeature(idx);
+  clearRowSelection();
+  const row = document.querySelector<HTMLElement>(`.point-row[data-idx="${idx}"]`);
+  if (row) { row.classList.add('point-row--sel'); row.scrollIntoView({ block: 'nearest', behavior: 'smooth' }); }
+  const c = representativeCoord(reviewFeats[idx]?.geometry);
+  if (c) {
+    showRecordPopup(idx, c);
+    map.easeTo({ center: c, offset: sheetLiftOffset(), duration: 300 });
+  }
+}
 
 // The non-point records overlay: one accumulating source for existing +
 // just-added lines/polygons. Points are plain markers.
@@ -411,8 +516,12 @@ function detailsSheet(geometry: GeoJSON.Geometry, modes: GeomMode[]): void {
         method: 'POST',
         body: JSON.stringify({ geometry, properties: valid.properties, contributor: lastContributor, turnstile_token }),
       });
-      if (geometry.type === 'Point') marker((geometry as GeoJSON.Point).coordinates as number[]);
-      else addRecordShape(geometry);
+      // In admin the status-coloured review layer owns the on-map display; a plain
+      // pin here would double it once they return to Review. Contributors get the pin.
+      if (ctx.mode !== 'admin') {
+        if (geometry.type === 'Point') marker((geometry as GeoJSON.Point).coordinates as number[]);
+        else addRecordShape(geometry);
+      }
       verts = []; redrawDraw();
       toast(meta.moderation ? 'Added, pending review ✓' : 'Added ✓');
       const editUrl = `${location.origin}/c/${ctx.id}/r/${res.id}#${res.edit_token}`;
@@ -563,6 +672,7 @@ function renderManageTab(): void {
   });
   const body = document.getElementById('tabbody');
   if (!body) return;
+  if (manageTab !== 'review') clearSelection(); // don't leave a tooltip/highlight behind
   if (manageTab === 'share') return renderShareTab(body);
   if (manageTab === 'data') return renderDataTab(body);
   return renderReviewTab(body);
@@ -837,6 +947,8 @@ async function renderPoints(): Promise<void> {
     const qs = status ? `?status=${status}&limit=1000` : '?limit=1000';
     const fc = await apiJson<{ features: Feature[] }>(`/collections/${ctx.id}/records${qs}`, ctx.token);
     reviewFeats = fc.features || [];
+    clearSelection();     // the previous selection points at stale indices
+    syncReviewLayer();    // redraw the clickable markers for this filter
     if (!reviewFeats.length) { q.innerHTML = '<p class="empty">No points here yet. Share the collect link and they will show up as people add them.</p>'; return; }
     q.innerHTML = reviewFeats.map((f, i) => {
       const st = (f.properties as { _status?: string })._status || 'published';
@@ -857,8 +969,26 @@ async function renderPoints(): Promise<void> {
 
 const fmtVal = (v: unknown): string => (Array.isArray(v) ? v.join(', ') : v == null || v === '' ? '—' : String(v));
 
+// One attribute row per (non-deleted) field — shared by the review sheet
+// (prefix "attr") and the map tooltip (prefix "pop-attr"). Empty-state per caller.
+function attrRowsHtml(p: Record<string, unknown>, prefix: string): string {
+  return meta.schema.fields
+    .filter((x) => !x.deleted)
+    .map((fl) => `<div class="${prefix}"><span class="${prefix}__k">${escapeHtml(fl.label)}</span><span class="${prefix}__v">${escapeHtml(fmtVal(p[fl.key]))}</span></div>`)
+    .join('');
+}
+
+// Lift a point into the band above the review sheet (which floats over the map).
+function sheetLiftOffset(): [number, number] { return [0, -Math.round(window.innerHeight * 0.2)]; }
+
+function clearRowSelection(): void {
+  document.querySelectorAll('.point-row--sel').forEach((el) => el.classList.remove('point-row--sel'));
+}
+
 function clearHighlight(): void {
   if (reviewMarker) { reviewMarker.remove(); reviewMarker = undefined; }
+  recordPopup?.remove(); recordPopup = undefined;
+  selectReviewFeature(null);
 }
 
 // Tap a point → see it on the map (fly + highlight) + every attribute, and
@@ -868,19 +998,16 @@ function openReview(idx: number): void {
   if (!f) return;
   const p = f.properties as { _status?: string; _contributor?: string; _admin_ctx?: AdminCtx; _source?: string; [k: string]: unknown };
   const st = p._status || 'published';
-  const fields = meta.schema.fields.filter((x) => !x.deleted);
 
   const c = representativeCoord(f.geometry);
   clearHighlight();
+  selectReviewFeature(idx); // emphasise the same feature on the map
   if (c) {
     reviewMarker = new maplibregl.Marker({ color: '#d97706' }).setLngLat(c).addTo(map);
-    // Lift the point into the band above the review sheet (which floats over the map).
-    map.flyTo({ center: c, zoom: Math.max(map.getZoom(), 14), offset: [0, -Math.round(window.innerHeight * 0.2)] });
+    map.flyTo({ center: c, zoom: Math.max(map.getZoom(), 14), offset: sheetLiftOffset() });
   }
 
-  const attrs = fields
-    .map((fl) => `<div class="attr"><span class="attr__k">${escapeHtml(fl.label)}</span><span class="attr__v">${escapeHtml(fmtVal(p[fl.key]))}</span></div>`)
-    .join('');
+  const attrs = attrRowsHtml(p, 'attr');
   const origin = p._source ? `⇪ from ${escapeHtml(p._source)}` : `by ${escapeHtml(p._contributor || 'anonymous')}`;
   const panel = document.getElementById('panel')!;
   panel.innerHTML = `<div class="sheet">

--- a/collect/src/schema-builder.ts
+++ b/collect/src/schema-builder.ts
@@ -1,6 +1,8 @@
 // The Phase-2 schema builder: add fields from the 7 types, set required +
 // type-specific config (options/chips for choices, whole-numbers for number),
-// reorder, remove. Generates schema_doc.fields. Keys derive from labels.
+// reorder, remove, and EDIT an existing field inline (click its name → the same
+// config form opens directly under that row). Generates schema_doc.fields; keys
+// derive from labels for new fields and stay stable across an edit.
 import { deriveKey } from './schema/derive-key';
 import { escapeHtml } from './util';
 
@@ -31,50 +33,172 @@ const MAX_FIELDS = 20;
 const needsOptions = (t: string) => t === 'select' || t === 'multiselect';
 const typeLabel = (t: string) => TYPES.find(([v]) => v === t)?.[1] ?? t;
 
+interface FieldForm {
+  read(): { field: BuilderField } | { error: string };
+  focus(): void;
+  setError(msg: string): void;
+}
+
+// The reusable field-config form (label / type / required / hint / type-extra).
+// One instance backs the persistent "add" card; another is mounted inline under
+// a row when editing. Everything is class-scoped to `host`, so instances never
+// collide. `initial` prefills it for editing.
+function createFieldForm(host: HTMLElement, initial: BuilderField | null): FieldForm {
+  host.innerHTML = `
+    <input class="ff-label" placeholder="Field label, e.g. Condition" />
+    <div class="row" style="margin-top:6px">
+      <select class="ff-type" style="flex:1">${TYPES.map(([v, l]) => `<option value="${v}">${escapeHtml(l)}</option>`).join('')}</select>
+      <label class="chip" style="gap:6px"><input type="checkbox" class="ff-req" style="width:auto;min-height:auto" /> Required</label>
+    </div>
+    <input class="ff-hint" placeholder="Help text (optional), shown under the field" style="margin-top:6px" />
+    <div class="ff-extra"></div>
+    <p class="ff-err warn"></p>`;
+
+  const $ = <T extends HTMLElement>(sel: string) => host.querySelector<T>(sel)!;
+  const labelEl = $<HTMLInputElement>('.ff-label');
+  const typeEl = $<HTMLSelectElement>('.ff-type');
+  const reqEl = $<HTMLInputElement>('.ff-req');
+  const hintEl = $<HTMLInputElement>('.ff-hint');
+  const extraEl = $<HTMLElement>('.ff-extra');
+  const errEl = $<HTMLElement>('.ff-err');
+
+  function renderExtra(): void {
+    const t = typeEl.value;
+    if (needsOptions(t)) {
+      extraEl.innerHTML = `<label>Options <span class="hint">(one per line)</span></label>
+        <textarea class="ff-opts" placeholder="Good&#10;Needs repair&#10;Unusable"></textarea>
+        <label class="chip" style="gap:6px;margin-top:6px"><input type="checkbox" class="ff-chips" style="width:auto;min-height:auto" /> Show as chips</label>`;
+    } else if (t === 'number') {
+      extraEl.innerHTML = `<div class="row" style="margin-top:6px">
+          <input class="ff-min" inputmode="decimal" placeholder="Min" style="flex:1" />
+          <input class="ff-max" inputmode="decimal" placeholder="Max" style="flex:1" />
+        </div>
+        <label class="chip" style="gap:6px;margin-top:6px"><input type="checkbox" class="ff-int" style="width:auto;min-height:auto" /> Whole numbers only</label>`;
+    } else if (t === 'text' || t === 'paragraph') {
+      extraEl.innerHTML = `<label>Max length <span class="hint">(optional)</span></label>
+        <input class="ff-maxlen" inputmode="numeric" placeholder="e.g. 200" />`;
+    } else {
+      extraEl.innerHTML = '';
+    }
+  }
+  typeEl.onchange = renderExtra;
+
+  if (initial) {
+    labelEl.value = initial.label;
+    typeEl.value = initial.type;
+    reqEl.checked = !!initial.required;
+    hintEl.value = initial.hint || '';
+  }
+  renderExtra();
+  if (initial) {
+    if (needsOptions(initial.type)) {
+      const o = host.querySelector<HTMLTextAreaElement>('.ff-opts'); if (o) o.value = (initial.options || []).join('\n');
+      const c = host.querySelector<HTMLInputElement>('.ff-chips'); if (c) c.checked = initial.render === 'chips';
+    } else if (initial.type === 'number') {
+      const mn = host.querySelector<HTMLInputElement>('.ff-min'); if (mn && initial.min != null) mn.value = String(initial.min);
+      const mx = host.querySelector<HTMLInputElement>('.ff-max'); if (mx && initial.max != null) mx.value = String(initial.max);
+      const it = host.querySelector<HTMLInputElement>('.ff-int'); if (it) it.checked = !!initial.integer;
+    } else if (initial.type === 'text' || initial.type === 'paragraph') {
+      const ml = host.querySelector<HTMLInputElement>('.ff-maxlen'); if (ml && initial.maxLength != null) ml.value = String(initial.maxLength);
+    }
+  }
+
+  function read(): { field: BuilderField } | { error: string } {
+    errEl.textContent = '';
+    const label = labelEl.value.trim();
+    if (!label) return { error: 'Give the field a label.' };
+    const type = typeEl.value;
+    const f: BuilderField = { key: '', label, type };
+    if (reqEl.checked) f.required = true;
+    const hint = hintEl.value.trim();
+    if (hint) f.hint = hint;
+
+    if (needsOptions(type)) {
+      const opts = (host.querySelector<HTMLTextAreaElement>('.ff-opts')?.value || '')
+        .split('\n').map((s) => s.trim()).filter(Boolean);
+      if (!opts.length) return { error: 'Add at least one option.' };
+      f.options = opts;
+      if (host.querySelector<HTMLInputElement>('.ff-chips')?.checked) f.render = 'chips';
+    }
+    if (type === 'number') {
+      const min = host.querySelector<HTMLInputElement>('.ff-min')?.value.trim();
+      const max = host.querySelector<HTMLInputElement>('.ff-max')?.value.trim();
+      if (min && Number.isFinite(Number(min))) f.min = Number(min);
+      if (max && Number.isFinite(Number(max))) f.max = Number(max);
+      if (host.querySelector<HTMLInputElement>('.ff-int')?.checked) f.integer = true;
+    }
+    if (type === 'text' || type === 'paragraph') {
+      const ml = host.querySelector<HTMLInputElement>('.ff-maxlen')?.value.trim();
+      if (ml && Number.isInteger(Number(ml)) && Number(ml) > 0) f.maxLength = Number(ml);
+    }
+    return { field: f };
+  }
+
+  return { read, focus: () => labelEl.focus(), setError: (m) => { errEl.textContent = m; } };
+}
+
 export function mountSchemaBuilder(
   container: HTMLElement,
   initial: BuilderField[] = [],
 ): { getFields: () => BuilderField[] } {
   const fields: BuilderField[] = initial.slice();
+  let editingIndex: number | null = null; // which row is open for inline edit
 
   container.innerHTML = `
     <div id="sb-list"></div>
-    <div class="card">
-      <input id="sb-label" placeholder="Field label, e.g. Condition" />
-      <div class="row" style="margin-top:6px">
-        <select id="sb-type" style="flex:1">${TYPES.map(([v, l]) => `<option value="${v}">${l}</option>`).join('')}</select>
-        <label class="chip" style="gap:6px"><input type="checkbox" id="sb-req" style="width:auto;min-height:auto" /> Required</label>
-      </div>
-      <input id="sb-hint" placeholder="Help text (optional), shown under the field" style="margin-top:6px" />
-      <div id="sb-extra"></div>
-      <p id="sb-err" class="warn"></p>
-      <button id="sb-add">+ Add field</button>
+    <div class="card" id="sb-add">
+      <div class="ff-host"></div>
+      <button type="button" id="sb-add-btn">+ Add field</button>
     </div>`;
+  const listEl = container.querySelector<HTMLElement>('#sb-list')!;
+  const addCardEl = container.querySelector<HTMLElement>('#sb-add')!;
+  const addBtn = container.querySelector<HTMLButtonElement>('#sb-add-btn')!;
+  let addForm = createFieldForm(container.querySelector<HTMLElement>('#sb-add .ff-host')!, null);
 
-  const q = <T extends HTMLElement>(sel: string) => container.querySelector<T>(sel)!;
-  const listEl = q<HTMLElement>('#sb-list');
-  const labelEl = q<HTMLInputElement>('#sb-label');
-  const typeEl = q<HTMLSelectElement>('#sb-type');
-  const reqEl = q<HTMLInputElement>('#sb-req');
-  const extraEl = q<HTMLElement>('#sb-extra');
-  const errEl = q<HTMLElement>('#sb-err');
+  addBtn.onclick = () => {
+    if (fields.length >= MAX_FIELDS) { addForm.setError(`Max ${MAX_FIELDS} fields.`); return; }
+    const built = addForm.read();
+    if ('error' in built) { addForm.setError(built.error); return; }
+    built.field.key = deriveKey(built.field.label, fields.map((x) => x.key));
+    fields.push(built.field);
+    addForm = createFieldForm(container.querySelector<HTMLElement>('#sb-add .ff-host')!, null); // reset
+    renderList();
+  };
 
   function renderList(): void {
+    // one form at a time: while a field is open for inline edit, hide the add card
+    addCardEl.style.display = editingIndex === null ? '' : 'none';
     if (!fields.length) {
       listEl.innerHTML = '<p class="hint">No fields yet. Add at least one.</p>';
       return;
     }
     listEl.innerHTML = fields.map((f, i) => `
-      <div class="link-box">
-        <span style="flex:1;overflow:hidden;text-overflow:ellipsis">${escapeHtml(f.label)}${f.required ? ' *' : ''}
-          <span class="hint">${typeLabel(f.type)}${f.options ? ` · ${f.options.length} options` : ''}</span></span>
+      <div class="link-box${editingIndex === i ? ' link-box--editing' : ''}">
+        <button type="button" class="sb-name" data-edit="${i}" aria-expanded="${editingIndex === i}" aria-label="Edit field ${escapeHtml(f.label)}">${escapeHtml(f.label)}${f.required ? ' *' : ''}
+          <span class="hint">${typeLabel(f.type)}${f.options ? ` · ${f.options.length} options` : ''}</span></button>
         <button data-mv="up" data-i="${i}" aria-label="Move up" ${i === 0 ? 'disabled' : ''}>↑</button>
         <button data-mv="dn" data-i="${i}" aria-label="Move down" ${i === fields.length - 1 ? 'disabled' : ''}>↓</button>
         <button data-rm="${i}" aria-label="Remove field">✕</button>
-      </div>`).join('');
+      </div>${editingIndex === i ? `
+      <div class="card sb-edit" data-editcard="${i}">
+        <div class="ff-host"></div>
+        <div class="row" style="margin-top:8px">
+          <button type="button" class="sb-save primary" style="flex:1">Save field</button>
+          <button type="button" class="sb-cancel">Cancel</button>
+        </div>
+      </div>` : ''}`).join('');
 
+    // click a field name → open its inline editor (or close it if already open)
+    listEl.querySelectorAll<HTMLButtonElement>('[data-edit]').forEach((b) => {
+      b.onclick = () => {
+        const i = Number(b.dataset.edit);
+        editingIndex = editingIndex === i ? null : i;
+        renderList();
+      };
+    });
+    // reorder / remove close any open editor first (indices would otherwise drift)
     listEl.querySelectorAll<HTMLButtonElement>('[data-rm]').forEach((b) => {
-      b.onclick = () => { fields.splice(Number(b.dataset.rm), 1); renderList(); };
+      b.onclick = () => { fields.splice(Number(b.dataset.rm), 1); editingIndex = null; renderList(); };
     });
     listEl.querySelectorAll<HTMLButtonElement>('[data-mv]').forEach((b) => {
       b.onclick = () => {
@@ -82,72 +206,31 @@ export function mountSchemaBuilder(
         const j = b.dataset.mv === 'up' ? i - 1 : i + 1;
         if (j < 0 || j >= fields.length) return;
         [fields[i], fields[j]] = [fields[j], fields[i]];
+        editingIndex = null;
         renderList();
       };
     });
-  }
 
-  function renderExtra(): void {
-    const t = typeEl.value;
-    if (needsOptions(t)) {
-      extraEl.innerHTML = `<label>Options <span class="hint">(one per line)</span></label>
-        <textarea id="sb-opts" placeholder="Good&#10;Needs repair&#10;Unusable"></textarea>
-        <label class="chip" style="gap:6px;margin-top:6px"><input type="checkbox" id="sb-chips" style="width:auto;min-height:auto" /> Show as chips</label>`;
-    } else if (t === 'number') {
-      extraEl.innerHTML = `<div class="row" style="margin-top:6px">
-          <input id="sb-min" inputmode="decimal" placeholder="Min" style="flex:1" />
-          <input id="sb-max" inputmode="decimal" placeholder="Max" style="flex:1" />
-        </div>
-        <label class="chip" style="gap:6px;margin-top:6px"><input type="checkbox" id="sb-int" style="width:auto;min-height:auto" /> Whole numbers only</label>`;
-    } else if (t === 'text' || t === 'paragraph') {
-      extraEl.innerHTML = `<label>Max length <span class="hint">(optional)</span></label>
-        <input id="sb-maxlen" inputmode="numeric" placeholder="e.g. 200" />`;
-    } else {
-      extraEl.innerHTML = '';
+    // mount the inline edit form under the open row
+    if (editingIndex !== null) {
+      const i = editingIndex;
+      const card = listEl.querySelector<HTMLElement>(`[data-editcard="${i}"]`);
+      if (card) {
+        const editForm = createFieldForm(card.querySelector<HTMLElement>('.ff-host')!, fields[i]);
+        editForm.focus();
+        (card.querySelector('.sb-save') as HTMLButtonElement).onclick = () => {
+          const built = editForm.read();
+          if ('error' in built) { editForm.setError(built.error); return; }
+          built.field.key = fields[i].key; // keep the key stable across an edit
+          fields[i] = built.field;
+          editingIndex = null;
+          renderList();
+        };
+        (card.querySelector('.sb-cancel') as HTMLButtonElement).onclick = () => { editingIndex = null; renderList(); };
+      }
     }
   }
-  typeEl.onchange = renderExtra;
 
-  q<HTMLButtonElement>('#sb-add').onclick = () => {
-    errEl.textContent = '';
-    const label = labelEl.value.trim();
-    if (!label) { errEl.textContent = 'Give the field a label.'; return; }
-    if (fields.length >= MAX_FIELDS) { errEl.textContent = `Max ${MAX_FIELDS} fields.`; return; }
-
-    const type = typeEl.value;
-    const f: BuilderField = { key: deriveKey(label, fields.map((x) => x.key)), label, type };
-    if (reqEl.checked) f.required = true;
-    const hint = q<HTMLInputElement>('#sb-hint').value.trim();
-    if (hint) f.hint = hint;
-
-    if (needsOptions(type)) {
-      const opts = (container.querySelector<HTMLTextAreaElement>('#sb-opts')?.value || '')
-        .split('\n').map((s) => s.trim()).filter(Boolean);
-      if (!opts.length) { errEl.textContent = 'Add at least one option.'; return; }
-      f.options = opts;
-      if (container.querySelector<HTMLInputElement>('#sb-chips')?.checked) f.render = 'chips';
-    }
-    if (type === 'number') {
-      const min = container.querySelector<HTMLInputElement>('#sb-min')?.value.trim();
-      const max = container.querySelector<HTMLInputElement>('#sb-max')?.value.trim();
-      if (min && Number.isFinite(Number(min))) f.min = Number(min);
-      if (max && Number.isFinite(Number(max))) f.max = Number(max);
-      if (container.querySelector<HTMLInputElement>('#sb-int')?.checked) f.integer = true;
-    }
-    if (type === 'text' || type === 'paragraph') {
-      const ml = container.querySelector<HTMLInputElement>('#sb-maxlen')?.value.trim();
-      if (ml && Number.isInteger(Number(ml)) && Number(ml) > 0) f.maxLength = Number(ml);
-    }
-
-    fields.push(f);
-    labelEl.value = '';
-    q<HTMLInputElement>('#sb-hint').value = '';
-    reqEl.checked = false;
-    renderExtra();
-    renderList();
-  };
-
-  renderExtra();
   renderList();
   return { getFields: () => fields.slice() };
 }

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -167,6 +167,17 @@ textarea { min-height: 92px; line-height: 1.5; }
   background: var(--surface); padding: 9px 11px; border-radius: 9px; font-size: 12px; color: var(--muted);
 }
 .link-box .btn, .link-box button { min-height: 40px; padding: 0 12px; }
+/* schema builder: a saved field's name is a button — tap it to edit the field */
+.link-box--editing { border-color: var(--accent); background: var(--accent-fill); }
+.sb-name {
+  flex: 1; min-width: 0; justify-content: flex-start; text-align: left; gap: 6px;
+  background: transparent; border: 0; padding: 8px 4px; min-height: 40px; font-weight: 500;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.sb-name:hover { color: var(--accent); }
+.sb-name .hint { font-weight: 400; }
+/* the inline editor that opens directly under the field being edited */
+.sb-edit { margin: -2px 0 12px; border-color: var(--accent); }
 
 /* ── share a link to another device (Copy / Share / QR) ────────────────── */
 .share-item {
@@ -307,6 +318,8 @@ textarea { min-height: 92px; line-height: 1.5; }
   background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); cursor: pointer;
 }
 .point-row:hover { border-color: var(--line-strong); }
+/* the row linked to the marker selected on the map */
+.point-row--sel { border-color: var(--accent); background: var(--accent-fill); box-shadow: inset 3px 0 0 var(--accent); }
 .point-row__title { flex: 1; min-width: 0; white-space: normal; overflow-wrap: anywhere; color: var(--fg); font-weight: 500; font-size: 14px; }
 .point-row__chev { color: var(--muted); font-size: 18px; line-height: 1; flex: 0 0 auto; }
 
@@ -323,6 +336,32 @@ textarea { min-height: 92px; line-height: 1.5; }
 .badge--pending { color: var(--amber); }
 .badge--published { color: var(--accent); }
 .badge--rejected { color: var(--danger); }
+
+/* ── map tooltip (record attributes, linked to the list) ───────────────── */
+/* theme MapLibre's popup (it ships light-only) */
+.maplibregl-popup-content {
+  background: var(--sheet); color: var(--fg); border: 1px solid var(--line);
+  border-radius: 14px; box-shadow: var(--shadow-pop); padding: 12px 14px;
+}
+.maplibregl-popup-close-button { color: var(--muted); font-size: 20px; padding: 0 6px; }
+.maplibregl-popup-anchor-bottom .maplibregl-popup-tip { border-top-color: var(--sheet); }
+.maplibregl-popup-anchor-top .maplibregl-popup-tip { border-bottom-color: var(--sheet); }
+.maplibregl-popup-anchor-left .maplibregl-popup-tip { border-right-color: var(--sheet); }
+.maplibregl-popup-anchor-right .maplibregl-popup-tip { border-left-color: var(--sheet); }
+.maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
+.maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip { border-right-color: var(--sheet); }
+.maplibregl-popup-anchor-top-right .maplibregl-popup-tip,
+.maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip { border-left-color: var(--sheet); }
+
+.pop { min-width: 168px; }
+.pop-head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; margin-bottom: 6px; }
+.pop-head strong { font-size: 14px; }
+.pop-attrs { display: flex; flex-direction: column; max-height: 38vh; overflow: auto; }
+.pop-attr { display: flex; gap: 10px; font-size: 12px; padding: 4px 0; border-top: 1px solid var(--line); }
+.pop-attr:first-child { border-top: 0; }
+.pop-attr__k { flex: 0 0 42%; color: var(--muted); }
+.pop-attr__v { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+.pop-review { margin-top: 10px; width: 100%; min-height: 40px; }
 
 /* home footer */
 .foot-note { display: flex; flex-direction: column; gap: 4px; margin-top: 28px; padding-top: 16px; border-top: 1px solid var(--line); color: var(--muted); font-size: 12px; }

--- a/collect/tests/schema-builder.test.ts
+++ b/collect/tests/schema-builder.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mountSchemaBuilder } from '../src/schema-builder';
+
+// Regression guard for the inline field editor: clicking a saved field opens an
+// editor UNDER that row, and saving updates THAT field only (an earlier version
+// wrote the edit to the wrong field and left the target untouched).
+
+const host = (): HTMLElement => {
+  const d = document.createElement('div');
+  document.body.appendChild(d);
+  return d;
+};
+const q = <T extends Element>(root: ParentNode, sel: string) => root.querySelector(sel) as T;
+
+beforeEach(() => { document.body.innerHTML = ''; });
+
+function addSelectField(root: HTMLElement, label: string, opts: string): void {
+  q<HTMLInputElement>(root, '#sb-add .ff-label').value = label;
+  const t = q<HTMLSelectElement>(root, '#sb-add .ff-type');
+  t.value = 'select';
+  t.dispatchEvent(new Event('change'));
+  q<HTMLTextAreaElement>(root, '#sb-add .ff-opts').value = opts;
+  q<HTMLButtonElement>(root, '#sb-add-btn').click();
+}
+
+describe('mountSchemaBuilder inline edit', () => {
+  it('edits the clicked field in place, keeps its key, and leaves others untouched', () => {
+    const root = host();
+    const b = mountSchemaBuilder(root, [{ key: 'name', label: 'Name', type: 'text', required: true }]);
+
+    addSelectField(root, 'Condition', 'Good\nBad');
+    expect(b.getFields().map((f) => f.label)).toEqual(['Name', 'Condition']);
+    const condKey = b.getFields()[1].key;
+
+    // open the inline editor for field #1
+    q<HTMLButtonElement>(root, '.sb-name[data-edit="1"]').click();
+    const card = q<HTMLElement>(root, '[data-editcard="1"]');
+    expect(card).toBeTruthy();
+    // it renders directly UNDER row #1 (not at the bottom)
+    expect(card.previousElementSibling!.querySelector('.sb-name[data-edit="1"]')).toBeTruthy();
+    // and is prefilled with the field's values
+    expect(q<HTMLInputElement>(card, '.ff-label').value).toBe('Condition');
+    expect(q<HTMLTextAreaElement>(card, '.ff-opts').value).toBe('Good\nBad');
+
+    // change it and save
+    q<HTMLInputElement>(card, '.ff-label').value = 'Condition v2';
+    q<HTMLTextAreaElement>(card, '.ff-opts').value = 'Good\nBad\nUgly';
+    q<HTMLButtonElement>(card, '.sb-save').click();
+
+    const fields = b.getFields();
+    expect(fields).toHaveLength(2);
+    expect(fields[0]).toMatchObject({ label: 'Name', type: 'text', required: true }); // untouched
+    expect(fields[1].label).toBe('Condition v2');
+    expect(fields[1].options).toEqual(['Good', 'Bad', 'Ugly']);
+    expect(fields[1].key).toBe(condKey); // key stable across the edit
+    expect(root.querySelector('[data-editcard]')).toBeNull(); // editor closed
+  });
+
+  it('cancel discards inline edits and closes the editor', () => {
+    const root = host();
+    const b = mountSchemaBuilder(root, [{ key: 'name', label: 'Name', type: 'text' }]);
+    q<HTMLButtonElement>(root, '.sb-name[data-edit="0"]').click();
+    const card = q<HTMLElement>(root, '[data-editcard="0"]');
+    q<HTMLInputElement>(card, '.ff-label').value = 'Changed but cancelled';
+    q<HTMLButtonElement>(card, '.sb-cancel').click();
+    expect(b.getFields()[0].label).toBe('Name');
+    expect(root.querySelector('[data-editcard]')).toBeNull();
+  });
+
+  it('a second click on the same field closes its editor (toggle)', () => {
+    const root = host();
+    mountSchemaBuilder(root, [{ key: 'name', label: 'Name', type: 'text' }]);
+    q<HTMLButtonElement>(root, '.sb-name[data-edit="0"]').click();
+    expect(root.querySelector('[data-editcard="0"]')).toBeTruthy();
+    q<HTMLButtonElement>(root, '.sb-name[data-edit="0"]').click();
+    expect(root.querySelector('[data-editcard="0"]')).toBeNull();
+  });
+
+  it('hides the add-card while an inline editor is open (one form at a time)', () => {
+    const root = host();
+    mountSchemaBuilder(root, [{ key: 'name', label: 'Name', type: 'text' }]);
+    const addCard = q<HTMLElement>(root, '#sb-add');
+    expect(addCard.style.display).toBe('');
+    q<HTMLButtonElement>(root, '.sb-name[data-edit="0"]').click();
+    expect(addCard.style.display).toBe('none');
+    q<HTMLButtonElement>(root, '[data-editcard="0"] .sb-cancel').click();
+    expect(addCard.style.display).toBe('');
+  });
+});


### PR DESCRIPTION
Two collect UX improvements (mobile-first, vanilla TS + MapLibre).

## 1. Linked map ↔ list (admin Review)
Review records now render as a **clickable, status-coloured layer** keyed to the list rows.
- **Click a marker/shape** → an attribute **tooltip** opens, the matching **list row highlights and scrolls into view**, and the feature is emphasised on the map (feature-state).
- **Click a row** → flies to and highlights the marker (via the detail sheet).
- The tooltip carries a **Review →** button into full moderation, so nothing is lost.

Points are coloured by status (pending / published / rejected). In admin the review layer owns the on-map display (the plain published-pin path is skipped to avoid doubling).

## 2. Editable form fields, edited in place
Clicking a saved field in the builder now opens its config form **inline, directly under that row** (prefilled) to edit it — previously fields could only be deleted and re-added. The "+ Add field" card stays at the bottom and hides while you're editing (one form at a time). Reworked around a reusable `createFieldForm` so add and edit share one implementation; keys stay stable across an edit.

## Verification
- **96 tests** (new `happy-dom` DOM tests guard the inline edit: right field updated, key stable, cancel/toggle, add-card hidden while editing), typecheck, and Vite build all green.
- Verified end-to-end in a real browser at 390px (add → inline edit → save; marker→tooltip+row-highlight; row→fly). This caught and fixed a bug where the first edit approach saved to the **wrong field**.
- Code-simplifier (shared attribute-row builder + DRY helpers) and an adversarial correctness review (no high-severity issues; 3 Low/Med polish items applied) both run.
- Lighthouse landing 100/100/96 (the 96 is the API-less preview); a11y clean.
- Bundle: app +~1 KB gzip, landing +~0.5 KB gzip, `qrcode` still lazy, no new chunks. One dev-only dependency: `happy-dom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)