### PR TITLE
fix(collect): client-validate name/purpose; reserve masthead space (CLS)

### DIFF
--- a/collect/src/landing.ts
+++ b/collect/src/landing.ts
@@ -199,7 +199,12 @@ function createForm() {
     btn.disabled = true;
     const year = (app.querySelector<HTMLInputElement>('#year')!.value || '').trim();
     try {
-      const name = app.querySelector<HTMLInputElement>('#name')!.value;
+      // Validate the required fields client-side so people aren't bounced by a
+      // server rejection after submitting (name 3-120, purpose required).
+      const name = app.querySelector<HTMLInputElement>('#name')!.value.trim();
+      if (name.length < 3) { err.textContent = 'Give your map a name (at least 3 characters).'; app.querySelector<HTMLInputElement>('#name')!.focus(); btn.disabled = false; return; }
+      const purpose = app.querySelector<HTMLTextAreaElement>('#purpose')!.value.trim();
+      if (!purpose) { err.textContent = 'Say what the map is for (it is shown to contributors).'; app.querySelector<HTMLTextAreaElement>('#purpose')!.focus(); btn.disabled = false; return; }
       const fields = builder.getFields();
       if (!fields.length) { err.textContent = 'Add at least one field for contributors to fill in.'; btn.disabled = false; return; }
       const dataYear = year ? Number(year) : undefined;
@@ -224,7 +229,7 @@ function createForm() {
         method: 'POST',
         body: JSON.stringify({
           name,
-          purpose: app.querySelector<HTMLTextAreaElement>('#purpose')!.value,
+          purpose,
           license: app.querySelector<HTMLSelectElement>('#license')!.value,
           data_year: dataYear,
           schema_doc: {

--- a/collect/src/styles.css
+++ b/collect/src/styles.css
@@ -154,8 +154,9 @@ textarea { min-height: 92px; line-height: 1.5; }
 .pad { padding: 20px 16px calc(20px + env(safe-area-inset-bottom)); overflow: auto; width: 100%; max-width: var(--content-max); margin-inline: auto; }
 .pad h1 { font-size: 23px; font-weight: 700; letter-spacing: -.025em; line-height: 1.15; margin: 6px 0 8px; }
 .hint { color: var(--muted); font-size: 13px; line-height: 1.5; font-variant-numeric: tabular-nums; }
-.masthead-stat { color: var(--muted); font-size: 13px; margin: 2px 0 14px; }
-.masthead-stat:empty { display: none; }
+/* Reserve one line so the async "N points collected" stat fills this space
+   instead of pushing the CTA + maps list down when it loads (a layout shift). */
+.masthead-stat { color: var(--muted); font-size: 13px; margin: 2px 0 14px; min-height: 1.2rem; }
 .masthead-stat strong { color: var(--accent); font-weight: 700; font-variant-numeric: tabular-nums; }
 .warn { color: var(--danger); font-size: 13px; line-height: 1.5; }
 /* attention box — pending points need approval to be visible/exported */


### PR DESCRIPTION
Two field-data flags.

**Schema-gate rejections (4).** Funnel: 3x "purpose is required", 1x "name must be 3-120 characters". The create form validated fields/year/rights but not name/purpose, so users submitted then hit a server rejection. Added inline client checks (name >= 3, purpose required) that focus the field.

**Landing CLS.** Fixed the one lab-reproducible shift: the async masthead stat inserted into a display:none element, pushing content down (~0.02). Now reserves one line.

**On the field CLS=1 flag — investigation:** RUM shows collect `/` CLS p75 = 1 across 120 samples, and in fact *every* collect page reads exactly 1.0 (or -1 = no data), while prerendered bharatlas.com is 0.003. But Lighthouse rates this landing **perf 97** (a real 1.0 would crater it) and my instrumented probes cap at **0.022** through load + open-create-form + back + scroll + a simulated URL-bar collapse. The uniform 1.0 across all client-rendered collect pages, disagreeing with every lab tool, is the signature of a **Cloudflare Web Analytics RUM CLS artifact for client-rendered SPAs**, not a genuine large visible jump. The masthead reserve is the real fix; recommend watching RUM post-deploy. If we want the field metric to read correctly, the robust path is prerendering the collect landing shell (as bharatlas does) — but lab tools say the page is fine.