### PR TITLE
Show community submission source (form vs collect) on the card

### DIFF
--- a/web/scripts/community-card.mjs
+++ b/web/scripts/community-card.mjs
@@ -11,6 +11,16 @@
 //
 // Pure + side-effect free so prerender and a vitest can share it.
 
+// Where a community submission entered the catalog, derived from what we already
+// store (no per-source keys): a collect map stamps `collection_id` on publish; the
+// bharatlas /submit form does not. MCP / API publishes go through collect's publish
+// too, so they read as 'collect'. Shared by the community card + the ops-dashboard
+// geodata tab so both count provenance the same way.
+export function channelOf(s) {
+  return s && s.collection_id ? 'collect' : 'form';
+}
+export const CHANNEL_LABEL = { collect: 'via collect', form: 'via the contribution form' };
+
 // Route an R2 public url through the same-origin /api/dl counter, except
 // pmtiles, which the viewer range-reads directly. Mirrors prerender's dlUrl().
 export function dlProxyUrl(r2Url, fmt) {

--- a/web/scripts/prerender.mjs
+++ b/web/scripts/prerender.mjs
@@ -6,7 +6,7 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 import { TOKENS, renderNav, FOOTER } from './shared-chrome.mjs';
-import { renderCommunityActions } from './community-card.mjs';
+import { renderCommunityActions, channelOf, CHANNEL_LABEL } from './community-card.mjs';
 import { expandAliases, buildBodyHaystack } from '../src/search-aliases.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -698,7 +698,7 @@ function fetchCommunitySubmissions() {
     const out = execSync(
       `${wranglerPrefix} d1 execute geodata-submissions --${COMMUNITY_SCOPE} --json --command "${
         'SELECT s.id, s.name, s.description, s.category, s.attribution, s.is_original, ' +
-        's.format, s.bytes, s.feature_count, s.r2_key, s.created_at, ' +
+        's.format, s.bytes, s.feature_count, s.r2_key, s.created_at, s.collection_id, ' +
         "COALESCE(SUM(CASE WHEN r.vote = 1 THEN 1 ELSE 0 END), 0) AS up_count, " +
         "COALESCE(SUM(CASE WHEN r.vote = -1 THEN 1 ELSE 0 END), 0) AS down_count " +
         'FROM submissions s LEFT JOIN submission_ratings r ON r.submission_id = s.id ' +
@@ -781,7 +781,7 @@ function renderCommunityCard(s, opts = {}) {
       </div>
     </div>
     ${s.description ? `<p class="comm-card__desc">${esc(s.description)}</p>` : ''}
-    <div class="comm-card__meta">${esc(s.format)} · ${s.feature_count != null ? s.feature_count.toLocaleString('en-IN') + ' features · ' : ''}${credit}</div>
+    <div class="comm-card__meta">${esc(s.format)} · ${s.feature_count != null ? s.feature_count.toLocaleString('en-IN') + ' features · ' : ''}${credit} · <span class="comm-card__via">${esc(CHANNEL_LABEL[channelOf(s)])}</span></div>
     ${renderCommunityActions(s, baked, { esc, fmtBytes })}
   </article>`;
 }

--- a/web/tests/community-card.test.ts
+++ b/web/tests/community-card.test.ts
@@ -1,10 +1,31 @@
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error — .mjs import resolves at test time, no type defs
-import { communityCardActions, dlProxyUrl, renderCommunityActions } from '../scripts/community-card.mjs';
+import { communityCardActions, dlProxyUrl, renderCommunityActions, channelOf, CHANNEL_LABEL } from '../scripts/community-card.mjs';
 
 const R2 = 'https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev';
 const esc = (s: string) => String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c] || c));
 const fmtBytes = (n: number) => `${Math.round(n / 1024)} KB`;
+
+describe('channelOf — where a community submission came from', () => {
+  it('a collect map stamps collection_id on publish → "collect"', () => {
+    expect(channelOf({ id: 'a', collection_id: 'Wo0Y5zzpUC' })).toBe('collect');
+  });
+  it('the bharatlas /submit form leaves collection_id null → "form"', () => {
+    expect(channelOf({ id: 'b', collection_id: null })).toBe('form');
+    expect(channelOf({ id: 'c' })).toBe('form'); // column absent
+  });
+  it('MCP / API publishes route through collect, so they read as "collect"', () => {
+    // no per-source key: any collection-linked submission is a collect publish
+    expect(channelOf({ id: 'd', collection_id: 'abc123' })).toBe('collect');
+  });
+  it('every channel has a human label for the card + dashboard', () => {
+    expect(CHANNEL_LABEL.collect).toBeTruthy();
+    expect(CHANNEL_LABEL.form).toBeTruthy();
+  });
+  it('is null-safe', () => {
+    expect(channelOf(null)).toBe('form');
+  });
+});
 
 describe('dlProxyUrl', () => {
   it('routes non-pmtiles R2 urls through the counting proxy', () => {


### PR DESCRIPTION
Adds a "via collect" / "via the contribution form" line to each community card, derived from `collection_id` (no per-source keys). Mirrors the ops-dashboard geodata tab's new "sources N form · N collect" badge.

- `channelOf()` + `CHANNEL_LABEL` in `community-card.mjs` — pure, unit-tested (5 new cases).
- prerender fetches `collection_id` and renders the channel on each card's meta line.
- 678 web tests pass, build green. Both render branches verified against the real helper.

Note: MCP/API publishes route through collect, so they read as "collect" (no per-source key by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)