### PR TITLE
collect: owner's own data publishes immediately + one-tap Approve all + pending notices

### DIFF
--- a/collect/functions/api/collect/[[path]].ts
+++ b/collect/functions/api/collect/[[path]].ts
@@ -57,6 +57,9 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
     if (p.length === 3 && p[2] === 'import') {
       return method === 'POST' ? h.importRecords(env, request, id, defer) : bad(405, 'method not allowed');
     }
+    if (p.length === 3 && p[2] === 'moderate-all') {
+      return method === 'POST' ? h.moderateAll(env, request, id) : bad(405, 'method not allowed');
+    }
     if (p.length === 3 && p[2] === 'tokens') {
       return method === 'POST' ? h.mintToken(env, request, id) : bad(405, 'method not allowed');
     }

--- a/collect/functions/lib/db.ts
+++ b/collect/functions/lib/db.ts
@@ -195,6 +195,21 @@ export async function setRecordStatus(
   await db.prepare(`UPDATE records SET status = ?, rejection_reason = ? WHERE id = ?`).bind(status, reason, id).run();
 }
 
+// Bulk status move for one collection (the "Approve all" action). Returns the
+// number of rows changed so the caller can report "approved N".
+export async function setAllRecordStatus(
+  db: DB,
+  collectionId: string,
+  from: 'pending' | 'rejected',
+  to: 'published' | 'rejected',
+): Promise<number> {
+  const res = await db
+    .prepare(`UPDATE records SET status = ? WHERE collection_id = ? AND status = ?`)
+    .bind(to, collectionId, from)
+    .run();
+  return (res.meta?.changes as number) ?? 0;
+}
+
 export async function updateRecord(
   db: DB,
   id: string,

--- a/collect/functions/lib/handlers.ts
+++ b/collect/functions/lib/handlers.ts
@@ -13,6 +13,7 @@ import { checkCreateRate, checkRecordRate, checkKeyDayRate } from './ratelimit';
 import { deferLog } from './collect-log';
 import { nanoid, sha256Hex, ipHashFor, verifyTurnstile, insertSubmission, insertToken } from './reuse';
 import * as db from './db';
+import { recordStatusFor } from './moderation';
 import { validateNewCollection, validateCollectionEdit } from '../../src/schema/validate-collection';
 import { validateRecordProperties, type Field } from '../../src/schema/validate-record';
 import { checkIndiaBounds } from '../../src/geo/bounds';
@@ -317,7 +318,8 @@ export async function addRecord(env: Env, req: Request, id: string, defer?: Defe
   }
 
   const contributor = typeof body.contributor === 'string' && body.contributor.trim() !== '' ? body.contributor.trim() : null;
-  const status: 'pending' | 'published' = c.moderation ? 'pending' : 'published';
+  // The owner's own captures publish immediately; only contributor input is moderated.
+  const status = recordStatusFor(atLeast(perm, 'admin'), c.moderation);
   const recId = nanoid(10);
   const recToken = generateRecordToken();
 
@@ -357,6 +359,21 @@ export async function moderateRecord(env: Env, req: Request, recordId: string): 
   const reason = typeof body?.reason === 'string' ? body.reason : null;
   await db.setRecordStatus(env.DB, recordId, status, reason);
   return json(200, { id: recordId, status });
+}
+
+// ---- POST /collections/:id/moderate-all ------------------------------------
+// Bulk moderation: move every record in one status to another in a single call
+// (the "Approve all N" action). Defaults to pending → published. Admin only.
+export async function moderateAll(env: Env, req: Request, id: string): Promise<Response> {
+  const perm = await permissionFor(env.DB, id, bearer(req));
+  if (!atLeast(perm, 'admin')) return bad(401, 'unauthorised');
+  const c = await db.getCollection(env.DB, id);
+  if (!c) return bad(404, 'not found');
+  const body = await readJson(req);
+  const from = body?.from === 'rejected' ? 'rejected' : 'pending';
+  const to = body?.to === 'rejected' ? 'rejected' : 'published';
+  const changed = await db.setAllRecordStatus(env.DB, id, from, to);
+  return json(200, { from, to, changed });
 }
 
 // ---- record-owner ops (rec_ token or admin): get / edit / delete / de-identify
