### PR TITLE
collect: India-correct overlay on every basemap; OSM replaces minimal

### DIFF
--- a/collect/public/_headers
+++ b/collect/public/_headers
@@ -1,5 +1,5 @@
 # Cloudflare Pages security headers for collect. CSP allows exactly what the app
-# needs: self, Turnstile, the basemap tile hosts (CARTO / Esri imagery / OpenTopo),
+# needs: self, Turnstile, the basemap tile hosts (Esri / OpenStreetMap / OpenTopo),
 # the bharatlas catalogue API + its R2 host for pmtiles reference overlays, and the
 # Cloudflare Web Analytics beacon (edge-injected script + its cross-origin report).
 # The security headers apply everywhere. X-Robots-Tag: noindex is scoped to /c/*
@@ -12,7 +12,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
   Permissions-Policy: geolocation=(self), camera=()
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; script-src 'self' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://services.arcgisonline.com https://*.tile.opentopomap.org; connect-src 'self' https://*.basemaps.cartocdn.com https://challenges.cloudflare.com https://cloudflareinsights.com https://bharatlas.com https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://services.arcgisonline.com https://*.tile.opentopomap.org; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com; form-action 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; script-src 'self' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://services.arcgisonline.com https://tile.openstreetmap.org https://*.tile.opentopomap.org; connect-src 'self' https://challenges.cloudflare.com https://cloudflareinsights.com https://bharatlas.com https://pub-0429b8e3b5a946e69ea007df844a6f1c.r2.dev https://services.arcgisonline.com https://tile.openstreetmap.org https://*.tile.opentopomap.org; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com; form-action 'self'
 
 # Private map pages: keep them out of search (belt-and-suspenders with c.html's meta noindex).
 /c/*

--- a/collect/src/basemap.ts
+++ b/collect/src/basemap.ts
@@ -1,24 +1,29 @@
-// Basemap registry for the collect map, ported from bharatlas.com (web/src/
-// basemaps.ts + the buildBaseStyle/setBasemap logic in web/src/map.ts). Four
-// options, switchable at runtime on the map:
+// Basemap registry for the collect map. Three switchable raster basemaps, plus a
+// persistent India-correct boundary overlay drawn on top of every one:
 //
-//   1. minimal — "Bharatlas Minimal": solid ocean + Natural Earth land + the
-//      LGD-dissolved India outline (India-correct claim, no international labels).
-//      Same-origin GeoJSON, no external tiles — fewer round-trips than raster.
-//   2. positron — Esri Light Gray Canvas (light base + labels; good field
-//      orientation). Default. Keyless, same host as the Esri imagery below.
+//   1. positron — Esri Light Gray Canvas (light base + labels). Default.
 //      (Was CARTO Light until CARTO started watermarking its free tiles with
 //      "API KEY REQUIRED"; the id/layer stay 'positron' for stored-preference
 //      and layer-order compatibility.)
+//   2. osm — OpenStreetMap standard (detailed streets, buildings, paths).
 //   3. opentopo — OpenTopoMap (topographic relief).
 //   4. satellite — Esri Imagery.
 //
-// All four live in ONE MapLibre style; switching flips layer visibility (never
-// setStyle), so the review markers + reference overlays survive a basemap change.
+// A "Bharatlas Minimal" basemap used to be here; it was dropped because a
+// featureless land/ocean canvas gives a field surveyor nothing to orient by. The
+// uncluttered look belongs to the atlas's layer viewer, not to marking points.
+//
+// India-correct overlay: the raster tiles render the international boundary view,
+// so the LGD-dissolved India outline is traced on top (always visible, above every
+// basemap, below the review markers). India's claim (J&K, Ladakh, Arunachal) is
+// shown correctly, mirroring bharatlas.com's view maps.
+//
+// Everything lives in ONE MapLibre style; switching flips basemap-layer visibility
+// (never setStyle), so the overlay + review markers + reference layers survive.
 import maplibregl from 'maplibre-gl';
 import type { StyleSpecification, SourceSpecification, LayerSpecification } from 'maplibre-gl';
 
-export type BasemapId = 'minimal' | 'positron' | 'opentopo' | 'satellite';
+export type BasemapId = 'positron' | 'osm' | 'opentopo' | 'satellite';
 
 export interface Basemap {
   id: BasemapId;
@@ -29,7 +34,7 @@ export interface Basemap {
 }
 
 const ESRI_LIGHT_ATTRIB = 'Tiles © <a href="https://www.esri.com">Esri</a>: Esri, HERE, Garmin, © OpenStreetMap contributors, GIS User Community';
-const OSM_IN_ATTRIB = 'India boundary: <a href="https://github.com/osm-in/mapbox-gl-styles" target="_blank" rel="noopener">osm-in</a> · © OpenStreetMap contributors (ODbL)';
+const OSM_ATTRIB = '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 const OPENTOPO_ATTRIB = 'Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, SRTM · Style: © <a href="https://opentopomap.org">OpenTopoMap</a> (CC-BY-SA)';
 const ESRI_ATTRIB = 'Tiles © <a href="https://www.esri.com">Esri</a> · Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community';
 
@@ -50,20 +55,13 @@ export const BASEMAPS: Basemap[] = [
     ],
   },
   {
-    id: 'minimal',
-    name: 'Bharatlas Minimal',
-    hint: 'India-correct boundaries · land + ocean · no labels',
+    id: 'osm',
+    name: 'OpenStreetMap',
+    hint: 'detailed streets, buildings and paths · full field reference',
     sources: {
-      'world-land': { type: 'geojson', data: '/world-land.geojson', attribution: 'Land: <a href="https://www.naturalearthdata.com/" target="_blank" rel="noopener">Natural Earth</a> (public domain)' },
-      'india-boundary': { type: 'geojson', data: '/india-boundary.geojson', attribution: OSM_IN_ATTRIB },
-      'india-outline': { type: 'geojson', data: '/india-outline.geojson', attribution: 'India outline: LGD (dissolved states)' },
+      'osm-tiles': { type: 'raster', tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'], tileSize: 256, maxzoom: 19, attribution: OSM_ATTRIB },
     },
-    layers: [
-      { id: 'minimal-bg', type: 'background', paint: { 'background-color': '#dee5e8' } },
-      { id: 'minimal-land', type: 'fill', source: 'world-land', paint: { 'fill-color': '#f5f3ef', 'fill-outline-color': '#d0c8be' } },
-      { id: 'minimal-india-fill', type: 'fill', source: 'india-outline', paint: { 'fill-color': '#f5f3ef' } },
-      { id: 'minimal-india-outline', type: 'line', source: 'india-outline', paint: { 'line-color': '#7d6a5a', 'line-width': ['interpolate', ['linear'], ['zoom'], 3, 1.0, 10, 2.0], 'line-opacity': 0.9 } },
-    ],
+    layers: [{ id: 'osm-base', type: 'raster', source: 'osm-tiles' }],
   },
   {
     id: 'opentopo',
@@ -86,20 +84,39 @@ export const BASEMAPS: Basemap[] = [
   },
 ];
 
+// India-correct boundary overlay — NOT a switchable basemap: always visible, above
+// whichever basemap is active. The LGD-dissolved outline traces India's full,
+// correct claim; a white casing under a taupe line keeps it legible over both the
+// light basemaps and the dark satellite imagery.
+const INDIA_OVERLAY_SOURCES: Record<string, SourceSpecification> = {
+  'india-outline': { type: 'geojson', data: '/india-outline.geojson', attribution: 'India outline: LGD (dissolved states)' },
+};
+const INDIA_OVERLAY_LAYERS: LayerSpecification[] = [
+  {
+    id: 'india-claim-casing', type: 'line', source: 'india-outline',
+    paint: { 'line-color': '#ffffff', 'line-opacity': 0.5, 'line-blur': 0.4, 'line-width': ['interpolate', ['linear'], ['zoom'], 3, 2.5, 8, 3.5, 12, 4.5] },
+  },
+  {
+    id: 'india-claim', type: 'line', source: 'india-outline',
+    paint: { 'line-color': '#5b4a3a', 'line-opacity': 0.9, 'line-width': ['interpolate', ['linear'], ['zoom'], 3, 1, 8, 1.6, 12, 2.2] },
+  },
+];
+
 export const DEFAULT_BASEMAP: BasemapId = 'positron'; // labelled tiles help field orientation
 export const INDIA_CENTER: [number, number] = [78.9, 22];
 
-// Accept a legacy/stored id (the old set was positron/satellite/topo).
+// Accept a legacy/stored id (older sets had 'topo' and 'minimal').
 export function normalizeBasemap(id?: string | null): BasemapId {
   if (id === 'topo') return 'opentopo';
   return BASEMAPS.some((b) => b.id === id) ? (id as BasemapId) : DEFAULT_BASEMAP;
 }
 
-// One style carrying every basemap's sources + layers; only the active basemap's
-// layers start visible. MapLibre's attribution control follows the visible layers,
-// so only the on-screen basemap is credited.
+// One style carrying every basemap's sources + layers (only the active basemap's
+// layers start visible) plus the always-on India overlay on top. MapLibre's
+// attribution control follows the visible layers, so only the on-screen basemap +
+// the India outline are credited.
 export function buildBaseStyle(active: BasemapId): StyleSpecification {
-  const sources: Record<string, SourceSpecification> = {};
+  const sources: Record<string, SourceSpecification> = { ...INDIA_OVERLAY_SOURCES };
   const layers: LayerSpecification[] = [];
   for (const b of BASEMAPS) {
     Object.assign(sources, b.sources);
@@ -108,6 +125,7 @@ export function buildBaseStyle(active: BasemapId): StyleSpecification {
       layers.push({ ...lyr, layout } as LayerSpecification);
     }
   }
+  layers.push(...INDIA_OVERLAY_LAYERS); // above every basemap, always visible
   return { version: 8, sources, layers };
 }
 
@@ -117,6 +135,7 @@ export function setBasemap(map: maplibregl.Map, id: BasemapId): void {
       if (map.getLayer(lyr.id)) map.setLayoutProperty(lyr.id, 'visibility', b.id === id ? 'visible' : 'none');
     }
   }
+  // the India overlay is never toggled — it stays visible across basemap changes
 }
 
 const KEY = 'collect:basemap';

--- a/collect/tests/basemaps.test.ts
+++ b/collect/tests/basemaps.test.ts
@@ -7,31 +7,57 @@ describe('normalizeBasemap', () => {
   });
   it('keeps a valid id', () => {
     expect(normalizeBasemap('satellite')).toBe('satellite');
-    expect(normalizeBasemap('minimal')).toBe('minimal');
+    expect(normalizeBasemap('osm')).toBe('osm');
   });
-  it('falls back to the default for unknown / empty', () => {
+  it('falls back to the default for unknown / empty (incl. the retired "minimal")', () => {
+    expect(normalizeBasemap('minimal')).toBe(DEFAULT_BASEMAP); // basemap was removed
     expect(normalizeBasemap('nope')).toBe(DEFAULT_BASEMAP);
     expect(normalizeBasemap(null)).toBe(DEFAULT_BASEMAP);
     expect(normalizeBasemap(undefined)).toBe(DEFAULT_BASEMAP);
   });
 });
 
+const allBasemapLayerIds = new Set(BASEMAPS.flatMap((b) => b.layers.map((l) => l.id)));
+
 describe('buildBaseStyle', () => {
-  it('carries every basemap\'s layers, with only the active one visible', () => {
-    const active: BasemapId = 'minimal';
+  it('carries every basemap\'s layers, with only the active basemap visible', () => {
+    const active: BasemapId = 'satellite';
     const style = buildBaseStyle(active);
     const ids = style.layers.map((l) => l.id);
     for (const b of BASEMAPS) for (const l of b.layers) expect(ids).toContain(l.id);
     const activeIds = new Set(BASEMAPS.find((b) => b.id === active)!.layers.map((l) => l.id));
     for (const l of style.layers) {
+      if (!allBasemapLayerIds.has(l.id)) continue; // skip the always-on India overlay
       const vis = (l as { layout?: { visibility?: string } }).layout?.visibility;
       expect(vis).toBe(activeIds.has(l.id) ? 'visible' : 'none');
     }
   });
   it('layer ids are unique across the whole registry (required for the single style)', () => {
-    const ids = BASEMAPS.flatMap((b) => b.layers.map((l) => l.id));
+    const ids = buildBaseStyle('positron').layers.map((l) => l.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
+});
+
+describe('India-correct overlay', () => {
+  // bharatlas view maps always trace India's LGD-dissolved claim on top of the
+  // basemap. It must be present + visible whatever basemap is active (the raster
+  // tiles render the international boundary view).
+  for (const active of ['positron', 'osm', 'opentopo', 'satellite'] as BasemapId[]) {
+    it(`draws the India outline over the ${active} basemap`, () => {
+      const style = buildBaseStyle(active);
+      const claim = style.layers.filter((l) => l.id === 'india-claim' || l.id === 'india-claim-casing');
+      expect(claim).toHaveLength(2);
+      for (const l of claim) {
+        const vis = (l as { layout?: { visibility?: string } }).layout?.visibility;
+        expect(vis === undefined || vis === 'visible').toBe(true); // never hidden
+      }
+      // the outline draws on top of every basemap layer
+      const ids = style.layers.map((l) => l.id);
+      const lastBasemapIdx = Math.max(...[...allBasemapLayerIds].map((id) => ids.indexOf(id)));
+      expect(ids.indexOf('india-claim-casing')).toBeGreaterThan(lastBasemapIdx);
+      expect(ids.indexOf('india-claim')).toBeGreaterThan(lastBasemapIdx);
+    });
+  }
 });
 
 describe('no CARTO dependency', () => {


### PR DESCRIPTION
1. **India-correct overlay** — trace the LGD-dissolved india-outline on top of every basemap (persistent, always-on), so India's claim (J&K, Ladakh, Arunachal) shows correctly over the raster tiles' international view. Mirrors bharatlas view maps. 2. **Removed 'minimal'** — featureless, gives field surveyors nothing to orient by. 3. **Added OpenStreetMap** in its place (detailed field reference); verified tiles render clean; CSP adds tile.openstreetmap.org, drops unused cartocdn. 131 tests pass; India-overlay + no-cartocdn guards included.