### PR TITLE
fix(collect): drop "by anonymous" from the record detail

### DIFF
--- a/collect/src/app.ts
+++ b/collect/src/app.ts
@@ -15,7 +15,7 @@ import { validateRecordProperties, type Field } from './schema/validate-record';
 import { orderedModes, drawGeometry, type GeomMode, type Coord } from './geo/draw';
 import { representativeCoord } from './geo/admin-ctx';
 import { geometryLngLats } from './geo/coords';
-import { statusOf, filterByStatus, countsOf, popupActions } from './review';
+import { statusOf, filterByStatus, countsOf, popupActions, recordWho } from './review';
 import { escapeHtml } from './util';
 import { toGeoJSON, toCSV, toKML, type ExportFeature } from './export/formats';
 import { detectFormat, parseImport, type Parsed } from './import/parse';
@@ -1095,7 +1095,7 @@ type AdminCtx = { state?: string; district?: string; subdistrict?: string } | nu
 function fmtAdminCtx(ctx: AdminCtx): string {
   if (!ctx) return '';
   const parts = [ctx.district, ctx.state].filter(Boolean);
-  return parts.length ? ` · 📍 ${parts.join(', ')}` : '';
+  return parts.length ? `📍 ${parts.join(', ')}` : '';
 }
 
 // Queue card label: the record's `name`, else the first author field value
@@ -1186,7 +1186,9 @@ function openReview(idx: number): void {
   }
 
   const attrs = attrRowsHtml(p, 'attr');
-  const origin = p._source ? `⇪ from ${escapeHtml(p._source)}` : `by ${escapeHtml(p._contributor || 'anonymous')}`;
+  // meta line: who (source or a named contributor; nothing for an unnamed capture) + place
+  const who = recordWho(p._source, p._contributor);
+  const meta = [who ? escapeHtml(who) : '', fmtAdminCtx(p._admin_ctx ?? null)].filter(Boolean).join(' · ');
   const panel = document.getElementById('panel')!;
   panel.innerHTML = `<div class="sheet">
     ${GRAB}
@@ -1195,7 +1197,7 @@ function openReview(idx: number): void {
         <strong style="flex:1">${escapeHtml(cardTitle(p))}</strong>
         <span class="badge badge--${st}">${st}</span>
       </div>
-      <p class="hint">${origin}${fmtAdminCtx(p._admin_ctx ?? null)}</p>
+      ${meta ? `<p class="hint">${meta}</p>` : ''}
       <div class="attrs">${attrs || '<p class="hint">No fields on this map.</p>'}</div>
     </div>
     <div class="foot">

--- a/collect/src/review.ts
+++ b/collect/src/review.ts
@@ -24,6 +24,15 @@ export function countsOf(feats: WithStatus[]): { published: number; pending: num
   return c;
 }
 
+// The "who" prefix for a record's meta line. Imported data credits its source; a
+// contributor who typed a name is shown; an unnamed capture returns '' so the UI
+// shows nothing — with no accounts, "by anonymous" is noise on every record.
+export function recordWho(source?: string | null, contributor?: string | null): string {
+  if (source && source.trim()) return `⇪ from ${source}`;
+  if (contributor && contributor.trim()) return `by ${contributor}`;
+  return '';
+}
+
 export type PopupAction = { act: string; label: string; cls: string };
 
 // The moderation actions a record's map tooltip offers, by status — so an admin

--- a/collect/tests/review.test.ts
+++ b/collect/tests/review.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { statusOf, filterByStatus, countsOf, popupActions } from '../src/review';
+import { statusOf, filterByStatus, countsOf, popupActions, recordWho } from '../src/review';
 
 const F = (status?: string) => ({ properties: status ? { _status: status } : {} });
 
@@ -32,6 +32,24 @@ describe('countsOf', () => {
   });
   it('empty set is all zeros', () => {
     expect(countsOf([])).toEqual({ published: 0, pending: 0, rejected: 0, total: 0 });
+  });
+});
+
+describe('recordWho — the "who" prefix on a record', () => {
+  it('imported data credits its source', () => {
+    expect(recordWho('SOI Atlas 2021', null)).toBe('⇪ from SOI Atlas 2021');
+  });
+  it('a contributor who typed a name is shown', () => {
+    expect(recordWho(null, 'Jane')).toBe('by Jane');
+  });
+  it('an unnamed capture shows nothing — no "by anonymous" (there are no accounts)', () => {
+    expect(recordWho(null, null)).toBe('');
+    expect(recordWho(null, '')).toBe('');
+    expect(recordWho('', '   ')).toBe('');
+    expect(recordWho(undefined, undefined)).toBe('');
+  });
+  it('an import source wins over a contributor name', () => {
+    expect(recordWho('Bhuvan', 'Jane')).toBe('⇪ from Bhuvan');
   });
 });
 


### PR DESCRIPTION
The review detail credited every unnamed capture as "by anonymous" — noise, since collect has no accounts and most contributors never type a name. `recordWho()` (pure, unit-tested) shows an import's source or a named contributor, and returns empty for an unnamed capture (so the line shows only the place, or nothing). The aggregate published attribution ("anonymous contributors") is unchanged. 126 tests pass.