@@ -476,7 +493,9 @@ export async function importRecords(env: Env, req: Request, id: string, defer?: 
 
   const schema = JSON.parse(c.schema_doc) as { geometry: string[]; fields: Field[] };
   const contributor = typeof body.contributor === 'string' && body.contributor.trim() !== '' ? body.contributor.trim() : null;
-  const status: 'pending' | 'published' = c.moderation ? 'pending' : 'published';
+  // Import is admin-only, so this is always the owner's own data → published
+  // immediately (no self-approval; that was the "bulk uploads stuck pending" bug).
+  const status = recordStatusFor(true, c.moderation);
   const ipHash = await ipHashFor(req, salt(env));
 
   let imported = 0;

--- a/collect/functions/lib/moderation.ts
+++ b/collect/functions/lib/moderation.ts
@@ -1,0 +1,10 @@
+// The moderation policy for a newly added record, in one place.
+//
+// Moderation exists to review CONTRIBUTOR (edit-link) input — the crowd — not the
+// owner's own data. So the owner (admin) always publishes immediately; a
+// contributor goes pending only when the map is moderated. This is what stops the
+// owner from having to approve their own bulk imports and captures.
+export function recordStatusFor(isAdmin: boolean, moderation: number | boolean): 'published' | 'pending' {
+  if (isAdmin) return 'published';
+  return moderation ? 'pending' : 'published';
+}

--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -766,6 +766,10 @@ function renderReviewTab(body: HTMLElement): void {
   const c = reviewLoaded ? countsOf(allFeats) : meta.counts;
   body.innerHTML = `
     <p class="hint" id="mcounts">${c.published} approved · ${c.pending} pending · ${c.rejected} rejected</p>
+    ${c.pending ? `<div class="notice">
+      <div><strong>${c.pending} point${c.pending === 1 ? '' : 's'} awaiting your approval.</strong> People you share the map with can't see ${c.pending === 1 ? 'it' : 'them'}, and ${c.pending === 1 ? "it isn't" : "they aren't"} exported or published to the catalog until you approve.</div>
+      <button type="button" class="primary" id="approve-all">✓ Approve all ${c.pending}</button>
+    </div>` : ''}
     <div class="row" id="pfilter" style="margin:8px 0 4px">
       <button type="button" class="chip on" data-s="">All ${c.total}</button>
       <button type="button" class="chip" data-s="pending">Pending ${c.pending}</button>
@@ -773,6 +777,17 @@ function renderReviewTab(body: HTMLElement): void {
       ${c.rejected ? `<button type="button" class="chip" data-s="rejected">Rejected ${c.rejected}</button>` : ''}
     </div>
     <div id="points"><p class="hint">Loading points…</p></div>`;
+  const approveAll = document.getElementById('approve-all') as HTMLButtonElement | null;
+  if (approveAll) approveAll.onclick = async () => {
+    approveAll.disabled = true;
+    try {
+      const res = await apiJson<{ changed: number }>(`/collections/${ctx.id}/moderate-all`, ctx.token, { method: 'POST', body: JSON.stringify({ to: 'published' }) });
+      invalidateReview();
+      await ensureReviewData(true);
+      toast(`Approved ${res.changed} ✓`);
+      renderManageTab(); // rebuild: notice clears, points show approved, counts refresh
+    } catch (e) { toast((e as Error).message); approveAll.disabled = false; }
+  };
   document.querySelectorAll<HTMLButtonElement>('#pfilter .chip').forEach((b) => {
     b.onclick = () => {
       document.querySelectorAll('#pfilter .chip').forEach((x) => x.classList.remove('on'));
@@ -819,10 +834,20 @@ const LINK_ROWS: LinkRow[] = [
   { role: 'view', perm: 'view', icon: '👁', title: 'View-only link', hint: 'read only' },
 ];
 
+// A one-line reminder that pending points are held back (invisible to shared
+// links, excluded from exports) — shown atop Share + Data so the consequence sits
+// where the owner acts. The Review tab carries the full notice + Approve-all.
+function pendingHint(): string {
+  const c = reviewLoaded ? countsOf(allFeats) : meta.counts;
+  if (!c.pending) return '';
+  return `<div class="notice notice--inline"><div><strong>${c.pending} point${c.pending === 1 ? '' : 's'} pending.</strong> Held back from people you share with, and from exports, until approved in Review.</div></div>`;
+}
+
 function renderShareTab(body: HTMLElement): void {
   const title = meta.name || 'bharatlas collect map';
   const adminLink = location.href;
   body.innerHTML = `
+    ${pendingHint()}
     <p class="hint">Tap a link to open its copy options. No accounts, so the link is the key: whoever holds it can use it at that level.</p>
     ${LINK_ROWS.map((r) => `<div class="linkrow" data-role="${r.role}">
       <button type="button" class="linkrow__head" aria-expanded="false">
@@ -882,8 +907,9 @@ function renderShareTab(body: HTMLElement): void {
 // Data: download every point, or bulk-import a file.
 function renderDataTab(body: HTMLElement): void {
   body.innerHTML = `
+    ${pendingHint()}
     <strong style="display:block">Download the data</strong>
-    <p class="hint">Every collected point, to use anywhere.</p>
+    <p class="hint">Every approved point, to use anywhere.</p>
     <div class="row">
       <button data-dl="geojson">GeoJSON</button>
       <button data-dl="csv">CSV</button>

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -158,6 +158,16 @@ textarea { min-height: 92px; line-height: 1.5; }
 .masthead-stat:empty { display: none; }
 .masthead-stat strong { color: var(--accent); font-weight: 700; font-variant-numeric: tabular-nums; }
 .warn { color: var(--danger); font-size: 13px; line-height: 1.5; }
+/* attention box — pending points need approval to be visible/exported */
+.notice {
+  background: var(--surface); border: 1px solid var(--line-strong);
+  border-left: 3px solid var(--amber); border-radius: var(--radius);
+  padding: 11px 13px; margin: 8px 0; font-size: 13px; line-height: 1.45; color: var(--fg);
+}
+.notice > div { margin-bottom: 10px; }
+.notice .primary { width: 100%; }
+.notice--inline { display: flex; gap: 8px; align-items: baseline; }
+.notice--inline > div { margin: 0; }
 
 .link-box {
   display: flex; gap: 8px; align-items: center; margin: 8px 0;

--- a/collect/tests/moderation.test.ts
+++ b/collect/tests/moderation.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { recordStatusFor } from '../functions/lib/moderation';
+
+describe('recordStatusFor — who needs approval', () => {
+  it('the owner (admin) publishes their own additions immediately, even when moderated', () => {
+    // Owner imports/captures are trusted; moderation is for reviewing others, not yourself.
+    expect(recordStatusFor(true, 1)).toBe('published');
+    expect(recordStatusFor(true, 0)).toBe('published');
+  });
+  it('a contributor (edit link) goes pending on a moderated map', () => {
+    expect(recordStatusFor(false, 1)).toBe('pending');
+  });
+  it('a contributor publishes immediately on an unmoderated map', () => {
+    expect(recordStatusFor(false, 0)).toBe('published');
+  });
+  it('treats moderation as truthy/falsy (D1 stores 0/1)', () => {
+    expect(recordStatusFor(false, 1)).toBe('pending');
+    expect(recordStatusFor(false, 0)).toBe('published');
+  });
+});


### PR DESCRIPTION
Fixes "collected points but forgot to approve." Maps default to moderation on, so everything went pending — including the owner's OWN bulk imports and captures — and pending points are invisible to view/collect links and excluded from exports/publish.

- `recordStatusFor(isAdmin, moderation)` (pure, unit-tested): the owner (admin) publishes immediately; only contributor (edit-link) input is moderated. Wired into `addRecord` (branches on caller permission) and `importRecords` (admin-only → always published).
- Bulk approve: `POST /collections/:id/moderate-all` (admin) moves pending → published in one call; Review tab shows "✓ Approve all N".
- Notices: Review ("N pending — not visible to people you share with, not exported/published until you approve") + one-line reminder atop Share/Data; download copy → "Every approved point".

122 tests pass (+4 moderation), functions typecheck. The existing pending backlog clears via Approve all (one tap per map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)