### PR TITLE
Gate all catalog submissions behind curator review (no auto-approval)

### DIFF
--- a/collect/functions/lib/handlers.ts
+++ b/collect/functions/lib/handlers.ts
@@ -571,7 +571,8 @@ export async function publish(env: Env, req: Request, id: string, defer?: Defer)
 
   await insertSubmission(env.DB, {
     id: submissionId,
-    status: 'accepted',
+    // Awaits a curator's review before it goes live in the catalog (no auto-approval).
+    status: 'pending',
     name: c.name,
     description: c.description,
     category: (JSON.parse(c.schema_doc) as { category?: string }).category || 'other',
@@ -613,7 +614,8 @@ export async function publish(env: Env, req: Request, id: string, defer?: Defer)
     submission_id: submissionId,
     feature_count: features.length,
     attribution: attribution.line,
-    share_url: `${BHARATLAS_ORIGIN}/c/${submissionId}`,
+    status: 'pending',
+    message: 'Submitted to the bharatlas catalog. A curator reviews it before it goes live — it is not public yet.',
     admin_token: adminToken,
   });
 }

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -685,7 +685,7 @@ async function manageSheet(): Promise<void> {
     </div>
     <div class="foot row">
       <button id="back">+ Add points</button>
-      <button class="primary" id="publish" style="flex:1">Publish → catalog</button>
+      <button class="primary" id="publish" style="flex:1">Submit → catalog</button>
     </div>
   </div>`;
   (document.getElementById('back') as HTMLButtonElement).onclick = captureSheet;
@@ -1162,12 +1162,12 @@ function confirmPublish(): void {
   const c = meta.counts;
   const panel = document.getElementById('panel')!;
   panel.innerHTML = `<div class="sheet">${GRAB}<div class="body">
-    <strong>Publish to the public catalog?</strong>
-    <p class="hint">Your ${c.published} approved point${c.published === 1 ? '' : 's'} are already saved and shown on this map. Publishing adds them to the open <strong>bharatlas catalog</strong> at bharatlas.com, where anyone can find, view, and download them. Do this once the map is ready to share widely.</p>
+    <strong>Submit to the public catalog?</strong>
+    <p class="hint">Your ${c.published} approved point${c.published === 1 ? '' : 's'} are already saved and shown on this map. Submitting sends them to the open <strong>bharatlas catalog</strong>. <strong>A bharatlas maintainer reviews and approves every submission before it goes live</strong> at bharatlas.com — it won't be public until then. Do this once the map is ready to share widely.</p>
     ${c.pending ? `<p class="hint">${c.pending} pending point${c.pending === 1 ? '' : 's'} won't be included until you approve them in Review.</p>` : ''}
   </div><div class="foot row">
     <button id="pub-cancel">← Back</button>
-    <button class="primary" id="pub-go" style="flex:1">${c.published ? `Publish ${c.published} to catalog` : 'Publish'}</button>
+    <button class="primary" id="pub-go" style="flex:1">${c.published ? `Submit ${c.published} for review` : 'Submit'}</button>
   </div></div>`;
   (document.getElementById('pub-cancel') as HTMLButtonElement).onclick = () => void manageSheet();
   (document.getElementById('pub-go') as HTMLButtonElement).onclick = (e) => void runPublish(e.currentTarget as HTMLButtonElement);
@@ -1176,15 +1176,14 @@ function confirmPublish(): void {
 async function runPublish(btn: HTMLButtonElement): Promise<void> {
   btn.disabled = true;
   try {
-    const res = await apiJson<{ version: number; share_url: string; feature_count: number }>(
+    const res = await apiJson<{ version: number; feature_count: number; message?: string }>(
       `/collections/${ctx.id}/publish`, ctx.token, { method: 'POST' },
     );
-    toast(`Published v${res.version} · ${res.feature_count} features`);
+    toast(`Submitted v${res.version} · ${res.feature_count} features`);
     const panel = document.getElementById('panel')!;
     panel.innerHTML = `<div class="sheet">${GRAB}<div class="body">
-      <strong>Published to the catalog 🎉</strong>
-      <p class="hint">Version ${res.version} · ${res.feature_count} features. It's now on the public bharatlas catalog.</p>
-      <a class="btn primary" href="${res.share_url}" target="_blank" rel="noopener">View on bharatlas →</a>
+      <strong>Submitted for review ✓</strong>
+      <p class="hint">Version ${res.version} · ${res.feature_count} features. ${escapeHtml(res.message || 'A curator reviews it before it goes live in the bharatlas catalog.')}</p>
       </div><div class="foot"><button id="back">← Back to manage</button></div></div>`;
     (document.getElementById('back') as HTMLButtonElement).onclick = () => void manageSheet();
   } catch (e) {

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -76,7 +76,7 @@ Collect (author your own map): this server also drives collect.bharatlas.com, th
   - view link  -> get_map, get_records: read / query / export that map's published points (analyse or back up what has been collected).
   - collect link -> the above; field capture itself is done in the browser on a phone via the collect link.
   - admin link -> everything: edit_map (settings), moderate_record (approve/reject), import_points (bulk data you already hold, with a source + rights), and publish.
-- publish bakes approved points into a bharatlas catalog submission. It is then queryable through the read tools above (list_submissions, query_layer, locate) — the full loop, gather -> moderate -> publish -> query, in one server.
+- publish submits a collect map's approved points to the bharatlas catalog FOR REVIEW — nothing is auto-approved. A bharatlas maintainer approves the submission before it goes live; the response's status is "pending" until then. Once approved it is queryable through the read tools above (list_submissions, query_layer, locate).
 - No accounts: the link is the credential. A tool that needs more than your link allows will say which link you need. create_map is optional and needs COLLECT_API_KEY (request-only); prefer creating online.`;
 
 const TOOLS = [
@@ -343,8 +343,9 @@ const TOOLS = [
   {
     name: "publish",
     description:
-      "Bake a collect map's approved points into a bharatlas catalog submission (needs the admin link). " +
-      "Once published it is queryable via list_submissions / query_layer / locate above.",
+      "Submit a collect map's approved points to the bharatlas catalog for review (needs the admin link). " +
+      "Nothing goes live automatically — a maintainer approves the submission first; the response status is 'pending' until then. " +
+      "Once approved it is queryable via list_submissions / query_layer / locate above.",
     inputSchema: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
   },
   {

--- a/scripts/moderate_submission.py
+++ b/scripts/moderate_submission.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Curator moderation for catalog submissions — the human review gate.
+
+Every submission (from the /submit form, from collect, or via the MCP) now lands
+as status='pending' and is invisible in the public catalog until a maintainer
+approves it here. Nothing is auto-approved.
+
+    python3 scripts/moderate_submission.py                 # list pending submissions
+    python3 scripts/moderate_submission.py list            # (same)
+    python3 scripts/moderate_submission.py accept <id>     # make it live (status=accepted)
+    python3 scripts/moderate_submission.py reject <id>     # hide it (status=rejected)
+    python3 scripts/moderate_submission.py show <id>       # full row for one submission
+
+After `accept`, promote it to curated parity with:
+    python3 scripts/bake_community.py <id>
+
+Auth: needs a wrangler that can reach the shared D1 (geodata-submissions), either
+via `wrangler login` (oauth with D1) or a D1-scoped CLOUDFLARE_API_TOKEN. If the
+env's CLOUDFLARE_API_TOKEN is R2-only it's dropped on a retry (same trick as
+bake_community.py), so oauth can handle D1.
+"""
+import json
+import os
+import subprocess
+import sys
+
+D1_DATABASE = 'geodata-submissions'
+
+
+def _wrangler_bin() -> list[str]:
+    try:
+        subprocess.run(['which', 'wrangler'], check=True, capture_output=True)
+        return ['wrangler']
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ['npx', '--yes', 'wrangler']
+
+
+def d1(sql: str) -> list[dict]:
+    cmd = [*_wrangler_bin(), 'd1', 'execute', D1_DATABASE, '--remote', '--json', '--command', sql]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0 and 'CLOUDFLARE_API_TOKEN' in os.environ:
+        env = {k: v for k, v in os.environ.items() if k != 'CLOUDFLARE_API_TOKEN'}
+        proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if proc.returncode != 0:
+        sys.exit(f'wrangler d1 execute failed (exit {proc.returncode}); is wrangler authed for --remote '
+                 f'with D1 access?\n{(proc.stderr or proc.stdout).strip()}')
+    data = json.loads(proc.stdout)
+    return data[0].get('results', []) if data else []
+
+
+def esc(s: str) -> str:
+    return s.replace("'", "''")
+
+
+def list_pending() -> None:
+    rows = d1("SELECT id, name, category, feature_count, is_original, source_url, substr(COALESCE(created_at,''),1,10) day "
+              "FROM submissions WHERE status='pending' ORDER BY created_at DESC")
+    if not rows:
+        print('No pending submissions. 🎉')
+        return
+    print(f'{len(rows)} pending submission(s) awaiting review:\n')
+    for r in rows:
+        print(f"  {r['id']}  {(r.get('name') or '(no name)')[:44]}")
+        print(f"      {r.get('feature_count')} features · {r.get('category')} · {r.get('day')} · {(r.get('source_url') or '')[:50]}")
+    print('\nAccept:  python3 scripts/moderate_submission.py accept <id>')
+    print('Reject:  python3 scripts/moderate_submission.py reject <id>')
+
+
+def show(sub_id: str) -> None:
+    rows = d1(f"SELECT id, status, name, description, category, license, attribution, feature_count, "
+              f"is_original, source_url, data_year, r2_key, substr(COALESCE(created_at,''),1,19) created "
+              f"FROM submissions WHERE id='{esc(sub_id)}'")
+    if not rows:
+        sys.exit(f'submission {sub_id!r} not found')
+    for k, v in rows[0].items():
+        print(f'  {k}: {v}')
+
+
+def set_status(sub_id: str, status: str) -> None:
+    rows = d1(f"SELECT id, name, status FROM submissions WHERE id='{esc(sub_id)}'")
+    if not rows:
+        sys.exit(f'submission {sub_id!r} not found')
+    cur = rows[0]
+    d1(f"UPDATE submissions SET status='{status}' WHERE id='{esc(sub_id)}'")
+    print(f"✓ {sub_id} ({cur.get('name') or '(no name)'}): {cur['status']} → {status}")
+    if status == 'accepted':
+        print('  It is now live in the catalog. Promote to curated parity with:')
+        print(f'    python3 scripts/bake_community.py {sub_id}')
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    cmd = args[0] if args else 'list'
+    if cmd == 'list':
+        list_pending()
+    elif cmd == 'show' and len(args) == 2:
+        show(args[1])
+    elif cmd == 'accept' and len(args) == 2:
+        set_status(args[1], 'accepted')
+    elif cmd == 'reject' and len(args) == 2:
+        set_status(args[1], 'rejected')
+    else:
+        sys.exit(__doc__)
+
+
+if __name__ == '__main__':
+    main()

--- a/web/functions/api/submit.ts
+++ b/web/functions/api/submit.ts
@@ -155,7 +155,9 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       }),
       insertSubmission(ctx.env.DB, {
         id,
-        status: 'accepted',
+        // Awaits a human curator's review before it goes live in the catalog.
+        // Nothing is auto-approved: a curator accepts it via scripts/moderate_submission.py.
+        status: 'pending',
         name,
         description,
         category,
@@ -190,6 +192,8 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   const origin = new URL(ctx.request.url).origin;
   return j(200, {
     id,
+    status: 'pending',
+    message: 'Submitted for review. A curator approves it before it appears in the catalog; the link works once it is live.',
     share_url: `${origin}/c/${id}`,
     admin_url: `${origin}/c/${id}?key=${adminToken}`,
     admin_token: adminToken,

--- a/web/preview.template.html
+++ b/web/preview.template.html
@@ -401,9 +401,9 @@
     </section>
 
     <section id="success" aria-live="polite">
-      <h2>✓ Your submission is live</h2>
+      <h2>✓ Submitted for review</h2>
       <p class="ok-line" id="success-url"></p>
-      <p class="ok-meta">The link works immediately. Your submission will be listed in the home page catalog in the next hour.</p>
+      <p class="ok-meta">A curator reviews it before it goes live. It appears in the catalog, and the link works, once it's approved.</p>
 
       <div class="warn">
         <strong>Admin token (shown once). Save it.</strong>
@@ -415,7 +415,7 @@
         <div class="hint">Lose this and you can't edit or delete your submission.</div>
       </div>
 
-      <a href="#" class="cta" id="goto-submission">Take me to my submission →</a>
+      <a href="/" class="cta" id="goto-submission">Back to the catalog →</a>
     </section>
 
     <div class="helper">

--- a/web/src/preview.ts
+++ b/web/src/preview.ts
@@ -562,7 +562,7 @@ function renderSuccess(payload: SuccessPayload): void {
   // keeps everything on one host so the back button works.
   const shareUrl = `${location.origin}/c/${payload.id}`;
   (document.getElementById('success-url') as HTMLElement).innerHTML =
-    `at <a href="${escapeHtml(shareUrl)}">${escapeHtml(shareUrl)}</a>`;
+    `It'll appear at <a href="${escapeHtml(shareUrl)}">${escapeHtml(shareUrl)}</a> once a maintainer approves it.`;
   (document.getElementById('success-token') as HTMLElement).textContent = payload.admin_token;
 
   const copyBtn = document.getElementById('copy-token')!;
@@ -595,7 +595,7 @@ function renderSuccess(payload: SuccessPayload): void {
     setTimeout(() => URL.revokeObjectURL(url), 1000);
   });
 
-  (document.getElementById('goto-submission') as HTMLAnchorElement).href = shareUrl;
+  (document.getElementById('goto-submission') as HTMLAnchorElement).href = '/';
 
   successEl.classList.add('show');
   window.scrollTo({ top: 0, behavior: 'smooth' });


### PR DESCRIPTION
## What

Every catalog submission path used to auto-accept (`status='accepted'` → instantly live). Now all three land as `status='pending'` and are invisible in the public catalog until a maintainer approves them.

- **/submit form** (`web/functions/api/submit.ts`) and **collect publish** (`collect/functions/lib/handlers.ts`) both insert `status:'pending'`.
- **Accept path**: new `scripts/moderate_submission.py` — `list` pending · `accept <id>` · `reject <id>`. `bake_community.py` stays the promote-to-curated step (it already only picks up `status='accepted'`).
- **Copy**: the collect publish dialog + result and the /submit success page now say a maintainer reviews and approves before it goes live.
- **API/MCP signal**: publish/submit responses carry `status:'pending'` + a message, so the MCP (which relays the response) surfaces "awaiting review". MCP `publish` tool description updated to describe the gate — no republish needed for the gate to function (server-enforced + relayed); the doc bump folds into the next MCP release.

## Verification

- `web`: 673 tests pass, build green.
- `collect`: 107 tests pass, build green.
- No test asserted the old `accepted`-on-insert; duplicate-detection still keys on `status='accepted'` (only live dups block a new upload), unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)