### PR TITLE
fix(collect): scope X-Robots-Tag noindex to /c/* so the landing actually indexes

### DIFF
--- a/collect/public/_headers
+++ b/collect/public/_headers
@@ -2,12 +2,18 @@
 # needs: self, Turnstile, the basemap tile hosts (CARTO / Esri imagery / OpenTopo),
 # the bharatlas catalogue API + its R2 host for pmtiles reference overlays, and the
 # Cloudflare Web Analytics beacon (edge-injected script + its cross-origin report).
-# noindex keeps unlisted collections off search (spec). Verify in prod after
-# the first deploy — a too-strict CSP would break the map, tiles, or Turnstile.
+# The security headers apply everywhere. X-Robots-Tag: noindex is scoped to /c/*
+# (the private, token-gated map pages) ONLY — the landing is public and indexable,
+# so a global noindex here would silently override the landing's indexability (an
+# HTTP header beats the page meta). Verify in prod after deploy — a too-strict CSP
+# would break the map, tiles, or Turnstile.
 /*
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
-  X-Robots-Tag: noindex
   Permissions-Policy: geolocation=(self), camera=()
   Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; script-src 'self' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://services.arcgisonline.com https://*.tile.opentopomap.org; connect-src 'self' https://*.basemaps.cartocdn.com https://challenges.cloudflare.com https://cloudflareinsights.com https://bharatlas.com https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://services.arcgisonline.com https://*.tile.opentopomap.org; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com; form-action 'self'
+
+# Private map pages: keep them out of search (belt-and-suspenders with c.html's meta noindex).
+/c/*
+  X-Robots-Tag: noindex


### PR DESCRIPTION
The docs-seo-audit fix was incomplete. collect's `_headers` applied `X-Robots-Tag: noindex` to `/*`; an HTTP header beats the page meta, so the landing stayed blocked even after removing the meta noindex (Lighthouse `is-crawlable` would still fail). Scoped the noindex to `/c/*` (private map pages); global security headers unchanged. Verifying in prod that /c/* keeps its CSP (CF Pages merges matching `_headers` rules).